### PR TITLE
Switch to exception syntax specified in PEP 3110.

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -324,7 +324,7 @@ class ModuleVistor(object):
                 defaults.append(ast_pp.pp(default))
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except Exception, e:
+            except Exception as e:
                 self.builder.warning("unparseable default",
                                      "%s: %s %r"%(e.__class__.__name__,
                                                   e, default))

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -265,7 +265,7 @@ def main(args):
         try:
             system.buildtime = datetime.datetime.utcfromtimestamp(
                 int(os.environ['SOURCE_DATE_EPOCH']))
-        except ValueError, e:
+        except ValueError as e:
             error(e)
         except KeyError:
             pass
@@ -274,7 +274,7 @@ def main(args):
             try:
                 system.buildtime = datetime.datetime.strptime(
                     options.buildtime, BUILDTIME_FORMAT)
-            except ValueError, e:
+            except ValueError as e:
                 error(e)
 
         # step 2: add any packages and modules

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -28,7 +28,7 @@ def get_parser(formatname):
     try:
         mod = __import__('epydoc.markup.' + formatname,
                          globals(), locals(), ['parse_docstring'])
-    except ImportError, e:
+    except ImportError as e:
         return None, e
     else:
         return mod.parse_docstring, None
@@ -535,7 +535,7 @@ def doc2stan(obj, summary=False, docstring=None):
     doc = inspect.getdoc(crappit)
     try:
         pdoc = parse_docstring(doc, errs)
-    except Exception, e:
+    except Exception as e:
         errs = [e.__class__.__name__ +': ' + str(e)]
     if errs:
         reportErrors(source, errs)
@@ -544,7 +544,7 @@ def doc2stan(obj, summary=False, docstring=None):
     if pdoc is not None:
         try:
             crap = pdoc.to_html(_EpydocLinker(source))
-        except Exception, e:
+        except Exception as e:
             reportErrors(source, [e.__class__.__name__ +': ' + str(e)])
             return (boringDocstring(doc, summary),
                     [e.__class__.__name__ +': ' + str(e)])

--- a/pydoctor/liveobjectchecker.py
+++ b/pydoctor/liveobjectchecker.py
@@ -36,11 +36,11 @@ def loadModulesForSystem(system):
         for i, m in enumerate(modlist):
             try:
                 realMod = __import__(m.fullName(), {}, {}, ['*'])
-            except ImportError, e:
+            except ImportError as e:
                 errcount += 1
                 if verbosity > 0:
                     print "could not import", m.fullName(), e
-            except Exception, e:
+            except Exception as e:
                 errcount += 1
                 if verbosity > 0:
                     print "error importing", m.fullName(), e


### PR DESCRIPTION
See:
https://www.python.org/dev/peps/pep-3110/

This is for compatibility with Python 3