### PR TITLE
twisted-apidoc tox env builds against post src-Twisted.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     ; Run current version against twisted trunk
     twisted-apidoc: rm -rf {toxworkdir}/twisted-trunk
     twisted-apidoc: git clone --depth 1 --branch trunk https://github.com/twisted/twisted.git {toxworkdir}/twisted-trunk
-    twisted-apidoc: bash -c \'{toxworkdir}/twisted-trunk/bin/admin/build-apidocs {toxworkdir}/twisted-trunk {toxworkdir}/twisted-apidocs-build > {toxworkdir}/twisted-apidocs.log \'
-    twisted-apidoc: cat {toxworkdir}/twisted-apidocs.log
+    twisted-apidoc: /bin/sh -c "{toxworkdir}/twisted-trunk/bin/admin/build-apidocs {toxworkdir}/twisted-trunk/src {toxworkdir}/twisted-apidocs-build > {toxworkdir}/twisted-apidocs.log"
+    twisted-apidoc: /bin/cat {toxworkdir}/twisted-apidocs.log
     ; Fail if the output of running pydoctor on Twisted is not emtpy.
-    twisted-apidoc: test ! -s {toxworkdir}/twisted-apidocs.log
+    twisted-apidoc: /bin/sh -c "test ! -s {toxworkdir}/twisted-apidocs.log"


### PR DESCRIPTION
The move to src/ broke this.

Closes #141.

Note that this environment will still fail because Twisted has errors in its documentation.