### PR TITLE
Fix generation of Twisted docs with port to ast module

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -51,7 +51,7 @@ class ModuleVistor(ast.NodeVisitor):
         for n in node.bases:
             if isinstance(n, ast.Name):
                 str_base = n.id
-            elif isinstance(n, ast.Attribute):
+            else:
                 str_base = astor.to_source(n).strip()
 
             rawbases.append(str_base)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -4,8 +4,6 @@ Convert epydoc markup into renderable content.
 
 from __future__ import print_function
 
-from six.moves import builtins
-from six.moves.urllib.parse import quote
 import exceptions
 import inspect
 import itertools
@@ -15,6 +13,7 @@ import sys
 
 from pydoctor import model
 from six.moves import builtins
+from six.moves.urllib.parse import quote
 from twisted.web.template import Tag, XMLString, tags
 from pydoctor.epydoc.markup import DocstringLinker
 

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 
 from twisted.web.template import tags, Element, renderer, XMLFile
 
-import astor
-
 from pydoctor import epydoc2stan, model
 from pydoctor.templatewriter.pages.table import ChildTable
 from pydoctor.templatewriter import util
@@ -46,7 +44,7 @@ def signature(argspec):
     if varargname:
         things.append('*%s' % varargname)
 
-    things += ['%s=%s' % (t[0].id, astor.to_source(t[1]).strip()) for t in kwargs]
+    things += ['%s=%s' % kwarg for kwarg in kwargs]
     if varkwname:
         things.append('**%s' % varkwname)
     return ', '.join(things)

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -3,13 +3,11 @@
 from __future__ import print_function
 
 import os
-import urllib
 
 from pydoctor import model
 from twisted.python.filepath import FilePath
 from twisted.web.template import tags
 
-import os
 from six.moves.urllib.parse import quote
 
 def link(o):

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -148,6 +148,8 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             name = node.func.id
         elif isinstance(node.func, ast.Attribute):
             name = astor.to_source(node).strip().split("(")[0]
+        elif isinstance(node.func, ast.Call):
+            return self.funcNameFromCall(node.func)
         else:
             raise Exception(node.func)
         return self.builder.current.expandName(name)


### PR DESCRIPTION
These are fixes for PR #151. As I write in the commit comment, I'm not sure if these fixes are correct for all use cases, but they do fix the issue of pydoctor crashing when generating Twisted's API documentation.