### PR TITLE
Cache Interpshinx objects.

### DIFF
--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -732,9 +732,9 @@ class System(object):
             self.processModule(mod)
 
 
-    def fetchIntersphinxInventories(self):
+    def fetchIntersphinxInventories(self, cache):
         """
         Download and parse intersphinx inventories based on configuration.
         """
         for url in self.options.intersphinx:
-            self.intersphinx.update(url)
+            self.intersphinx.update(cache, url)

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -4,9 +4,27 @@ Support for Sphinx compatibility.
 from __future__ import absolute_import
 from __future__ import print_function
 
+import appdirs
+import attr
+
+from cachecontrol import CacheControl
+from cachecontrol.caches import FileCache
+from cachecontrol.heuristics import ExpiresAfter
+
+import logging
+
 import os
-import urllib2
+
+import requests
+
+import shutil
+
+import textwrap
+
 import zlib
+
+
+logger = logging.getLogger(__name__)
 
 
 class SphinxInventory(object):
@@ -103,7 +121,7 @@ class SphinxInventory(object):
 
         return '%s py:%s -1 %s %s\n' % (full_name, domainname, url, display)
 
-    def update(self, url):
+    def update(self, cache, url):
         """
         Update inventory from URL.
         """
@@ -115,7 +133,7 @@ class SphinxInventory(object):
 
         base_url = parts[0]
 
