### PR TITLE
Modernize

### DIFF
--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -228,7 +228,7 @@ def parse_args(args):
     return options, args
 
 def main(args):
-    import cPickle
+    from six.moves import cPickle
     options, args = parse_args(args)
 
     exitcode = 0

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -430,7 +430,7 @@ def main(args):
     except:
         if options.pdb:
             import pdb
-            pdb.post_mortem(sys.exc_traceback)
+            pdb.post_mortem(sys.exc_info()[2])
         raise
     return exitcode
 

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -47,6 +47,7 @@ each error.
 __docformat__ = 'epytext en'
 
 import re
+import six
 from pydoctor.epydoc import log
 from pydoctor.epydoc.util import plaintext_to_html
 from pydoctor import epydoc
@@ -137,7 +138,7 @@ def parse(docstring, markup='plaintext', errors=None, **options):
     parse_docstring = _markup_language_registry[markup]
 
     # If it's a string, then it names a function to import.
-    if isinstance(parse_docstring, basestring):
+    if isinstance(parse_docstring, six.string_types):
         try: exec('from %s import parse_docstring' % parse_docstring)
         except ImportError as ex:
             _parse_warn('Error importing %s for markup language %s: %s' %

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -252,7 +252,7 @@ class ParsedDocstring:
         @return: A plaintext fragment that encodes this docstring.
         @rtype: C{string}
         """
-        raise NotImplementedError, 'ParsedDocstring.to_plaintext()'
+        raise NotImplementedError('ParsedDocstring.to_plaintext()')
 
 ##################################################
 ## Fields

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -139,7 +139,7 @@ def parse(docstring, markup='plaintext', errors=None, **options):
     # If it's a string, then it names a function to import.
     if isinstance(parse_docstring, basestring):
         try: exec('from %s import parse_docstring' % parse_docstring)
-        except ImportError, ex:
+        except ImportError as ex:
             _parse_warn('Error importing %s for markup language %s: %s' %
                         (parse_docstring, markup, ex))
             import pydoctor.epydoc.markup.plaintext as plaintext
@@ -149,7 +149,7 @@ def parse(docstring, markup='plaintext', errors=None, **options):
     # Parse the docstring.
     try: parsed_docstring = parse_docstring(docstring, errors, **options)
     except KeyboardInterrupt: raise
-    except Exception, ex:
+    except Exception as ex:
         if epydoc.DEBUG: raise
         log.error('Internal error while parsing a docstring: %s; '
                   'treating docstring as plaintext' % ex)

--- a/pydoctor/epydoc/markup/doctest.py
+++ b/pydoctor/epydoc/markup/doctest.py
@@ -16,6 +16,7 @@ on doctest blocks with other output formats.
 __docformat__ = 'epytext en'
 
 import re
+from six.moves import builtins
 from pydoctor.epydoc.util import plaintext_to_html
 
 __all__ = ['doctest_to_html', 'DoctestColorizer', 'HTMLDoctestColorizer']
@@ -76,7 +77,7 @@ class DoctestColorizer:
                  "def       finally   in        print     as").split()
 
     #: A list of all Python builtins.
-    _BUILTINS = [_BI for _BI in dir(__builtins__)
+    _BUILTINS = [_BI for _BI in dir(builtins)
                  if not _BI.startswith('__')]
 
     #: A regexp group that matches keywords.

--- a/pydoctor/epydoc/markup/doctest.py
+++ b/pydoctor/epydoc/markup/doctest.py
@@ -13,6 +13,9 @@ C{colorize_doctest()}, which could be used to do syntax highlighting
 on doctest blocks with other output formats.
 (C{doctest_to_html()} is defined using C{colorize_doctest()}.)
 """
+
+from __future__ import print_function
+
 __docformat__ = 'epytext en'
 
 import re
@@ -192,7 +195,7 @@ class DoctestColorizer:
 
     def subfunc(self, match):
         other, text = match.group(1, 2)
-        #print 'M %20r %20r' % (other, text) # <- for debugging
+        #print('M %20r %20r' % (other, text)) # <- for debugging
         if other:
             other = self.NEWLINE.join([self.markup(line, 'other')
                                        for line in other.split('\n')])

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -1373,7 +1373,7 @@ def to_debug(tree, indent=4, seclevel=0):
         str = re.sub('\0', 'E{lb}', childstr)
         str = re.sub('\1', 'E{rb}', str)
         uline = len(childstr)*_HEADING_CHARS[seclevel-1]
-        return ('SEC'+`seclevel`+'>|'+(indent-8)*' ' + str + '\n' +
+        return ('SEC'+repr(seclevel)+'>|'+(indent-8)*' ' + str + '\n' +
                 '     |'+(indent-8)*' ' + uline + '\n')
     elif tree.tag == 'doctestblock':
         str = re.sub('\0', '{', childstr)

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -96,6 +96,8 @@ Description::
 # Note: the symbol list is appended to the docstring automatically,
 # below.
 
+from __future__ import print_function
+
 __docformat__ = 'epytext en'
 
 # Code organization..
@@ -276,7 +278,7 @@ def parse(str, errors = None):
 
     for token in tokens:
         # Uncomment this for debugging:
-        #print ('%s: %s\n%s: %s\n' %
+        #print('%s: %s\n%s: %s\n' %
         #       (''.join(['%-11s' % (t and t.tag) for t in stack]),
         #        token.tag, ''.join(['%-11s' % i for i in indent_stack]),
         #        token.indent))

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -106,6 +106,7 @@ __docformat__ = 'epytext en'
 #   5. testing
 
 import re, string
+import six
 from pydoctor.epydoc.markup import Field, ParseError, ParsedDocstring
 from pydoctor.epydoc.util import wordwrap, plaintext_to_html
 from pydoctor.epydoc.markup.doctest import doctest_to_html
@@ -1048,7 +1049,7 @@ def _colorize(doc, token, errors, tagName='para'):
             # Special handling for symbols:
             if stack[-1].tag == 'symbol':
                 if (len(stack[-1].children) != 1 or
-                    not isinstance(stack[-1].children[0], basestring)):
+                    not isinstance(stack[-1].children[0], six.string_types)):
                     estr = "Invalid symbol code."
                     errors.append(ColorizingError(estr, token, end))
                 else:
@@ -1063,7 +1064,7 @@ def _colorize(doc, token, errors, tagName='para'):
             # Special handling for escape elements:
             if stack[-1].tag == 'escape':
                 if (len(stack[-1].children) != 1 or
-                    not isinstance(stack[-1].children[0], basestring)):
+                    not isinstance(stack[-1].children[0], six.string_types)):
                     estr = "Invalid escape code."
                     errors.append(ColorizingError(estr, token, end))
                 else:
