### PR TITLE
add a data-type for doc2dash

### DIFF
--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -39,4 +39,7 @@ def taglink(o, label=None):
     else:
         raise AssertionError(
             "Unknown documentation_location: %s" % o.documentation_location)
+    # Create a link to the object, with a "data-type" attribute which says what
+    # kind of object it is (class, etc). This helps doc2dash figure out what it
+    # is.
     return tags.a(href=linktext, class_="code", **{"data-type":o.kind})(label)

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -39,4 +39,4 @@ def taglink(o, label=None):
     else:
         raise AssertionError(
             "Unknown documentation_location: %s" % o.documentation_location)
-    return tags.a(href=linktext, class_="code")(label)
+    return tags.a(href=linktext, class_="code", **{"data-type":o.kind})(label)


### PR DESCRIPTION
This adds a data-* attribute in the nameIndex.html for doc2dash to extract.