### PR TITLE
Use exec as a function, for compatibility with Python 3

### DIFF
--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -44,7 +44,7 @@ def test_function_argspec():
     mod = fromText(src)
     docfunc, = mod.contents.values()
     ns = {}
-    exec src in ns
+    exec(src, ns)
     realf = ns['f']
     inspectargspec = inspect.getargspec(realf)
     assert inspectargspec[:-1] == docfunc.argspec[:-1]

--- a/pydoctor/test/testpackages/liveobject/mod.py
+++ b/pydoctor/test/testpackages/liveobject/mod.py
@@ -9,4 +9,4 @@ m = C().m
 class B:
     pass
 
-exec '''class D(B): pass'''
+exec('''class D(B): pass''')


### PR DESCRIPTION
See:
https://docs.python.org/3/whatsnew/3.0.html#removed-syntax
