### PR TITLE
Fix crash when @implementer argument is not a class

### DIFF
--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -237,6 +237,18 @@ def test_docsources_includes_baseinterface():
     method = mod.contents['Implementation'].contents['method']
     assert imethod in method.docsources(), list(method.docsources())
 
+def test_implementer_decoration_nonclass():
+    src = '''
+    from zope.interface import implementer
+    var = 0
+    @implementer(var)
+    class Implementation(object):
+        pass
+    '''
+    mod = fromText(src, systemcls=ZopeInterfaceSystem)
+    impl = mod.contents['Implementation']
+    assert impl.implements_directly == []
+
 def test_docsources_from_moduleprovides():
     src = '''
     from zope import interface

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -237,6 +237,22 @@ def test_docsources_includes_baseinterface():
     method = mod.contents['Implementation'].contents['method']
     assert imethod in method.docsources(), list(method.docsources())
 
+def test_implementer_decoration():
+    src = '''
+    from zope.interface import Interface, implementer
+    class IMyInterface(Interface):
+        def method(self):
+            """documentation"""
+    @implementer(IMyInterface)
+    class Implementation(object):
+        def method(self):
+            pass
+    '''
+    mod = fromText(src, systemcls=ZopeInterfaceSystem)
+    iface = mod.contents['IMyInterface']
+    impl = mod.contents['Implementation']
+    assert impl.implements_directly == [iface.fullName()]
+
 def test_implementer_decoration_nonclass():
     src = '''
     from zope.interface import implementer

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -77,14 +77,14 @@ class ZopeInterfaceFunction(model.Function):
                     if self.name in io2.contents:
                         yield io2.contents[self.name]
 
-def addInterfaceInfoToModule(module, interfaceargs):
+def addInterfaceInfoToScope(scope, interfaceargs):
     for arg in interfaceargs:
         if not isinstance(arg, tuple):
-            fullName = module.expandName(astor.to_source(arg).strip())
+            fullName = scope.expandName(astor.to_source(arg).strip())
         else:
             fullName = arg[1]
-        module.implements_directly.append(fullName)
-        obj = module.system.objForFullName(fullName)
+        scope.implements_directly.append(fullName)
+        obj = scope.system.objForFullName(fullName)
         if obj is not None:
             if not obj.isinterface:
                 obj.system.msg(
@@ -94,29 +94,16 @@ def addInterfaceInfoToModule(module, interfaceargs):
                 obj.isinterface = True
                 obj.kind = "Interface"
                 obj.implementedby_directly = []
-            obj.implementedby_directly.append(module)
+            obj.implementedby_directly.append(scope)
+
+def addInterfaceInfoToModule(module, interfaceargs):
+    addInterfaceInfoToScope(module, interfaceargs)
 
 def addInterfaceInfoToClass(cls, interfaceargs, implementsOnly):
     cls.implementsOnly = implementsOnly
     if implementsOnly:
         cls.implements_directly = []
-    for arg in interfaceargs:
-        if not isinstance(arg, tuple):
-            fullName = cls.expandName(astor.to_source(arg).strip())
-        else:
-            fullName = arg[1]
-        cls.implements_directly.append(fullName)
-        obj = cls.system.objForFullName(fullName)
-        if obj is not None:
-            if not obj.isinterface:
-                obj.system.msg(
-                    'zopeinterface',
-                    'probable interface %r not marked as such'%obj,
-                    thresh=1)
-                obj.isinterface = True
-                obj.kind = "Interface"
-                obj.implementedby_directly = []
-            obj.implementedby_directly.append(cls)
+    addInterfaceInfoToScope(cls, interfaceargs)
 
 
 schema_prog = re.compile(r'zope\.schema\.([a-zA-Z_][a-zA-Z0-9_]*)')

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -83,9 +83,9 @@ def addInterfaceInfoToScope(scope, interfaceargs):
             fullName = scope.expandName(astor.to_source(arg).strip())
         else:
             fullName = arg[1]
-        scope.implements_directly.append(fullName)
         obj = scope.system.objForFullName(fullName)
-        if obj is not None:
+        if isinstance(obj, ZopeInterfaceClass):
+            scope.implements_directly.append(fullName)
             if not obj.isinterface:
                 obj.system.msg(
                     'zopeinterface',
@@ -95,6 +95,10 @@ def addInterfaceInfoToScope(scope, interfaceargs):
                 obj.kind = "Interface"
                 obj.implementedby_directly = []
             obj.implementedby_directly.append(scope)
+        elif obj is not None:
+            obj.system.msg(
+                'zopeinterface',
+                'probable interface %r not detected as class'%obj)
 
 def addInterfaceInfoToModule(module, interfaceargs):
     addInterfaceInfoToScope(module, interfaceargs)


### PR DESCRIPTION
This crash happened while extracting API docs from Klein.