-        data = self._getURL(url)
+        data = cache.get(url)
 
         if not data:
             self.error(
@@ -124,18 +142,6 @@ class SphinxInventory(object):
 
         payload = self._getPayload(base_url, data)
         self._links.update(self._parseInventory(base_url, payload))
-
-    def _getURL(self, url):
-        """
-        Get content of URL.
-
-        This is a helper for testing.
-        """
-        try:
-            response = urllib2.urlopen(url)
-            return response.read()
-        except:
-            return None
 
     def _getPayload(self, base_url, data):
         """
@@ -188,3 +194,212 @@ class SphinxInventory(object):
             relative_link = relative_link[:-1] + name
 
         return '%s/%s' % (base_url, relative_link)
+
+
+USER_INTERSPHINX_CACHE = appdirs.user_cache_dir("pydoctor")
+
+
+@attr.s
+class _Unit(object):
+    """
+    A unit of time for maximum age parsing.
+
+    @ivar name: The name of the unit.
+    @type name: L{str}
+
+    @ivar minimum: The minimum value, inclusive.
+    @ivar minimum: L{int}
+
+    @ivar maximum: The maximum value, exclusive.
+    @ivar maxium: L{int}
+
+    @see: L{parseMaxAge}
+    """
+    name = attr.ib()
+    minimum = attr.ib()
+    maximum = attr.ib()
+
+
+# timedelta stores seconds and minutes internally as ints.  Limit them
+# to a 32 bit value.  Per the documentation, days are limited to
+# 999999999, and weeks are converted to days by multiplying 7.
+_maxAgeUnits = {
+    "s": _Unit("seconds", minimum=1, maximum=2 ** 32 - 1),
+    "m": _Unit("minutes", minimum=1, maximum=2 ** 32 - 1),
+    "h": _Unit("hours", minimum=1, maximum=2 ** 32 - 1),
+    "d": _Unit("days", minimum=1, maximum=999999999 + 1),
+    "w": _Unit("weeks", minimum=1, maximum=(999999999 + 1) / 7),
+}
+_maxAgeUnitNames = ", ".join(
+    "{} ({})".format(indicator, unit.name)
+    for indicator, unit in _maxAgeUnits.items()
+)
+
+
+MAX_AGE_HELP = textwrap.dedent(
+    """
+    The maximum age of any entry in the cache.  Of the format
+    <int><unit> where <unit> is one of {}.
+    """.format(_maxAgeUnitNames)
+)
+MAX_AGE_DEFAULT = '1w'
+
+
+class InvalidMaxAge(Exception):
+    """
+    Raised when a string cannot be parsed as a maximum age.
+    """
+
+
+def parseMaxAge(maxAge):
+    try:
+        amount = int(maxAge[:-1])
+    except (ValueError, TypeError):
+        raise InvalidMaxAge("Maximum age must be parseable as integer.")
+
+    try:
+        unit = _maxAgeUnits[maxAge[-1]]
+    except (IndexError, KeyError):
+        raise InvalidMaxAge(
+            "Maximum age's units must be one of {}".format(_maxAgeUnitNames))
+
+    if not (unit.minimum <= amount < unit.maximum):
+        raise InvalidMaxAge(
+            "Maximum age in {} must be "
+            "greater than or equal to {} "
+            "and less than {}".format(unit.name, unit.minimum, unit.maximum))
+
+    return {unit.name: amount}
+
+
+parseMaxAge.__doc__ = (
+    """
+    Parse a string into a maximum age dictionary.
+
+    @param maxAge: {}
+    @type maxAge: L{str}
+
+    @raises: L{InvalidMaxAge} when a string cannot be parsed.
+
+    @return: A dictionary whose keys match L{datetime.timedelta}'s
+        arguments.
+    @rtype: L{dict}
+    """
+)
+
+
+@attr.s
+class IntersphinxCache(object):
+    """
+    An Intersphinx cache.
+
+    @param session: A session that may or may not cache requests.
+    @type session: L{requests.Session}
+    """
+    _session = attr.ib()
+    _logger = attr.ib(default=logger)
+
+    @classmethod
+    def fromParameters(cls, sessionFactory, cachePath, maxAgeDictionary):
+        """
+        Construct an instance with the given parameters.
+
+        @param sessionFactory: A zero-argument L{callable} that
+            returns a L{requests.Session}.
+
+        @param cachePath: Path of the cache directory.
+        @type cachePath: L{str}
+
+        @param maxAgeDictionary: A dictionary describing the maximum
+            age of any cache entry.
+        @type maxAgeDictionary: L{dict}
+
+        @see: L{parseMaxAge}
+        """
+        session = CacheControl(sessionFactory(),
+                               cache=FileCache(cachePath),
+                               heuristic=ExpiresAfter(**maxAgeDictionary))
+        return cls(session)
+
+    def get(self, url):
+        """
+        Retrieve a URL using the cache.
+
+        @param url: The URL to retrieve.
+        @type url: L{str}
+
+        @return: The body of the URL.
+        @rtype: L{bytes} on success and L{None} on failure.
+        """
+        try:
+            return self._session.get(url).content
+        except Exception:
+            self._logger.exception(
+                "Could not retrieve intersphinx object.inv from %s",
+                url
+            )
+            return None
+
+
+@attr.s
+class StubCache(object):
+    """
+    A stub cache.
+
+    @param cache: A L{dict} mapping URLs to content.
+    @type cache: L{dict} of L{str} to L{bytes}
+    """
+    _cache = attr.ib()
+
+    def get(self, url):
+        """
+        Return stored for the given URL.
+
+        @param url: The URL to retrieve.
+        @type url: L{str}
+
+        @return: The "body" of the URL - the value from L{_cache} or
+            L{None}.
+        @rtype: L{bytes}.
+        """
+        return self._cache.get(url)
+
+
+def prepareCache(
+        clearCache,
+        enableCache,
+        cachePath,
+        maxAge,
+        sessionFactory=requests.Session,
+):
+    """
+    Prepare an Intersphinx cache.
+
+    @param clearCache: Remove the cache?
+    @type clearCache: L{bool}
+
+    @param enableCache: Enable the cache?
+    @type enableCache: L{bool}
+
+    @param cachePath: Path of the cache directory.
+    @type cachePath: L{str}
+
+    @param maxAge: The maximum age in seconds of cached Intersphinx
+        C{objects.inv} files.
+    @type maxAge: L{float}
+
+    @param sessionFactory: (optional) A zero-argument L{callable} that
+        returns a L{requests.Session}.
+
+    @return: A L{IntersphinxCache} instance.
+    """
+    if clearCache:
+        shutil.rmtree(cachePath)
+    if enableCache:
+        maxAgeDictionary = parseMaxAge(maxAge)
+        return IntersphinxCache.fromParameters(
+            sessionFactory,
+            cachePath,
+            maxAgeDictionary,
+        )
+    return IntersphinxCache(sessionFactory())

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -3,7 +3,9 @@ from __future__ import print_function
 from twisted.python.compat import NativeStringIO
 
 from pydoctor import driver
+
 import sys
+
 
 def geterrtext(*options):
     options = list(options)
@@ -50,3 +52,12 @@ def test_projectbasedir():
     options, args = driver.parse_args([
             "--project-base-dir", value])
     assert options.projectbasedirectory == value
+
+
+def test_cache_disabled_by_default():
+    """
+    Intersphinx object caching is disabled by default.
+    """
+    parser = driver.getparser()
+    (options, _) = parser.parse_args([])
+    assert not options.enable_intersphinx_cache

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -3,7 +3,7 @@ Unit tests for model.
 """
 from __future__ import print_function
 
-from pydoctor import model
+from pydoctor import model, sphinx
 from pydoctor.driver import parse_args
 import zlib
 
@@ -81,7 +81,7 @@ def test_fetchIntersphinxInventories_empty():
     options.intersphinx = []
     sut = model.System(options=options)
 
-    sut.fetchIntersphinxInventories()
+    sut.fetchIntersphinxInventories(sphinx.StubCache({}))
 
     # Use internal state since I don't know how else to
     # check for SphinxInventory state.
@@ -110,7 +110,7 @@ def test_fetchIntersphinxInventories_content():
     # Patch url getter to avoid touching the network.
     sut.intersphinx._getURL = lambda url: url_content[url]
 
-    sut.fetchIntersphinxInventories()
+    sut.fetchIntersphinxInventories(sphinx.StubCache(url_content))
 
     assert [] == log
     assert (

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,12 @@ setup(
         'Topic :: Documentation',
         'Topic :: Software Development :: Documentation',
     ],
-    install_requires=["Twisted", "epydoc", "six"],
+    install_requires=[
+        "appdirs",
+        "CacheControl[filecache]",
+        "Twisted",
+        "epydoc",
+        "requests",
+        "six",
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
     test: epydoc
     test: pytest
     test: docutils
+    test: hypothesis
 
     codecov-travis: codecov
 


### PR DESCRIPTION
Closes #120, #129, and #137 

This introduces four new command line options:

1. **--enable-intersphinx-cache** Enable the Intersphinx object cache, which is disabled by default.
2. **--intersphinx-cache-path** The location of the Intersphinx object cache.  By default, this is a user cache dir selected by appdirs.
3. **--clear-intersphinx-cache** Remove the Intersphinx cache directory.  This does not require the cache be enabled.
4. **--intersphinx-cache-max-age** The maximum age for *new* items in the Intersphinx cache directory. 
 This defaults to 1 week.  It's specified by a number followed by a single letter representing the units, e.g., `20h` is 20 hours.

The implementation CacheControl with an ExpiresAfter heuristic.  The heuristic was chosen because most of Twisted's objects.inv URLs do not set the necessary cache headers.

CacheControl requires requests, so SphinxInventory now uses requests.  This closes #137.