### PR TITLE
Send coverage to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - python: 2.7
       env: TOX_ENV=pyflakes
     - python: pypy
-      env: TOX_ENV=pypy
+      env: TOX_ENV=test-pypy
     - python: 2.7
       env: TOX_ENV=test-py27-codecov-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
-python: 2.7
 
-env:
-    - TOX_ENV=pyflakes
-    - TOX_ENV=pypy
-    - TOX_ENV=py27
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=pyflakes
+    - python: pypy
+      env: TOX_ENV=pypy
+    - python: 2.7
+      env: TOX_ENV=py27-codecov-travis
 
 install:
     - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - python: pypy
       env: TOX_ENV=pypy
     - python: 2.7
-      env: TOX_ENV=py27-codecov-travis
+      env: TOX_ENV=test-py27-codecov-travis
 
 install:
     - pip install tox

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ pydoctor
 .. image:: https://travis-ci.org/twisted/pydoctor.svg?branch=tox-travis-2
     :target: https://travis-ci.org/twisted/pydoctor
 
+.. image:: https://codecov.io/gh/twisted/pydoctor/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/twisted/pydoctor
+
 This is 'pydoctor', an API documentation generator that works by
 static analysis.
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 import sys
 
-if sys.version_info > (3, 0):
-    raise Exception(("PyDoctor does not yet work on Python 3. Please see "
-                     "https://github.com/twisted/pydoctor/issues/96 for "
-                     "the tracking ticket for work on this."))
+# if sys.version_info > (3, 0):
+#     raise Exception(("PyDoctor does not yet work on Python 3. Please see "
+#                      "https://github.com/twisted/pydoctor/issues/96 for "
+#                      "the tracking ticket for work on this."))
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 import sys
 
-# if sys.version_info > (3, 0):
-#     raise Exception(("PyDoctor does not yet work on Python 3. Please see "
-#                      "https://github.com/twisted/pydoctor/issues/96 for "
-#                      "the tracking ticket for work on this."))
+if sys.version_info > (3, 0):
+    raise Exception(("PyDoctor does not yet work on Python 3. Please see "
+                     "https://github.com/twisted/pydoctor/issues/96 for "
+                     "the tracking ticket for work on this."))
 
 from setuptools import setup
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
     test: coverage run --source pydoctor --omit pydoctor/test/* --branch {envdir}/bin/nosetests pydoctor
     test: coverage report -m
 
-    codecov-travis: coverage xml
+    codecov-travis: coverage xml -o coverage.xml -i
     codecov-travis: codecov
 
     pyflakes: /bin/sh -c "find pydoctor/ -name \*.py ! -path '*/testpackages/*' | xargs pyflakes"

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     test: nose
     test: docutils
 
-    coverage-publish: codecov
+    codecov-travis: codecov
 
     pyflakes: pyflakes
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,35 @@
 [tox]
 envlist =
-    py27,pypy,pyflakes
+    test-{py27,pypy,py27-codecov-travis},pyflakes
 
 
 [testenv:pyflakes]
-deps = pyflakes
-commands = /bin/sh -c "find pydoctor/ -name \*.py ! -path '*/testpackages/*' | xargs pyflakes"
 basepython = /usr/bin/python
 
 
 [testenv]
+passenv = *
+
 deps =
-    coverage
-    Twisted
-    epydoc
-    nose
-    docutils
+    test: coverage
+    test: Twisted
+    test: epydoc
+    test: nose
+    test: docutils
+
+    coverage-publish: codecov
+
+    pyflakes: pyflakes
+
+
 commands =
-    {envpython} --version
-    trial --version
-    coverage run --source pydoctor --omit pydoctor/test/* --branch {envdir}/bin/nosetests pydoctor
-    coverage report -m
+    test: {envpython} --version
+    test: trial --version
+    test: coverage erase
+    test: coverage run --source pydoctor --omit pydoctor/test/* --branch {envdir}/bin/nosetests pydoctor
+    test: coverage report -m
+
+    codecov-travis: coverage xml
+    codecov-travis: codecov
+
+    pyflakes: /bin/sh -c "find pydoctor/ -name \*.py ! -path '*/testpackages/*' | xargs pyflakes"


### PR DESCRIPTION
This update the tox environments so that we have an env which sends the coverate report to codecov.io

I have also refactored the tox.ini to use the same "design" as the one used by twisted