### PR TITLE
Add support for variable docstrings

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -24,7 +24,20 @@ def parse(buf):
 
 
 def node2dottedname(node):
-    return astor.to_source(node).strip().split(".")
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    else:
+        return None
+    if len(parts) == 1 and parts[0] in ('True', 'False', 'None'):
+        # On Python 3, these are NameConstant nodes, but on Python 2
+        # they are Name nodes.
+        return None
+    parts.reverse()
+    return parts
 
 class ModuleVistor(ast.NodeVisitor):
     def __init__(self, builder, module):

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -264,8 +264,16 @@ class ModuleVistor(ast.NodeVisitor):
         else:
             return False
 
+    def _handleModuleVar(self, target, lineno):
+        obj = self.builder.current.resolveName(target)
+        if obj is None:
+            obj = self.builder.addAttribute(target, None, 'Variable', lineno)
+        if isinstance(obj, model.Attribute):
+            self.newAttr = obj
+
     def _handleAssignmentInModule(self, target, expr, lineno):
-        self._handleAliasing(target, expr)
+        if not self._handleAliasing(target, expr):
+            self._handleModuleVar(target, lineno)
 
     def _handleClassVar(self, target, lineno):
         attr = self.builder.addAttribute(target, None, 'Class Variable', lineno)

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -396,6 +396,17 @@ class ASTBuilder(object):
     def popPackage(self):
         self._pop(self.system.Package)
 
+    def addAttribute(self, target, docstring, kind, lineno):
+        system = self.system
+        parentMod = self.currentMod
+        attr = model.Attribute(system, target, docstring, self.current)
+        attr.kind = kind
+        attr.parentMod = parentMod
+        attr.linenumber = lineno
+        if parentMod.sourceHref:
+            attr.sourceHref = '%s#L%d' % (parentMod.sourceHref, lineno)
+        system.addObject(attr)
+
     def warning(self, type, detail):
         self.system._warning(self.current, type, detail)
 

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -241,11 +241,7 @@ class ModuleVistor(ast.NodeVisitor):
         if not isinstance(self.builder.current, model.CanContainImportsDocumentable):
             return
         c = self.builder.current
-        base = None
-        if dottedname[0] in c._localNameToFullName_map:
-            base = c._localNameToFullName_map[dottedname[0]]
-        elif dottedname[0] in c.contents:
-            base = c.contents[dottedname[0]].fullName()
+        base = c.expandName(dottedname[0])
         if base:
             c._localNameToFullName_map[target] = '.'.join([base] + dottedname[1:])
 

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -288,7 +288,7 @@ class ModuleVistor(ast.NodeVisitor):
         cls = func.parent
         if not isinstance(cls, model.Class):
             return
-        obj = cls.resolveName(target)
+        obj = cls.contents.get(target)
         if obj is None:
             obj = self.builder.addAttribute(target, None, None, lineno, cls)
         if isinstance(obj, model.Attribute):

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -109,7 +109,8 @@ class ModuleVistor(ast.NodeVisitor):
 
     def visit_ImportFrom(self, node):
         if not isinstance(self.builder.current, model.CanContainImportsDocumentable):
-            self.warning("processing import statement in odd context")
+            self.builder.warning("processing import statement in odd context",
+                                 str(self.builder.current))
             return
 
         if node.module is None:
