### PR TITLE
[Fix #117] Report intersphinx error as level -1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ matrix:
       env: TOX_ENV=test-pypy
     - python: 2.7
       env: TOX_ENV=test-py27-codecov-travis
+    - python: 2.7
+      env: TOX_ENV=twisted-apidoc
+
+ allow_failures:
+    # Twisted trunk is broken for now.
+    - env: TOX_ENV=twisted-apidoc
 
 install:
     - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - python: 2.7
       env: TOX_ENV=twisted-apidoc
 
- allow_failures:
+  allow_failures:
     # Twisted trunk is broken for now.
     - env: TOX_ENV=twisted-apidoc
 

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,15 @@ The default HTML generator requires Twisted.
 There are some more notes in the doc/ subdirectory.
 
 
+Tox development environment
+---------------------------
+
+Since Python 3 is not yet supported, you the case in which your default
+tox runs with Python 3, call the tox as::
+
+    python2 -m tox -e pyflakes
+
+
 Sphinx Integration
 ------------------
 

--- a/pydoctor/__init__.py
+++ b/pydoctor/__init__.py
@@ -1,3 +1,3 @@
 """PyDoctor, an API documentation generator for Python libraries."""
 
-version_info = (16, 1, 0, '', 0)
+version_info = (16, 1, 1, '', 0)

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -17,15 +17,16 @@ class SphinxInventory(object):
 
     def __init__(self, logger, project_name):
         self.project_name = project_name
-        self.msg = logger
+        self.info = logger
         self._links = {}
+        self.error = lambda where, message: logger(where, message, thresh=-1)
 
     def generate(self, subjects, basepath):
         """
         Generate Sphinx objects inventory version 2 at `basepath`/objects.inv.
         """
         path = os.path.join(basepath, 'objects.inv')
-        self.msg('sphinx', 'Generating objects inventory at %s' % (path,))
+        self.info('sphinx', 'Generating objects inventory at %s' % (path,))
 
         with self._openFileForWriting(path) as target:
             target.write(self._generateHeader())
@@ -96,7 +97,8 @@ class SphinxInventory(object):
             domainname = 'attribute'
         else:
             domainname = 'obj'
-            self.msg('sphinx', "Unknown type %r for %s." % (type(obj), full_name,))
+            self.error(
+                'sphinx', "Unknown type %r for %s." % (type(obj), full_name,))
 
         return '%s py:%s -1 %s %s\n' % (full_name, domainname, url, display)
 
@@ -106,7 +108,7 @@ class SphinxInventory(object):
         """
         parts = url.rsplit('/', 1)
         if len(parts) != 2:
-            self.msg(
+            self.error(
                 'sphinx', 'Failed to get remote base url for %s' % (url,))
             return
 
@@ -115,7 +117,7 @@ class SphinxInventory(object):
         data = self._getURL(url)
 
         if not data:
-            self.msg(
+            self.error(
                 'sphinx', 'Failed to get object inventory from %s' % (url, ))
             return
 
@@ -151,7 +153,7 @@ class SphinxInventory(object):
         try:
             return zlib.decompress(payload)
         except:
-            self.msg(
+            self.error(
                 'sphinx',
                 'Failed to uncompress inventory from %s' % (base_url,))
             return ''
@@ -164,7 +166,7 @@ class SphinxInventory(object):
         for line in payload.splitlines():
             parts = line.split(' ', 4)
             if len(parts) != 5:
-                self.msg(
+                self.error(
                     'sphinx',
                     'Failed to parse line "%s" for %s' % (line, base_url),
                     )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 setup(
     name='pydoctor',
-    version='16.1.0',
+    version='16.1.1',
     author='Michael Hudson-Doyle',
     author_email='micahel@gmail.com',
     url='http://github.com/twisted/pydoctor',

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,18 @@
 ;
 [tox]
 envlist =
-    test-{py27,pypy},pyflakes
-
+    test-{py27,pypy},pyflakes,twisted-apidoc
 
 [testenv:pyflakes]
 basepython = /usr/bin/python
 
 
 [testenv]
+whitelist_externals =
+    git
+    rm
 passenv = *
+
 
 deps =
     test: coverage
@@ -40,3 +43,9 @@ commands =
 
     ; Custom pyflakes run to exlcude test files.
     pyflakes: /bin/sh -c "find pydoctor/ -name \*.py ! -path '*/testpackages/*' | xargs pyflakes"
+
+    ; Run current version against twisted trunk
+    twisted-apidoc: rm -rf {toxworkdir}/twisted-trunk
+    twisted-apidoc: git clone --depth 1 --branch trunk https://github.com/twisted/twisted.git {toxworkdir}/twisted-trunk
+    twisted-apidoc: bash -c \'{toxworkdir}/twisted-trunk/bin/admin/build-apidocs {toxworkdir}/twisted-trunk {toxworkdir}/twisted-apidocs-build > {toxworkdir}/twisted-apidocs.log \'
+    twisted-apidoc: cat {toxworkdir}/twisted-apidocs.log


### PR DESCRIPTION
See #117 

intershinx errors are reported with level 0 just like normal info messages.

It was my fault for not understand how pydoctor.model.System.msg function works and not paying attention that I use the same method for both info and error messages.

Now errors are reported with -1

I have updated the release number, so that after this is merge we can do a release as it will help Twisted :)

I have updated the travis-ci job to also run against the latest twisted trunk... in this way I hope that we can prevent some regressions