### PR TITLE
Make the output reproducible

### DIFF
--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -623,7 +623,7 @@ class System(object):
         package = self.ensurePackage(package_full_name)
         package.filepath = dirpath
         self.setSourceHref(package)
-        for fname in os.listdir(dirpath):
+        for fname in sorted(os.listdir(dirpath)):
             fullname = os.path.join(dirpath, fname)
             if os.path.isdir(fullname):
                 initname = os.path.join(fullname, '__init__.py')


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that pydoctor generates output that is not reproducible.

By iterating over the filesystem (which returns values in a non-
determinstic order) we end up with different id="" attributes in
the HTML.

This affects other packages such as "subvertpy" amongst others.

 [0] https://reproducible-builds.org/