### PR TITLE
Automatically gather type information

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -6,7 +6,7 @@ import ast
 from itertools import chain
 
 import astor
-from pydoctor import model
+from pydoctor import epydoc2stan, model
 from six import string_types
 
 
@@ -421,8 +421,6 @@ class ASTBuilder(object):
                 obj.parentMod = self.currentMod
         else:
             assert obj.parentMod is None
-        # Method-level import to avoid a circular dependency.
-        from pydoctor import epydoc2stan
         for attrobj in epydoc2stan.extract_fields(obj):
             self.system.addObject(attrobj)
 

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -266,8 +266,9 @@ class ModuleVistor(ast.NodeVisitor):
     def _handleModuleVar(self, target, lineno):
         obj = self.builder.current.resolveName(target)
         if obj is None:
-            obj = self.builder.addAttribute(target, None, 'Variable', lineno)
+            obj = self.builder.addAttribute(target, None, None, lineno)
         if isinstance(obj, model.Attribute):
+            obj.kind = 'Variable'
             self.newAttr = obj
 
     def _handleAssignmentInModule(self, target, expr, lineno):
@@ -277,7 +278,9 @@ class ModuleVistor(ast.NodeVisitor):
     def _handleClassVar(self, target, lineno):
         obj = self.builder.current.contents.get(target)
         if not isinstance(obj, model.Attribute):
-            obj = self.builder.addAttribute(target, None, 'Class Variable', lineno)
+            obj = self.builder.addAttribute(target, None, None, lineno)
+        if obj.kind is None:
+            obj.kind = 'Class Variable'
         self.newAttr = obj
 
     def _handleInstanceVar(self, target, lineno):
@@ -421,8 +424,7 @@ class ASTBuilder(object):
                 obj.parentMod = self.currentMod
         else:
             assert obj.parentMod is None
-        for attrobj in epydoc2stan.extract_fields(obj):
-            self.system.addObject(attrobj)
+        epydoc2stan.extract_fields(obj)
 
     def pop(self, obj):
         assert self.current is obj, "%r is not %r"%(self.current, obj)

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -424,7 +424,8 @@ class ASTBuilder(object):
                 obj.parentMod = self.currentMod
         else:
             assert obj.parentMod is None
-        epydoc2stan.extract_fields(obj)
+        if not isinstance(obj, model.Function):
+            epydoc2stan.extract_fields(obj)
 
     def pop(self, obj):
         assert self.current is obj, "%r is not %r"%(self.current, obj)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -559,11 +559,12 @@ def doc2stan(obj, summary=False):
             return ()
         stan = html2stan(crap)
         s = tags.div(stan)
-        fh = FieldHandler(obj)
-        for field in fields:
-            fh.handle(Field(field, obj))
-        fh.resolve_types()
-        s(fh.format())
+        if fields:
+            fh = FieldHandler(obj)
+            for field in fields:
+                fh.handle(Field(field, obj))
+            fh.resolve_types()
+            s(fh.format())
     return s
 
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -621,6 +621,10 @@ def extract_fields(obj):
         tag = field.tag()
         if tag in ['ivar', 'cvar', 'var', 'type']:
             arg = field.arg()
+            if arg is None:
+                obj.system.msg('epydoc2stan', '%s: Missing field name in @%s'
+                               % (obj.fullName(), tag))
+                continue
             attrobj = obj.contents.get(arg)
             if attrobj is None:
                 attrobj = obj.system.Attribute(obj.system, arg, None, obj)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -486,10 +486,7 @@ def reportErrors(obj, errs):
 def doc2stan(obj, summary=False):
     """Generate an HTML representation of a docstring"""
     if getattr(obj, 'parsed_docstring', None) is not None:
-        r = html2stan(obj.parsed_docstring.to_html(_EpydocLinker(obj)))
-        if getattr(obj, 'parsed_type', None) is not None:
-            r = [r, ' (type: ', html2stan(obj.parsed_type.to_html(_EpydocLinker(obj))), ')']
-        return r
+        return html2stan(obj.parsed_docstring.to_html(_EpydocLinker(obj)))
     doc, source = get_docstring(obj)
     if doc is None:
         text = "Undocumented"
