### PR TITLE
Allow all types of objects with their own page to be deprecated

### DIFF
--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -98,7 +98,10 @@ class CommonPage(Element):
 
     @renderer
     def deprecated(self, request, tag):
-        return ()
+        if hasattr(self.ob, "_deprecated_info"):
+            return (tags.div(self.ob._deprecated_info, role="alert", class_="deprecationNotice alert alert-warning"),)
+        else:
+            return ()
 
     @renderer
     def source(self, request, tag):
@@ -316,14 +319,6 @@ class ClassPage(CommonPage):
             del tail[-1]
             r.extend([' (via ', tail, ')'])
         return r
-
-    @renderer
-    def deprecated(self, request, tag):
-        if hasattr(self.ob, "_deprecated_info"):
-            return (tags.div(self.ob._deprecated_info, role="alert", class_="deprecationNotice alert alert-warning"),)
-        else:
-            return ()
-
 
     def functionExtras(self, data):
         r = []


### PR DESCRIPTION
This will make a function detail page (like `twisted.internet.defer.deferredGenerator.html`) have deprecations at the top, like classes.