### PR TITLE
Publish to PyPi via Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,21 @@ script: tox -e $TOX_ENV
 
 notifications:
     email: false
+
+# Do an automatic PyPi release when a tag is created.
+# http://docs.travis-ci.com/user/deployment/pypi/
+# Make sure builds are triggered for any push so that the tag push will also
+# trigger a build.
+deploy:
+  provider: pypi
+  server: https://testpypi.python.org/pypi
+  # twistedchecker-robot is associated with adi.roiban email address from
+  # Gmail. It uses a random password which was not recorded in plain text.
+  user: twistedchecker-robot
+  password:
+    secure: VS3uq3pdprwQUQmMFlS0ieXTX7UKvNjAQi/6CXfxqcJVlExVojsiSwOIgE76r74TuLRKDzlYD+G6dGkvaRmlfV2GVMhChUCN71Y0QtFPB68M9MuFyf/ICHb0zhs2f53/86m+ThphCOQwnOYxDeramR4TAsQR95buDO2Ko590vnQ=
+  on:
+    tags: true
+    # All branches is still required.
+    # https://github.com/travis-ci/travis-ci/issues/1675
+    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ deploy:
   # Gmail. It uses a random password which was not recorded in plain text.
   user: twistedchecker-robot
   password:
-    secure: VS3uq3pdprwQUQmMFlS0ieXTX7UKvNjAQi/6CXfxqcJVlExVojsiSwOIgE76r74TuLRKDzlYD+G6dGkvaRmlfV2GVMhChUCN71Y0QtFPB68M9MuFyf/ICHb0zhs2f53/86m+ThphCOQwnOYxDeramR4TAsQR95buDO2Ko590vnQ=
+    secure: D8Jlbsm8sN1Nz11SgFI7HRxjx0/gLDl66RB101nrhP4Bs4tzK2s9duu7P6nGRIupX5r5czRpSyhPrPQjci3UhcxZf5OTTCd5pamGBd7dv32Usr2aXWhvIfulX+i7jtbOBiWQT7JhxjSjlvyZLW0kka3eClQaD+D4iI64zaBn7y0=
   on:
     tags: true
     # All branches is still required.

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,4 @@ deploy:
     # All branches is still required.
     # https://github.com/travis-ci/travis-ci/issues/1675
     all_branches: true
+    condition: "$TOX_ENV = test-py27-codecov-travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ notifications:
 # trigger a build.
 deploy:
   provider: pypi
-  server: https://testpypi.python.org/pypi
   # twistedchecker-robot is associated with adi.roiban email address from
   # Gmail. It uses a random password which was not recorded in plain text.
   user: twistedchecker-robot

--- a/README.rst
+++ b/README.rst
@@ -58,3 +58,14 @@ It can link to external API documentation using Sphinx objects inventory using
 the following cumulative configuration option::
 
     --intersphinx=http://sphinx-doc.org/objects.inv
+
+
+Releasing a new package
+-----------------------
+
+Releasing a new version is done via Travis-CI.
+First commit the version update to master and wait for tests to pass.
+Create a tag on local branch and then push it::
+
+    git tag 1.2.3
+    git push --tags

--- a/pydoctor/__init__.py
+++ b/pydoctor/__init__.py
@@ -1,3 +1,3 @@
 """PyDoctor, an API documentation generator for Python libraries."""
 
-version_info = (16, 0, 0, '', 0)
+version_info = (16, 1, 0, '', 0)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 setup(
     name='pydoctor',
-    version='16.0.0',
+    version='16.1.0',
     author='Michael Hudson-Doyle',
     author_email='micahel@gmail.com',
     url='http://github.com/twisted/pydoctor',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,11 @@
+;
+; Coverage is always reported at the end of test run.
+; There is a dedicated hidden environment for publishing the coverage report
+; to the codecov.io service.
+;
 [tox]
 envlist =
-    test-{py27,pypy,py27-codecov-travis},pyflakes
+    test-{py27,pypy},pyflakes
 
 
 [testenv:pyflakes]
@@ -29,7 +34,9 @@ commands =
     test: coverage run --source pydoctor --omit pydoctor/test/* --branch {envdir}/bin/nosetests pydoctor
     test: coverage report -m
 
+    ; Hidden env for pusblishing coverage reports from Travis to codecov.io
     codecov-travis: coverage xml -o coverage.xml -i
     codecov-travis: codecov
 
+    ; Custom pyflakes run to exlcude test files.
     pyflakes: /bin/sh -c "find pydoctor/ -name \*.py ! -path '*/testpackages/*' | xargs pyflakes"


### PR DESCRIPTION
This add support for publishing to PyPi via Travis-CI builders.

The publish is triggered when a tag is pushed to the repo.

It uses the same robot username as twistedchecker.

I have not recorded the password for this account... so when the password is change, the secret from this repo should also be recreated.

The initial version is for testpypi and if all is ok we can change it before the merge.

A testing push is here https://testpypi.python.org/pypi/pydoctor