@@ -569,6 +566,14 @@ def doc2stan(obj, summary=False):
             fh.resolve_types()
             s(fh.format())
     return s
+
+
+def type2stan(obj):
+    parsed_type = getattr(obj, 'parsed_type', None)
+    if parsed_type is None:
+        return None
+    else:
+        return html2stan(parsed_type.to_html(_EpydocLinker(obj)))
 
 
 field_name_to_human_name = {

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -447,6 +447,8 @@ class System(object):
                 yield o
 
     def privacyClass(self, ob):
+        if ob.kind is None:
+            return PrivacyClass.HIDDEN
         if ob.name.startswith('_') and \
                not (ob.name.startswith('__') and ob.name.endswith('__')):
             return PrivacyClass.PRIVATE

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -232,7 +232,8 @@ def unmasked_attrs(baselist):
     maybe_masking = set()
     for b in baselist[1:]:
         maybe_masking.update(set([o.name for o in b.orderedcontents]))
-    return [o for o in baselist[0].orderedcontents if o.name not in maybe_masking]
+    return [o for o in baselist[0].orderedcontents
+            if o.isVisible and o.name not in maybe_masking]
 
 
 def assembleList(system, label, lst, idbase):

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -51,7 +51,12 @@ def signature(argspec):
 
 class DocGetter(object):
     def get(self, ob, summary=False):
-        return epydoc2stan.doc2stan(ob, summary=summary)
+        doc = epydoc2stan.doc2stan(ob, summary=summary)
+        typ = epydoc2stan.type2stan(ob)
+        if typ is None:
+            return doc
+        else:
+            return [doc, ' (type: ', typ, ')']
 
 class CommonPage(Element):
 

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -548,3 +548,70 @@ def test_variable_scopes():
     m2 = C.contents['m']
     assert m2.kind == 'Class Variable'
     assert m2.docstring == """class-level m"""
+
+def test_variable_types():
+    mod = fromText('''
+    class C:
+        """class docstring
+
+        @cvar a: first
+        @type a: C{str}
+
+        @type b: C{str}
+        @cvar b: second
+
+        @type c: C{str}
+
+        @ivar d: fourth
+        @type d: C{str}
+
+        @type e: C{str}
+        @ivar e: fifth
+
+        @type f: C{str}
+        """
+
+        a = "A"
+
+        b = "B"
+
+        c = "C"
+        """third"""
+
+        def __init__(self):
+
+            self.d = "D"
+
+            self.e = "E"
+
+            self.f = "F"
+            """sixth"""
+    ''', modname='test')
+    C = mod.contents['C']
+    assert sorted(C.contents.keys()) == [
+        '__init__', 'a', 'b', 'c', 'd', 'e', 'f'
+        ]
+    a = C.contents['a']
+    assert unwrap(a.parsed_docstring) == """first"""
+    assert str(unwrap(a.parsed_type)) == '<code>str</code>'
+    assert a.kind == 'Class Variable'
+    b = C.contents['b']
+    assert unwrap(b.parsed_docstring) == """second"""
+    assert str(unwrap(b.parsed_type)) == '<code>str</code>'
+    assert b.kind == 'Class Variable'
+    c = C.contents['c']
+    assert c.docstring == """third"""
+    assert str(unwrap(c.parsed_type)) == '<code>str</code>'
+    assert c.kind == 'Class Variable'
+    d = C.contents['d']
+    assert unwrap(d.parsed_docstring) == """fourth"""
+    assert str(unwrap(d.parsed_type)) == '<code>str</code>'
+    assert d.kind == 'Instance Variable'
+    e = C.contents['e']
+    assert unwrap(e.parsed_docstring) == """fifth"""
+    assert str(unwrap(e.parsed_type)) == '<code>str</code>'
+    assert e.kind == 'Instance Variable'
+    f = C.contents['f']
+    assert f.docstring == """sixth"""
+    assert str(unwrap(f.parsed_type)) == '<code>str</code>'
+    assert f.kind == 'Instance Variable'

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -27,6 +27,15 @@ def fromText(text, modname='<test>', system=None,
     mod.state = model.ProcessingState.PROCESSED
     return mod
 
+def unwrap(parsed_docstring):
+    epytext = parsed_docstring._tree
+    assert epytext.tag == 'epytext'
+    assert len(epytext.children) == 1
+    para = epytext.children[0]
+    assert para.tag == 'para'
+    assert len(para.children) == 1
+    return para.children[0]
+
 def test_no_docstring():
     # Inheritance of the docstring of an overridden method depends on
     # methods with no docstring having None in their 'docstring' field.
@@ -353,8 +362,7 @@ def test_inline_docstring_modulevar():
     a = mod.contents['a']
     assert a.docstring == """inline doc for a"""
     b = mod.contents['b']
-    assert b.docstring is None
-    assert b.parsed_docstring is not None
+    assert unwrap(b.parsed_docstring) == """doc for b"""
     f = mod.contents['f']
     assert not f.docstring
 
@@ -533,7 +541,7 @@ def test_variable_scopes():
     assert a.docstring == """inline doc for a"""
     k = C.contents['k']
     assert k.kind == 'Instance Variable'
-    assert k.parsed_docstring is not None
+    assert unwrap(k.parsed_docstring) == """class level doc for k"""
     l2 = C.contents['l']
     assert l2.kind == 'Instance Variable'
     assert l2.docstring == """instance l"""

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import textwrap
 
 from pydoctor import astbuilder, model
+from pydoctor.epydoc2stan import get_parsed_type
 
 
 
@@ -615,3 +616,71 @@ def test_variable_types():
     assert f.docstring == """sixth"""
     assert str(unwrap(f.parsed_type)) == '<code>str</code>'
     assert f.kind == 'Instance Variable'
+
+@py3only
+def test_annotated_variables():
+    mod = fromText('''
+    class C:
+        """class docstring
+
+        @cvar a: first
+        @type a: string
+
+        @type b: string
+        @cvar b: second
+        """
+
+        a: str = "A"
+
+        b: str
+
+        c: str = "C"
+        """third"""
+
+        d: str
+        """fourth"""
+
+        e: List['C']
+        """fifth"""
+
+        f: 'List[C]'
+        """sixth"""
+
+        g: 'List["C"]'
+        """seventh"""
+
+        def __init__(self):
+            self.s: List[str] = []
+            """instance"""
+
+    m: bytes = b"M"
+    """module-level"""
+    ''', modname='test')
+    C = mod.contents['C']
+    a = C.contents['a']
+    assert unwrap(a.parsed_docstring) == """first"""
+    assert str(unwrap(get_parsed_type(a))) == 'string'
+    b = C.contents['b']
+    assert unwrap(b.parsed_docstring) == """second"""
+    assert str(unwrap(get_parsed_type(b))) == 'string'
+    c = C.contents['c']
+    assert c.docstring == """third"""
+    assert str(unwrap(get_parsed_type(c))) == '<code>str</code>'
+    d = C.contents['d']
+    assert d.docstring == """fourth"""
+    assert str(unwrap(get_parsed_type(d))) == '<code>str</code>'
+    e = C.contents['e']
+    assert e.docstring == """fifth"""
+    assert str(unwrap(get_parsed_type(e))) == '<code>List[C]</code>'
+    f = C.contents['f']
+    assert f.docstring == """sixth"""
+    assert str(unwrap(get_parsed_type(f))) == '<code>List[C]</code>'
+    g = C.contents['g']
+    assert g.docstring == """seventh"""
+    assert str(unwrap(get_parsed_type(g))) == '<code>List[C]</code>'
+    s = C.contents['s']
+    assert s.docstring == """instance"""
+    assert str(unwrap(get_parsed_type(s))) == '<code>List[str]</code>'
+    m = mod.contents['m']
+    assert m.docstring == """module-level"""
+    assert str(unwrap(get_parsed_type(m))) == '<code>bytes</code>'

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -740,3 +740,19 @@ def test_inferred_variable_types():
     # On Python 2.7, bytes literals are parsed into ast.Str objects,
     # so there is no way to tell them apart from ASCII strings.
     assert type2str(mod.contents['m'].annotation) in ('bytes', 'str')
+
+def test_type_from_attrib():
+    mod = fromText('''
+    import attr
+    from attr import attrib
+    class C:
+        a = attr.ib(type=int)
+        b = attrib(type=int)
+        c = attr.ib(type='C')
+        d = attr.ib(default=True)
+    ''', modname='test')
+    C = mod.contents['C']
+    assert type2str(C.contents['a'].annotation) == 'int'
+    assert type2str(C.contents['b'].annotation) == 'int'
+    assert type2str(C.contents['c'].annotation) == 'C'
+    assert type2str(C.contents['d'].annotation) == 'bool'

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -28,11 +28,17 @@ def test_multiple_types():
         @type a: a pink thing!
         @type a: no, blue! aaaargh!
         """
+    class E(object):
+        """
+        @cvar: missing name
+        @type: name still missing
+        """
     ''')
     # basically "assert not fail":
     epydoc2stan.doc2stan(mod.contents['f'])
     epydoc2stan.doc2stan(mod.contents['C'])
     epydoc2stan.doc2stan(mod.contents['D'])
+    epydoc2stan.doc2stan(mod.contents['E'])
 
 def test_summary():
     mod = fromText('''

--- a/pydoctor/test/test_templatewriter.py
+++ b/pydoctor/test/test_templatewriter.py
@@ -91,6 +91,16 @@ def test_hasdocstring():
     sub_f = system.allobjects['basic.mod.D.f']
     assert hasdocstring(sub_f) and not sub_f.docstring
 
+def test_missing_variable():
+    mod = fromText('''
+    """Module docstring.
+
+    @type thisVariableDoesNotExist: Type for non-existent variable.
+    """
+    ''')
+    html = getHTMLOf(mod)
+    assert 'thisVariableDoesNotExist' not in html
+
 
 @pytest.mark.parametrize(
     'className',

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -156,8 +156,9 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             return None
         return self.builder.current.expandName(name)
 
-    def _handleAssignmentInModule(self, target, expr, lineno):
-        super(ZopeInterfaceModuleVisitor, self)._handleAssignmentInModule(target, expr, lineno)
+    def _handleAssignmentInModule(self, target, annotation, expr, lineno):
+        super(ZopeInterfaceModuleVisitor, self)._handleAssignmentInModule(
+                target, annotation, expr, lineno)
 
         if not isinstance(expr, ast.Call):
             return
@@ -173,8 +174,9 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             interface.linenumber = lineno
             self.builder.popClass()
 
-    def _handleAssignmentInClass(self, target, expr, lineno):
-        super(ZopeInterfaceModuleVisitor, self)._handleAssignmentInClass(target, expr, lineno)
+    def _handleAssignmentInClass(self, target, annotation, expr, lineno):
+        super(ZopeInterfaceModuleVisitor, self)._handleAssignmentInClass(
+                target, annotation, expr, lineno)
 
         def handleSchemaField():
             descriptions = [arg.value for arg in expr.keywords if arg.arg == 'description']


### PR DESCRIPTION
If no `@type` field exists in the docstring, pydoctor will now try to take type information from the following sources:

- type annotations
- `attr.ib` definitions
- inferred from default values

See #136 and #135.

There are still things that could be improved:

- link extracted type names to their documentation
- the presentation of type information in the HTML
- infer type of instance variables from init/setter arguments
- support for `enum.Enum`

But I'd like to address those some other time in separate PRs.