@@ -1106,7 +1107,7 @@ def _colorize_link(doc, link, token, end, errors):
     variables = link.children[:]
 
     # If the last child isn't text, we know it's bad.
-    if len(variables)==0 or not isinstance(variables[-1], basestring):
+    if len(variables)==0 or not isinstance(variables[-1], six.string_types):
         estr = "Bad %s target." % link.tag
         errors.append(ColorizingError(estr, token, end))
         return
@@ -1177,7 +1178,7 @@ def to_epytext(tree, indent=0, seclevel=0):
     @return: The epytext string corresponding to C{tree}.
     @rtype: C{string}
     """
-    if isinstance(tree, basestring):
+    if isinstance(tree, six.string_types):
         str = re.sub(r'\{', '\0', tree)
         str = re.sub(r'\}', '\1', str)
         return str
@@ -1262,7 +1263,7 @@ def to_plaintext(tree, indent=0, seclevel=0):
     @return: The epytext string corresponding to C{tree}.
     @rtype: C{string}
     """
-    if isinstance(tree, basestring): return tree
+    if isinstance(tree, six.string_types): return tree
 
     if tree.tag == 'section': seclevel += 1
 
@@ -1340,7 +1341,7 @@ def to_debug(tree, indent=4, seclevel=0):
     @return: The epytext string corresponding to C{tree}.
     @rtype: C{string}
     """
-    if isinstance(tree, basestring):
+    if isinstance(tree, six.string_types):
         str = re.sub(r'\{', '\0', tree)
         str = re.sub(r'\}', '\1', str)
         return str
@@ -1596,7 +1597,7 @@ class ParsedEpytextDocstring(ParsedDocstring):
 
     def _to_html(self, tree, linker, directory, docindex, context,
                  indent=0, seclevel=0):
-        if isinstance(tree, basestring):
+        if isinstance(tree, six.string_types):
             return plaintext_to_html(tree)
 
         if tree.tag == 'epytext': indent -= 2
@@ -1701,7 +1702,7 @@ class ParsedEpytextDocstring(ParsedDocstring):
         para = Element('para', inline=True)
         doc.children.append(para)
         for parachild in parachildren:
-            if isinstance(parachild, basestring):
+            if isinstance(parachild, six.string_types):
                 m = self._SUMMARY_RE.match(parachild)
                 if m:
                     para.children.append(m.group(1))

--- a/pydoctor/epydoc/markup/plaintext.py
+++ b/pydoctor/epydoc/markup/plaintext.py
@@ -27,7 +27,7 @@ def parse_docstring(docstring, errors, **options):
 class ParsedPlaintextDocstring(ParsedDocstring):
     def __init__(self, text, **options):
         self._verbatim = options.get('verbatim', 1)
-        if text is None: raise ValueError, 'Bad text value (expected a str)'
+        if text is None: raise ValueError('Bad text value (expected a str)')
         self._text = text
 
     def to_html(self, docstring_linker, **options):

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -273,7 +273,7 @@ class _SplitFieldsTranslator(NodeVisitor):
                     try:
                         self.handle_consolidated_field(fbody, entry_tag)
                         return
-                    except ValueError, e:
+                    except ValueError as e:
                         estr = 'Unable to split consolidated field '
                         estr += '"%s" - %s' % (tagname, e)
                         self._errors.append(ParseError(estr, node.line,

--- a/pydoctor/epydoc/test/epytext.doctest
+++ b/pydoctor/epydoc/test/epytext.doctest
@@ -23,151 +23,151 @@ than it was with unittest.
 
 Paragraphs:
 
-    >>> print testparse("""
+    >>> print(testparse("""
     ...     this is one paragraph.
     ...
     ...     This is
     ...     another.
     ...
-    ...     This is a third""")
+    ...     This is a third"""))
     <para>this is one paragraph.</para>
     <para>This is another.</para>
     <para>This is a third</para>
 
 Make sure that unindented fields are allowed:
 
-    >>> print testparse("""
+    >>> print(testparse("""
     ...     This is a paragraph.
     ...
-    ...     @foo: This is a field.""")
+    ...     @foo: This is a field."""))
     <para>This is a paragraph.</para>
     <fieldlist><field><tag>foo</tag>
     <para inline=True>This is a field.</para></field></fieldlist>
 
-    >>> print testparse("""
+    >>> print(testparse("""
     ...     This is a paragraph.
-    ...     @foo: This is a field.""")
+    ...     @foo: This is a field."""))
     <para>This is a paragraph.</para>
     <fieldlist><field><tag>foo</tag>
     <para inline=True>This is a field.</para></field></fieldlist>
 
-    >>> print testparse("""
+    >>> print(testparse("""
     ...     This is a paragraph.
     ...       @foo: This is a field.
-    ...         Hello.""")
+    ...         Hello."""))
     <para>This is a paragraph.</para>
     <fieldlist><field><tag>foo</tag>
     <para inline=True>This is a field. Hello.</para></field>
     </fieldlist>
 
-    >>> print testparse("""Paragraph\n@foo: field""")
+    >>> print(testparse("""Paragraph\n@foo: field"""))
     <para>Paragraph</para>
     <fieldlist><field><tag>foo</tag>
     <para inline=True>field</para></field></fieldlist>
 
-    >>> print testparse("""Paragraph\n\n@foo: field""")
+    >>> print(testparse("""Paragraph\n\n@foo: field"""))
     <para>Paragraph</para>
     <fieldlist><field><tag>foo</tag>
     <para inline=True>field</para></field></fieldlist>
 
-    >>> print testparse("""\nParagraph\n@foo: field""")
+    >>> print(testparse("""\nParagraph\n@foo: field"""))
     <para>Paragraph</para>
     <fieldlist><field><tag>foo</tag>
     <para inline=True>field</para></field></fieldlist>
 
 Make sure thta unindented lists are not allowed:
 
-    >>> print testparse("""
+    >>> print(testparse("""
     ...     This is a paragraph.
     ...
-    ...     - This is a list item.""")
+    ...     - This is a list item."""))
     Traceback (most recent call last):
     StructuringError: Line 4: Lists must be indented.
 
-    >>> print testparse("""
+    >>> print(testparse("""
     ...     This is a paragraph.
-    ...     - This is a list item.""")
+    ...     - This is a list item."""))
     Traceback (most recent call last):
     StructuringError: Line 3: Lists must be indented.
 
-    >>> print testparse("""
+    >>> print(testparse("""
     ...     This is a paragraph.
     ...       - This is a list item.
     ...         Hello.
-    ...         - Sublist item""")
+    ...         - Sublist item"""))
     Traceback (most recent call last):
     StructuringError: Line 5: Lists must be indented.
 
-    >>> print testparse("""
+    >>> print(testparse("""
     ...     This is a paragraph.
     ...       - This is a list item.
     ...         Hello.
     ...
-    ...         - Sublist item""")
+    ...         - Sublist item"""))
     Traceback (most recent call last):
     StructuringError: Line 6: Lists must be indented.
 
-    >>> print testparse("""Paragraph\n\n- list item""")
+    >>> print(testparse("""Paragraph\n\n- list item"""))
     Traceback (most recent call last):
     StructuringError: Line 3: Lists must be indented.
 
-    >>> print testparse("""\nParagraph\n- list item""")
+    >>> print(testparse("""\nParagraph\n- list item"""))
     Traceback (most recent call last):
     StructuringError: Line 3: Lists must be indented.
 
 Special case if there's text on the same line as the opening quote:
 
-    >>> print testparse("""Paragraph\n- list item""")
+    >>> print(testparse("""Paragraph\n- list item"""))
     <para>Paragraph</para>
     <ulist><li><para inline=True>list item</para></li></ulist>
 
 Make sure that indented lists are allowed:
 
-    >>> print testparse('This is a paragraph.\n  - This is a list item.\n'+
-    ...           'This is a paragraph')
+    >>> print(testparse('This is a paragraph.\n  - This is a list item.\n'+
+    ...           'This is a paragraph'))
     <para>This is a paragraph.</para>
     <ulist><li><para inline=True>This is a list item.</para></li>
     </ulist>
     <para>This is a paragraph</para>
 
-    >>> print testparse('This is a paragraph.\n\n  - This is a list item.'+
-    ...           '\n\nThis is a paragraph')
+    >>> print(testparse('This is a paragraph.\n\n  - This is a list item.'+
+    ...           '\n\nThis is a paragraph'))
     <para>This is a paragraph.</para>
     <ulist><li><para inline=True>This is a list item.</para></li>
     </ulist>
     <para>This is a paragraph</para>
 
-    >>> print testparse("""
+    >>> print(testparse("""
     ...     This is a paragraph.
     ...
     ...       - This is a list item.
     ...
-    ...     This is a paragraph""")
+    ...     This is a paragraph"""))
     <para>This is a paragraph.</para>
     <ulist><li><para inline=True>This is a list item.</para></li>
     </ulist>
     <para>This is a paragraph</para>
 
-    >>> print testparse("""
+    >>> print(testparse("""
     ...     This is a paragraph.
     ...
     ...           - This is a list item.
-    ...     This is a paragraph""")
+    ...     This is a paragraph"""))
     <para>This is a paragraph.</para>
     <ulist><li><para inline=True>This is a list item.</para></li>
     </ulist>
     <para>This is a paragraph</para>
 
-    >>> print testparse("""
-    ...       - This is a list item.""")
+    >>> print(testparse("""
+    ...       - This is a list item."""))
     <ulist><li><para inline=True>This is a list item.</para></li>
     </ulist>
 
-    >>> print testparse("""- This is a list item.""")
+    >>> print(testparse("""- This is a list item."""))
     <ulist><li><para inline=True>This is a list item.</para></li>
     </ulist>
 
-    >>> print testparse("""\n- This is a list item.""")
+    >>> print(testparse("""\n- This is a list item."""))
     <ulist><li><para inline=True>This is a list item.</para></li>
     </ulist>
 
@@ -239,16 +239,16 @@ tests make sure that braces are getting rendered as desired.
 >>> def epytext2html(s):
 ...     errs = []
 ...     v = epytext.parse_docstring(s, errs).to_html(None)
-...     for err in errs: print err
+...     for err in errs: print(err)
 ...     return (v or '').rstrip()
 
->>> print epytext2html("{1:{2:3}}")
+>>> print(epytext2html("{1:{2:3}}"))
 <p>{1:{2:3}}</p>
->>> print epytext2html("C{{1:{2:3}}}")
+>>> print(epytext2html("C{{1:{2:3}}}"))
 <p><code>{1:{2:3}}</code></p>
->>> print epytext2html("{1:C{{2:3}}}")
+>>> print(epytext2html("{1:C{{2:3}}}"))
 <p>{1:<code>{2:3}</code>}</p>
->>> print epytext2html("{{{}{}}{}}")
+>>> print(epytext2html("{{{}{}}{}}"))
 <p>{{{}{}}{}}</p>
->>> print epytext2html("{{E{lb}E{lb}E{lb}}}")
+>>> print(epytext2html("{{E{lb}E{lb}E{lb}}}"))
 <p>{{{{{}}</p>

--- a/pydoctor/epydoc/test/restructuredtext.doctest
+++ b/pydoctor/epydoc/test/restructuredtext.doctest
@@ -25,7 +25,7 @@ as colorized Python code.
 ... """, err)
 >>> err
 []
->>> print p.to_html(None)
+>>> print(p.to_html(None))
 <p>A test module</p>
 <pre class="py-doctest">
 <span class="py-comment"># This is some Python code</span>

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -345,7 +345,6 @@ class FieldHandler(object):
     handle_rtype = handle_returntype
 
     def add_type_info(self, desc_list, field):
-        #print desc_list, field
         if desc_list and desc_list[-1].name == field.arg:
             if desc_list[-1].type is not None:
                 self.redef(field)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -5,13 +5,13 @@ Convert epydoc markup into renderable content.
 from __future__ import print_function
 
 from six.moves import builtins
+from six.moves.urllib.parse import quote
 import exceptions
 import inspect
 import itertools
 import os
 import re
 import sys
-import urllib
 
 from twisted.web.template import Tag, tags, XMLString
 
@@ -24,7 +24,7 @@ STDLIB_URL = 'http://docs.python.org/library/'
 
 
 def link(o):
-    return o.system.urlprefix + urllib.quote(o.fullName()+'.html')
+    return o.system.urlprefix + quote(o.fullName()+'.html')
 
 
 def get_parser(formatname):
@@ -91,7 +91,7 @@ class _EpydocLinker(DocstringLinker):
             p = obj.parent
             if isinstance(p, model.Module) and p.name == '__init__':
                 p = p.parent
-            linktext = link(p) + '#' + urllib.quote(obj.name)
+            linktext = link(p) + '#' + quote(obj.name)
         elif obj.documentation_location == model.DocLocation.OWN_PAGE:
             linktext = link(obj)
         else:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -728,7 +728,7 @@ class System(object):
 
     def process(self):
         while self.unprocessed_modules:
-            mod = iter(self.unprocessed_modules).next()
+            mod = next(iter(self.unprocessed_modules))
             self.processModule(mod)
 
 

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -228,7 +228,7 @@ _maxAgeUnits = {
     "m": _Unit("minutes", minimum=1, maximum=2 ** 32 - 1),
     "h": _Unit("hours", minimum=1, maximum=2 ** 32 - 1),
     "d": _Unit("days", minimum=1, maximum=999999999 + 1),
-    "w": _Unit("weeks", minimum=1, maximum=(999999999 + 1) / 7),
+    "w": _Unit("weeks", minimum=1, maximum=(999999999 + 1) // 7),
 }
 _maxAgeUnitNames = ", ".join(
     "{} ({})".format(indicator, unit.name)

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -19,7 +19,7 @@ def getBetterThanArgspec(argspec):
     backargs.reverse()
     defaults = list(defaults)
     defaults.reverse()
-    kws = zip(backargs, defaults)
+    kws = list(zip(backargs, defaults))
     kws.reverse()
     return (args[:-len(kws)], kws)
 
@@ -278,7 +278,7 @@ class ClassPage(CommonPage):
 
     def mediumName(self, ob):
         r = [super(ClassPage, self).mediumName(ob)]
-        zipped = zip(self.ob.rawbases, self.ob.bases, self.ob.baseobjects)
+        zipped = list(zip(self.ob.rawbases, self.ob.bases, self.ob.baseobjects))
         if zipped:
             r.append('(')
             for i, (n, m, o) in enumerate(zipped):

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -7,12 +7,13 @@ from pydoctor import model
 from twisted.python.filepath import FilePath
 from twisted.web.template import tags
 
-import os, urllib
+import os
+from six.moves.urllib.parse import quote
 
 def link(o):
     if not o.isVisible:
         o.system.msg("html", "don't link to %s"%o.fullName())
-    return o.system.urlprefix+urllib.quote(o.fullName()+'.html')
+    return o.system.urlprefix+quote(o.fullName()+'.html')
 
 def srclink(o):
     return o.sourceHref
@@ -39,7 +40,7 @@ def taglink(o, label=None):
         p = o.parent
         if isinstance(p, model.Module) and p.name == '__init__':
             p = p.parent
-        linktext = link(p) + '#' + urllib.quote(o.name)
+        linktext = link(p) + '#' + quote(o.name)
     elif o.documentation_location == model.DocLocation.OWN_PAGE:
         linktext = link(o)
     else:

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -193,7 +193,6 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
                 return node.args[0].value
 
         def handleSchemaField(kind):
-            #print node.expr
             descriptions = [arg for arg in node.expr.args if isinstance(arg, ast.Keyword)
                             and arg.name == 'description']
             docstring = None


### PR DESCRIPTION
This is a collection of code modernizations that should make the transition to Python 3 easier. Most of these were done with `python-modernize` and then manually reviewed and tweaked.

There is more work to be done, for example replacing `__cmp__`, but I figure it's worth integrating these changes already.