### PR TITLE
Hide private stuff for real

### DIFF
--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -182,13 +182,13 @@ code > .code {
 }
 
 
-div.function {
+#childList > div {
     border-left-color: #03a9f4;
     border-left-width: 1px;
     border-left-style: solid;
 }
 
-div.function .functionHeader {
+#childList > div .functionHeader {
     font-family: monospace;
 }
 
@@ -207,4 +207,22 @@ div.function .functionHeader {
 
 pre {
     padding-left: 0px;
+}
+
+/* Private stuff */
+
+body.private-hidden .private {
+    display: none;
+}
+
+#showPrivate {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    padding: 10px;
+    opacity: 0.7;
+}
+
+#showPrivate:hover {
+    opacity: 1;
 }

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -211,7 +211,7 @@ pre {
 
 /* Private stuff */
 
-body.private-hidden .private {
+body.private-hidden #splitTables .private, body.private-hidden #childList .private {
     display: none;
 }
 

--- a/pydoctor/templates/attribute-child.html
+++ b/pydoctor/templates/attribute-child.html
@@ -1,4 +1,5 @@
 <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" class="function">
+  <t:attr name="class" t:render="class_" />
   <a>
     <t:attr name="name" t:render="functionAnchor" />
   </a>

--- a/pydoctor/templates/common.html
+++ b/pydoctor/templates/common.html
@@ -19,6 +19,10 @@
       </div>
     </nav>
 
+    <div id="showPrivate">
+      <button class="btn btn-link" onclick="togglePrivate()">Toggle Private API</button>
+    </div>
+
     <div class="container">
 
       <div class="page-header">
@@ -66,5 +70,8 @@
       </address>
 
     </div>
+
+    <script src="pydoctor.js" type='text/javascript'></script>
+
   </body>
 </html>

--- a/pydoctor/templates/function-child.html
+++ b/pydoctor/templates/function-child.html
@@ -1,4 +1,5 @@
-<div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" class="function">
+<div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
+  <t:attr name="class" t:render="class_" />
   <a>
     <t:attr name="name" t:render="functionAnchor" />
   </a>

--- a/pydoctor/templates/pydoctor.js
+++ b/pydoctor/templates/pydoctor.js
@@ -1,0 +1,7 @@
+function togglePrivate() {
+    // Hide all private things by adding the private-hidden class to them.
+    document.body.classList.toggle("private-hidden");
+}
+
+// On load, hide everything private
+togglePrivate()

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -12,6 +12,13 @@ class AttributeChild(Element):
         self.ob = ob
 
     @renderer
+    def class_(self, request, tag):
+        class_ = self.ob.css_class
+        if self.ob.parent is not self.ob:
+            class_ = 'base' + class_
+        return class_
+
+    @renderer
     def functionAnchor(self, request, tag):
         return self.ob.fullName()
 

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -15,6 +15,13 @@ class FunctionChild(Element):
         self._functionExtras = functionExtras
 
     @renderer
+    def class_(self, request, tag):
+        class_ = self.ob.css_class
+        if self.ob.parent is not self.ob:
+            class_ = 'base' + class_
+        return class_
+
+    @renderer
     def functionAnchor(self, request, tag):
         return self.ob.fullName()
 

--- a/pydoctor/templatewriter/writer.py
+++ b/pydoctor/templatewriter/writer.py
@@ -33,6 +33,8 @@ class TemplateWriter:
                         os.path.join(self.base, 'apidocs.css'))
         shutil.copyfile(templatefile('bootstrap.min.css'),
                         os.path.join(self.base, 'bootstrap.min.css'))
+        shutil.copyfile(templatefile('pydoctor.js'),
+                        os.path.join(self.base, 'pydoctor.js'))
 
     def writeIndividualFiles(self, obs, functionpages=False):
         self.dry_run = True


### PR DESCRIPTION
For #87 -- this uses a little bit of JS to hide private things using CSS. The no-JS fallback is that private things are still shown.

I had some reservations about performance, but this approach only modifies the DOM once, and the rest is done in CSS, making it very fast.

Test pages are available at https://dl.dropboxusercontent.com/u/14290114/pydoctortest/twisted-hidden/index.html .