### PR TITLE
Use build time set by SOURCE_DATE_EPOCH environment variable, if set.

### DIFF
--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -296,6 +296,16 @@ def main(args):
             else:
                 options.makehtml = False
 
+        # Support source date epoch:
+        # https://reproducible-builds.org/specs/source-date-epoch/
+        try:
+            system.buildtime = datetime.datetime.utcfromtimestamp(
+                int(os.environ['SOURCE_DATE_EPOCH']))
+        except ValueError, e:
+            error(e)
+        except KeyError:
+            pass
+
         if options.buildtime:
             try:
                 system.buildtime = datetime.datetime.strptime(


### PR DESCRIPTION
This is an alternative to the --buildtime argument that already exists.

See https://reproducible-builds.org/specs/source-date-epoch/ for background.