### PR TITLE
Fix warnings

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -11,15 +11,14 @@ from six import string_types
 
 
 def parseFile(path):
-    """Duplicate of L{compiler.parseFile} that uses L{MyTransformer}."""
-    f = open(path, "U")
-    src = f.read() + "\n"
-    f.close()
+    """Parse the contents of a Python source file."""
+    with open(path, 'rb') as f:
+        src = f.read() + b'\n'
     return parse(src)
 
 
 def parse(buf):
-    """Duplicate of L{compiler.parse} that uses L{MyTransformer}."""
+    """Parse the contents of a Unicode or bytes string."""
     return ast.parse(buf)
 
 

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import inspect
 import textwrap
 
 from pydoctor import astbuilder, model
@@ -42,42 +41,24 @@ def test_simple():
 
 
 def test_function_argspec():
-    # we don't compare the defaults part of the argspec directly any
-    # more because inspect.getargspec returns the actual objects that
-    # are the defaults where as the ast stuff always gives strings
-    # representing those objects
     src = textwrap.dedent('''
     def f(a, b=3, *c, **kw):
         pass
     ''')
     mod = fromText(src)
     docfunc, = mod.contents.values()
-    ns = {}
-    exec(src, ns)
-    realf = ns['f']
-    inspectargspec = inspect.getargspec(realf)
-    assert inspectargspec[:-1] == docfunc.argspec[:-1]
-    assert docfunc.argspec[-1] == ('3',)
+    assert docfunc.argspec == (['a', 'b'], 'c', 'kw', ('3',))
 
 
 @py2only
 def test_function_argspec_with_tuple():
-    # we don't compare the defaults part of the argspec directly any
-    # more because inspect.getargspec returns the actual objects that
-    # are the defaults where as the ast stuff always gives strings
-    # representing those objects
     src = textwrap.dedent('''
     def f((a,z), b=3, *c, **kw):
         pass
     ''')
     mod = fromText(src)
     docfunc, = mod.contents.values()
-    ns = {}
-    exec(src, ns)
-    realf = ns['f']
-    inspectargspec = inspect.getargspec(realf)
-    assert tuple(inspectargspec[:-1]) == tuple(docfunc.argspec[:-1])
-    assert docfunc.argspec[-1] == ('3',)
+    assert docfunc.argspec ==  ([['a', 'z'], 'b'], 'c', 'kw', ('3',))
 
 def test_class():
     src = '''

--- a/pydoctor/test/test_templatewriter.py
+++ b/pydoctor/test/test_templatewriter.py
@@ -78,7 +78,8 @@ def test_basic_package():
         for ob in system.allobjects.values():
             if ob.documentation_location is model.DocLocation.OWN_PAGE:
                 assert os.path.isfile(os.path.join(targetdir, ob.fullName() + '.html'))
-        assert 'Package docstring' in open(os.path.join(targetdir, 'basic.html')).read()
+        with open(os.path.join(targetdir, 'basic.html')) as f:
+            assert 'Package docstring' in f.read()
     finally:
         shutil.rmtree(targetdir)
 

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -119,10 +119,10 @@ def addInterfaceInfoToClass(cls, interfaceargs, implementsOnly):
             obj.implementedby_directly.append(cls)
 
 
-schema_prog = re.compile('zope\.schema\.([a-zA-Z_][a-zA-Z0-9_]*)')
+schema_prog = re.compile(r'zope\.schema\.([a-zA-Z_][a-zA-Z0-9_]*)')
 interface_prog = re.compile(
-    'zope\.schema\.interfaces\.([a-zA-Z_][a-zA-Z0-9_]*)'
-    '|zope\.interface\.Interface')
+    r'zope\.schema\.interfaces\.([a-zA-Z_][a-zA-Z0-9_]*)'
+    r'|zope\.interface\.Interface')
 
 def namesInterface(system, name):
     if interface_prog.match(name):
@@ -151,7 +151,7 @@ def extractStringLiteral(node):
 class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
 
     schema_like_patterns = [
-        ('zope\.interface\.Attribute', extractAttributeDescription),
+        (r'zope\.interface\.Attribute', extractAttributeDescription),
         ]
 
     def funcNameFromCall(self, node):


### PR DESCRIPTION
This fixes four warnings that were shown when running `pytest -Wd` under Python 3.6.

There is one remaining warning, but that does not reside in pydoctor itsefl:
```
pydoctor/test/test_sphinx.py::TestIntersphinxCache::test_cache
  [...]/site-packages/cachecontrol/serialize.py:182: DeprecationWarning: encoding is deprecated, Use raw=False instead.
    cached = msgpack.loads(data, encoding="utf-8")
```
This [issue](https://github.com/ionrock/cachecontrol/issues/198) has been fixed in CacheControl already, but there hasn't been a release since the fix was integrated.
