### PR TITLE
Fix hypothesis argument error

### DIFF
--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -619,7 +619,7 @@ class TestStubCache(object):
     clearCache=st.booleans(),
     enableCache=st.booleans(),
     cacheDirectoryName=st.text(
-        alphabet=set(string.printable) - set('\/:*?"<>|\x0c\x0b\n'),
+        alphabet=sorted(set(string.printable) - set('\/:*?"<>|\x0c\x0b\n')),
         min_size=3,             # Avoid ..
         max_size=32,            # Avoid upper length on path
     ),


### PR DESCRIPTION
Fix this exception, which causes the test suite to fail:

    InvalidArgument: alphabet must be an ordered sequence, or tests may be flaky and shrinking weaker, but a <type 'set'> is not a type of sequence.