### PR TITLE
Disable installation on Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,25 @@ setup(
         'pydoctor',
         'pydoctor.templatewriter',
         'pydoctor.templatewriter.pages',
-        ],
+    ],
     package_data={
         'pydoctor': [
             'templates/*',
-            ],
-        },
+        ],
+    },
     scripts=[
         'bin/pydoctor',
-        ],
+    ],
+    classifiers=[
+        'Development Status :: 6 - Mature',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 2 :: Only',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Documentation',
+        'Topic :: Software Development :: Documentation',
+    ],
     install_requires=["Twisted", "epydoc"],
-    )
+)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
 #!/usr/bin/python
+import sys
+
+if sys.version_info > (3, 0):
+    raise Exception(("PyDoctor does not yet work on Python 3. Please see "
+                     "https://github.com/twisted/pydoctor/issues/96 for "
+                     "the tracking ticket for work on this."))
+
 from setuptools import setup
 
 setup(


### PR DESCRIPTION
Would fix the "installs but doesn't work" problem in #94.