### PR TITLE
Cleanups in the epydoc2stan module

### DIFF
--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -478,7 +478,7 @@ def doc2stan(obj, summary=False):
         r = html2stan(obj.parsed_docstring.to_html(_EpydocLinker(obj)))
         if getattr(obj, 'parsed_type', None) is not None:
             r = [r, ' (type: ', html2stan(obj.parsed_type.to_html(_EpydocLinker(obj))), ')']
-        return r, []
+        return r
     origobj = obj
     if isinstance(obj, model.Package):
         obj = obj.contents['__init__']
@@ -508,9 +508,9 @@ def doc2stan(obj, summary=False):
                                          plurals.get(k, k+'s')))
                 text += '; ' + ', '.join(u) + " documented"
         if summary:
-            return tags.span(class_="undocumented")(text), []
+            return tags.span(class_="undocumented")(text)
         else:
-            return tags.div(class_="undocumented")(text), []
+            return tags.div(class_="undocumented")(text)
     if summary:
         # Use up to three first non-empty lines of doc string as summary.
         lines = itertools.dropwhile(lambda line: not line.strip(),
@@ -518,7 +518,7 @@ def doc2stan(obj, summary=False):
         lines = itertools.takewhile(lambda line: line.strip(), lines)
         lines = [ line.strip() for line in lines ]
         if len(lines) > 3:
-            return tags.span(class_="undocumented")('No summary'), []
+            return tags.span(class_="undocumented")('No summary')
         else:
             doc = ' '.join(lines)
     parse_docstring, e = get_parser(obj.system.options.docformat)
@@ -526,7 +526,7 @@ def doc2stan(obj, summary=False):
         msg = 'Error trying to import %r parser:\n\n    %s: %s\n\nUsing plain text formatting only.'%(
             obj.system.options.docformat, e.__class__.__name__, e)
         obj.system.msg('epydoc2stan', msg, thresh=-1, once=True)
-        return boringDocstring(doc, summary), []
+        return boringDocstring(doc, summary)
     errs = []
     doc = inspect.cleandoc(doc)
     try:
@@ -535,29 +535,28 @@ def doc2stan(obj, summary=False):
         errs = [e.__class__.__name__ +': ' + str(e)]
     if errs:
         reportErrors(source, errs)
-        return boringDocstring(doc, summary), errs
+        return boringDocstring(doc, summary)
     pdoc, fields = pdoc.split_fields()
     if pdoc is not None:
         try:
             crap = pdoc.to_html(_EpydocLinker(source))
         except Exception as e:
             reportErrors(source, [e.__class__.__name__ +': ' + str(e)])
-            return (boringDocstring(doc, summary),
-                    [e.__class__.__name__ +': ' + str(e)])
+            return boringDocstring(doc, summary)
     else:
         crap = ''
     if isinstance(crap, text_type):
         crap = crap.encode('utf-8')
     if summary:
         if not crap:
-            return (), []
+            return ()
         stan = html2stan(crap)
         if len(stan) == 1 and isinstance(stan[0], Tag) and stan[0].tagName == 'p':
             stan = stan[0].children
         s = tags.span(stan)
     else:
         if not crap and not fields:
-            return (), []
+            return ()
         stan = html2stan(crap)
         s = tags.div(stan)
         fh = FieldHandler(obj)
@@ -565,7 +564,7 @@ def doc2stan(obj, summary=False):
             fh.handle(Field(field, obj))
         fh.resolve_types()
         s(fh.format())
-    return s, []
+    return s
 
 
 field_name_to_human_name = {

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -44,13 +44,9 @@ def get_parser(formatname):
 def boringDocstring(doc, summary=False):
     """Generate an HTML representation of a docstring in a really boring way.
     """
-    # inspect.getdoc requires an object with a __doc__ attribute, not
-    # just a string :-(
     if doc is None or not doc.strip():
         return '<pre class="undocumented">Undocumented</pre>'
-    def crappit(): pass
-    crappit.__doc__ = doc
-    return (tags.pre, tags.tt)[bool(summary)](inspect.getdoc(crappit))
+    return (tags.pre, tags.tt)[bool(summary)](inspect.cleandoc(doc))
 
 
 def stdlib_doc_link_for_name(name):
@@ -532,9 +528,7 @@ def doc2stan(obj, summary=False):
         obj.system.msg('epydoc2stan', msg, thresh=-1, once=True)
         return boringDocstring(doc, summary), []
     errs = []
-    def crappit(): pass
-    crappit.__doc__ = doc
-    doc = inspect.getdoc(crappit)
+    doc = inspect.cleandoc(doc)
     try:
         pdoc = parse_docstring(doc, errs)
     except Exception as e:
@@ -592,9 +586,7 @@ def extract_fields(obj):
     parse_docstring, e = get_parser(obj.system.options.docformat)
     if not parse_docstring:
         return []
-    def crappit(): pass
-    crappit.__doc__ = doc
-    doc = inspect.getdoc(crappit)
+    doc = inspect.cleandoc(doc)
     try:
         pdoc = parse_docstring(doc, [])
     except Exception:

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -476,7 +476,7 @@ def reportErrors(obj, errs):
             p(err)
 
 
-def doc2stan(obj, summary=False, docstring=None):
+def doc2stan(obj, summary=False):
     """Generate an HTML representation of a docstring"""
     if getattr(obj, 'parsed_docstring', None) is not None:
         r = html2stan(obj.parsed_docstring.to_html(_EpydocLinker(obj)))
@@ -486,15 +486,11 @@ def doc2stan(obj, summary=False, docstring=None):
     origobj = obj
     if isinstance(obj, model.Package):
         obj = obj.contents['__init__']
-    if docstring is None:
-        doc = None
-        for source in obj.docsources():
-            if source.docstring is not None:
-                doc = source.docstring
-                break
-    else:
-        source = obj
-        doc = docstring
+    doc = None
+    for source in obj.docsources():
+        if source.docstring is not None:
+            doc = source.docstring
+            break
     if doc is None or not doc.strip():
         text = "Undocumented"
         subdocstrings = {}

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -51,7 +51,7 @@ def signature(argspec):
 
 class DocGetter(object):
     def get(self, ob, summary=False):
-        return epydoc2stan.doc2stan(ob, summary=summary)[0]
+        return epydoc2stan.doc2stan(ob, summary=summary)
 
 class CommonPage(Element):
 

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -8,7 +8,7 @@ from twisted.web.template import Element, TagLoader, XMLFile, renderer, tags
 
 
 def moduleSummary(modorpack):
-    r = tags.li(util.taglink(modorpack), ' - ', epydoc2stan.doc2stan(modorpack, summary=True)[0])
+    r = tags.li(util.taglink(modorpack), ' - ', epydoc2stan.doc2stan(modorpack, summary=True))
     if not isinstance(modorpack, model.Package):
         return r
     contents = [m for m in modorpack.orderedcontents
@@ -73,7 +73,7 @@ def subclassesFrom(hostsystem, cls, anchors):
     if name not in anchors:
         r(tags.a(name=name))
         anchors.add(name)
-    r(util.taglink(cls), ' - ', epydoc2stan.doc2stan(cls, summary=True)[0])
+    r(util.taglink(cls), ' - ', epydoc2stan.doc2stan(cls, summary=True))
     scs = [sc for sc in cls.subclasses if sc.system is hostsystem and ' ' not in sc.fullName()
            and sc.isVisible]
     if len(scs) > 0:

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -67,7 +67,7 @@ def test_summary():
         return part_flat(
             epydoc2stan.doc2stan(
                 mod.contents[func],
-                summary=True)[0].children)
+                summary=True).children)
     assert u'Lorem Ipsum' == get_summary('single_line_summary')
     assert u'Foo Bar Baz' == get_summary('three_lines_summary')
     assert u'No summary' == get_summary('no_summary')


### PR DESCRIPTION
Removes some unused features of the `doc2stan()` function and a workaround for Python versions older than 2.6.