@@ -179,7 +180,8 @@ class ModuleVistor(ast.NodeVisitor):
         part of the statement.
         """
         if not isinstance(self.builder.current, model.CanContainImportsDocumentable):
-            self.warning("processing import statement in odd context")
+            self.builder.warning("processing import statement in odd context",
+                                 str(self.builder.current))
             return
         _localNameToFullName = self.builder.current._localNameToFullName_map
         for al in node.names:

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -276,8 +276,10 @@ class ModuleVistor(ast.NodeVisitor):
             self._handleModuleVar(target, lineno)
 
     def _handleClassVar(self, target, lineno):
-        attr = self.builder.addAttribute(target, None, 'Class Variable', lineno)
-        self.newAttr = attr
+        obj = self.builder.current.contents.get(target)
+        if not isinstance(obj, model.Attribute):
+            obj = self.builder.addAttribute(target, None, 'Class Variable', lineno)
+        self.newAttr = obj
 
     def _handleInstanceVar(self, target, lineno):
         func = self.builder.current

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -600,9 +600,12 @@ def extract_fields(obj):
             types[field.arg()] = field.body()
     for field in fields:
         if field.tag() in ['ivar', 'cvar', 'var']:
-            attrobj = obj.system.Attribute(obj.system, field.arg(), None, obj)
+            arg = field.arg()
+            attrobj = obj.contents.get(arg)
+            if attrobj is None:
+                attrobj = obj.system.Attribute(obj.system, arg, None, obj)
             attrobj.parsed_docstring = field.body()
-            attrobj.parsed_type = types.get(field.arg())
+            attrobj.parsed_type = types.get(arg)
             attrobj.kind = field_name_to_human_name[field.tag()]
             r.append(attrobj)
     return r

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -499,6 +499,9 @@ def test_inline_docstring_annotated_instancevar():
 
 def test_variable_scopes():
     mod = fromText('''
+    l = 1
+    """module-level l"""
+
     m = 1
     """module-level m"""
 
@@ -518,18 +521,26 @@ def test_variable_scopes():
         def __init__(self):
             self.a = 1
             """inline doc for a"""
+            self.l = 2
+            """instance l"""
     ''', modname='test')
+    l1 = mod.contents['l']
+    assert l1.kind == 'Variable'
+    assert l1.docstring == """module-level l"""
     m1 = mod.contents['m']
     assert m1.kind == 'Variable'
     assert m1.docstring == """module-level m"""
     C = mod.contents['C']
-    assert sorted(C.contents.keys()) == ['__init__', 'a', 'k', 'm']
+    assert sorted(C.contents.keys()) == ['__init__', 'a', 'k', 'l', 'm']
     a = C.contents['a']
     assert a.kind == 'Instance Variable'
     assert a.docstring == """inline doc for a"""
     k = C.contents['k']
     assert k.kind == 'Instance Variable'
     assert k.parsed_docstring is not None
+    l2 = C.contents['l']
+    assert l2.kind == 'Instance Variable'
+    assert l2.docstring == """instance l"""
     m2 = C.contents['m']
     assert m2.kind == 'Class Variable'
     assert m2.docstring == """class-level m"""

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -335,6 +335,33 @@ def test_import_star():
     assert mod_b.resolveName('f') == mod_a.contents['f']
 
 
+def test_inline_docstring_modulevar():
+    mod = fromText('''
+    """regular module docstring
+
+    @var b: doc for b
+    """
+
+    """not a docstring"""
+
+    a = 1
+    """inline doc for a"""
+
+    b = 2
+
+    def f():
+        pass
+    """not a docstring"""
+    ''', modname='test')
+    assert sorted(mod.contents.keys()) == ['a', 'b', 'f']
+    a = mod.contents['a']
+    assert a.docstring == """inline doc for a"""
+    b = mod.contents['b']
+    assert b.docstring is None
+    assert b.parsed_docstring is not None
+    f = mod.contents['f']
+    assert not f.docstring
+
 def test_inline_docstring_classvar():
     mod = fromText('''
     class C:

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -386,3 +386,86 @@ def test_inline_docstring_annotated_classvar():
     b = C.contents['_b']
     assert b.docstring == """inline doc for _b"""
     assert b.privacyClass is model.PrivacyClass.PRIVATE
+
+def test_inline_docstring_instancevar():
+    mod = fromText('''
+    class C:
+        """regular class docstring"""
+
+        d = None
+        """inline doc for d"""
+
+        f = None
+        """inline doc for f"""
+
+        def __init__(self):
+            self.a = 1
+            """inline doc for a"""
+
+            """not a docstring"""
+
+            self._b = 2
+            """inline doc for _b"""
+
+            x = -1
+            """not a docstring"""
+
+            self.c = 3
+            """inline doc for c"""
+
+            self.d = 4
+
+            self.e = 5
+        """not a docstring"""
+
+        def set_f(self, value):
+            self.f = value
+    ''', modname='test')
+    C = mod.contents['C']
+    assert sorted(C.contents.keys()) == [
+        '__init__', '_b', 'a', 'c', 'd', 'e', 'f', 'set_f'
+        ]
+    a = C.contents['a']
+    assert a.docstring == """inline doc for a"""
+    assert a.privacyClass is model.PrivacyClass.VISIBLE
+    assert a.kind == 'Instance Variable'
+    b = C.contents['_b']
+    assert b.docstring == """inline doc for _b"""
+    assert b.privacyClass is model.PrivacyClass.PRIVATE
+    assert b.kind == 'Instance Variable'
+    c = C.contents['c']
+    assert c.docstring == """inline doc for c"""
+    assert c.privacyClass is model.PrivacyClass.VISIBLE
+    assert c.kind == 'Instance Variable'
+    d = C.contents['d']
+    assert d.docstring == """inline doc for d"""
+    assert d.privacyClass is model.PrivacyClass.VISIBLE
+    assert d.kind == 'Instance Variable'
+    e = C.contents['e']
+    assert not e.docstring
+    f = C.contents['f']
+    assert f.docstring == """inline doc for f"""
+    assert f.privacyClass is model.PrivacyClass.VISIBLE
+    assert f.kind == 'Instance Variable'
+
+@py3only
+def test_inline_docstring_annotated_instancevar():
+    mod = fromText('''
+    class C:
+        """regular class docstring"""
+
+        a: int
+
+        def __init__(self):
+            self.a = 1
+            """inline doc for a"""
+
+            self.b: int = 2
+            """inline doc for b"""
+    ''', modname='test')
+    C = mod.contents['C']
+    assert sorted(C.contents.keys()) == ['__init__', 'a', 'b']
+    a = C.contents['a']
+    assert a.docstring == """inline doc for a"""
+    b = C.contents['b']
+    assert b.docstring == """inline doc for b"""

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -496,3 +496,40 @@ def test_inline_docstring_annotated_instancevar():
     assert a.docstring == """inline doc for a"""
     b = C.contents['b']
     assert b.docstring == """inline doc for b"""
+
+def test_variable_scopes():
+    mod = fromText('''
+    m = 1
+    """module-level m"""
+
+    class C:
+        """class docstring
+
+        @ivar k: class level doc for k
+        """
+
+        a = None
+
+        k = 640
+
+        m = 2
+        """class-level m"""
+
+        def __init__(self):
+            self.a = 1
+            """inline doc for a"""
+    ''', modname='test')
+    m1 = mod.contents['m']
+    assert m1.kind == 'Variable'
+    assert m1.docstring == """module-level m"""
+    C = mod.contents['C']
+    assert sorted(C.contents.keys()) == ['__init__', 'a', 'k', 'm']
+    a = C.contents['a']
+    assert a.kind == 'Instance Variable'
+    assert a.docstring == """inline doc for a"""
+    k = C.contents['k']
+    assert k.kind == 'Instance Variable'
+    assert k.parsed_docstring is not None
+    m2 = C.contents['m']
+    assert m2.kind == 'Class Variable'
+    assert m2.docstring == """class-level m"""

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -164,6 +164,18 @@ def test_with_underscore():
     assert text.docstring == 'fun in a bap'
     assert text.kind == "TextLine"
 
+def test_aliasing_in_class():
+    src = '''
+    from zope import interface
+    class IMyInterface(interface.Interface):
+        Attrib = interface.Attribute
+        attribute = Attrib("fun in a bun")
+    '''
+    mod = fromText(src, systemcls=ZopeInterfaceSystem)
+    attr = mod.contents['IMyInterface'].contents['attribute']
+    assert attr.docstring == 'fun in a bun'
+    assert attr.kind == "Attribute"
+
 def test_zopeschema_inheritance():
     src = '''
     from zope import schema, interface

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -116,11 +116,15 @@ def test_multiply_inheriting_interfaces():
 def test_attribute():
     src = '''
     import zope.interface as zi
-    class C:
-        attr = zi.Attribute("docstring")
+    class C(zi.Interface):
+        attr = zi.Attribute("documented attribute")
     '''
     mod = fromText(src, systemcls=ZopeInterfaceSystem)
     assert len(mod.contents['C'].contents) == 1
+    attr = mod.contents['C'].contents['attr']
+    assert attr.kind == 'Attribute'
+    assert attr.name == 'attr'
+    assert attr.docstring == "documented attribute"
 
 def test_interfaceclass():
     system = processPackage('interfaceclass', systemcls=ZopeInterfaceSystem)

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -169,9 +169,6 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
 
         if isinstance(self.builder.current, model.Module):
             name = node.targets[0].id
-            # TODO: Which is correct?
-            args = node.value
-            args = node.value.args
             ob = self.system.objForFullName(funcName)
             if ob is not None and isinstance(ob, model.Class) and ob.isinterfaceclass:
                 interface = self.builder.pushClass(name, "...")

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -138,6 +138,16 @@ def extractAttributeDescription(node):
 def extractSchemaDescription(node):
     pass
 
+def extractStringLiteral(node):
+    if isinstance(node, ast.Str):
+        return node.s
+    elif isinstance(node, ast.Name):
+        return node.id
+    elif isinstance(node, ast.Call):
+        return node.args[0].s
+    else:
+        raise TypeError("cannot extract string from %r" % (node,))
+
 class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
 
     schema_like_patterns = [
@@ -189,16 +199,6 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
                 attr.sourceHref = attr.parentMod.sourceHref + '#L' + \
                                   str(attr.linenumber)
             self.builder._pop(model.Attribute)
-
-        def extractStringLiteral(node):
-            if isinstance(node, ast.Str):
-                return node.s
-            elif isinstance(node, ast.Name):
-                return node.id
-            elif isinstance(node, ast.Call):
-                return node.args[0].s
-            else:
-                raise Exception(node)
 
         def handleSchemaField(kind):
             descriptions = [arg.value for arg in node.value.keywords if arg.arg == 'description']

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -162,7 +162,7 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
         elif isinstance(node.func, ast.Call):
             return self.funcNameFromCall(node.func)
         else:
-            raise Exception(node.func)
+            return None
         return self.builder.current.expandName(name)
 
     def _handleAssignmentInModule(self, target, expr, lineno):
@@ -171,6 +171,8 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
         if not isinstance(expr, ast.Call):
             return
         funcName = self.funcNameFromCall(expr)
+        if funcName is None:
+            return
         ob = self.system.objForFullName(funcName)
         if isinstance(ob, model.Class) and ob.isinterfaceclass:
             interface = self.builder.pushClass(target, "...")
@@ -194,6 +196,8 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             return
         attr = self.builder.current.contents[target]
         funcName = self.funcNameFromCall(expr)
+        if funcName is None:
+            return
         if funcName == 'zope.interface.Attribute':
             args = expr.args
             if args is not None and len(args) == 1:
@@ -210,6 +214,8 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
 
     def visit_Call(self, node):
         base = self.funcNameFromCall(node)
+        if base is None:
+            return
         meth = getattr(self, "visit_Call_" + base.replace('.', '_'), None)
         if meth is not None:
             meth(base, node)


### PR DESCRIPTION
This makes pydoctor process inline docstrings below assignments to variables. It allows module, class or instance variables to be documented where they are defined instead of in their scope's docstring. See the added unit tests for examples.

Other documentation extraction tools such as Epydoc, pdoc and Sphinx autodoc have similar support, so this helps people who want to migrate to pydoctor. It could also act as a base for attrs support, see #135.

The changes in this pull request were deliberately made to also pave the way for extracting type information from PEP 484 style type annotations, see #136. Nodes of type `AnnAssign` (assignment with annotation) are now handled, although the annotation itself is still ignored.

One visible side effect of the changes made is that undocumented variables are now listed as undocumented variables in the documentation, rather than being omitted. I don't know if that omission was deliberate or an unintended limitation of pydoctor. In my opinion, if we don't want undocumented variables to be considered part of the public API, it would be better to mark them as private instead of pretending they don't exist.