### PR TITLE
Fix XMLFile sans FilePath deprecation

### DIFF
--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -62,7 +62,7 @@ class CommonPage(Element):
 
     @property
     def loader(self):
-        return XMLFile(util.templatefile('common.html'))
+        return XMLFile(util.templatefilepath('common.html'))
 
     def title(self):
         return self.ob.fullName()

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -6,7 +6,7 @@ from pydoctor.templatewriter import util
 
 class AttributeChild(Element):
 
-    loader = XMLFile(util.templatefile('attribute-child.html'))
+    loader = XMLFile(util.templatefilepath('attribute-child.html'))
 
     def __init__(self, docgetter, ob):
         self.docgetter = docgetter

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -11,7 +11,7 @@ from pydoctor.templatewriter.pages import signature
 
 class FunctionChild(Element):
 
-    loader = XMLFile(util.templatefile('function-child.html'))
+    loader = XMLFile(util.templatefilepath('function-child.html'))
 
     def __init__(self, docgetter, ob, functionExtras):
         self.docgetter = docgetter

--- a/pydoctor/templatewriter/pages/table.py
+++ b/pydoctor/templatewriter/pages/table.py
@@ -33,7 +33,7 @@ class TableRow(Element):
 
 
 class ChildTable(Element):
-    loader = XMLFile(util.templatefile('table.html'))
+    loader = XMLFile(util.templatefilepath('table.html'))
     last_id = 0
 
     def __init__(self, docgetter, ob, children):

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -30,7 +30,7 @@ class ModuleIndexPage(Element):
 
     @property
     def loader(self):
-        return XMLFile(util.templatefile('summary.html'))
+        return XMLFile(util.templatefilepath('summary.html'))
 
     def __init__(self, system):
         self.system = system
@@ -89,7 +89,7 @@ class ClassIndexPage(Element):
 
     @property
     def loader(self):
-        return XMLFile(util.templatefile('summary.html'))
+        return XMLFile(util.templatefilepath('summary.html'))
 
     def __init__(self, system):
         self.system = system
@@ -170,7 +170,7 @@ class NameIndexPage(Element):
 
     @property
     def loader(self):
-        return XMLFile(util.templatefile('nameIndex.html'))
+        return XMLFile(util.templatefilepath('nameIndex.html'))
 
     def __init__(self, system):
         self.system = system
@@ -204,7 +204,7 @@ class IndexPage(Element):
 
     @property
     def loader(self):
-        return XMLFile(util.templatefile('index.html'))
+        return XMLFile(util.templatefilepath('index.html'))
 
     def __init__(self, system):
         self.system = system
@@ -276,7 +276,7 @@ class UndocumentedSummaryPage(Element):
 
     @property
     def loader(self):
-        return XMLFile(util.templatefile('summary.html'))
+        return XMLFile(util.templatefilepath('summary.html'))
 
     def __init__(self, system):
         self.system = system

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 from pydoctor import model
 
+from twisted.python.filepath import FilePath
 from twisted.web.template import tags
 
 import os, urllib
@@ -21,8 +22,11 @@ def templatefile(filename):
     pydoctordir = os.path.dirname(os.path.dirname(abspath))
     return os.path.join(pydoctordir, 'templates', filename)
 
+def templatefilepath(filename):
+    return FilePath(templatefile(filename))
+
 def fillSlots(tag, **kw):
-    for k, v in kw.iteritems():
+    for k, v in kw.items():
         tag = tag.fillSlots(k, v)
     return tag
 


### PR DESCRIPTION
Fix this warning:

    pydoctor/templatewriter/pages/table.py:36
      /home/twm/pydoctor/pydoctor/templatewriter/pages/table.py:36: DeprecationWarning: Passing filenames or file objects to XMLFile is deprecated since Twisted 12.1.  Pass a FilePath instead.
        loader = XMLFile(util.templatefile('table.html'))