### PR TITLE
Fix docstring inheritance

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -257,7 +257,7 @@ class ModuleVistor(ast.NodeVisitor):
         self._handleAliasing(target, node.value)
 
     def visit_FunctionDef(self, node):
-        doc = ""
+        doc = None
         if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
             doc = node.body[0].value.s
         func = self.builder.pushFunction(node.name, doc)

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -28,6 +28,21 @@ def fromText(text, modname='<test>', system=None,
     mod.state = model.ProcessingState.PROCESSED
     return mod
 
+def test_no_docstring():
+    # Inheritance of the docstring of an overridden method depends on
+    # methods with no docstring having None in their 'docstring' field.
+    mod = fromText('''
+    def f():
+        pass
+    class C:
+        def m(self):
+            pass
+    ''', modname='test')
+    f = mod.contents['f']
+    assert f.docstring is None
+    m = mod.contents['C'].contents['m']
+    assert m.docstring is None
+
 def test_simple():
     src = '''
     """ MOD DOC """


### PR DESCRIPTION
After the `compiler` to `ast` migration, overridden methods without a docstring were listed as "Undocumented" instead of inheriting the docstring of the method they override.