### PR TITLE
Fix Sphinx inventory loading

### DIFF
--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -157,7 +157,7 @@ class SphinxInventory(object):
                 'Failed to uncompress inventory from %s' % (base_url,))
             return ''
         try:
-            return decompressed.decode()
+            return decompressed.decode('utf-8')
         except UnicodeError:
             self.error(
                 'sphinx',

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -150,11 +150,18 @@ class SphinxInventory(object):
                 break
             data = parts[1]
         try:
-            return zlib.decompress(payload).decode()
-        except:
+            decompressed = zlib.decompress(payload)
+        except zlib.error:
             self.error(
                 'sphinx',
                 'Failed to uncompress inventory from %s' % (base_url,))
+            return ''
+        try:
+            return decompressed.decode()
+        except UnicodeError:
+            self.error(
+                'sphinx',
+                'Failed to decode inventory from %s' % (base_url,))
             return ''
 
     def _parseInventory(self, base_url, payload):

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -59,7 +59,7 @@ class SphinxInventory(object):
 # Project: %s
 # Version: %s
 # The rest of this file is compressed with zlib.
-""" % (self.project_name, '.'.join(version))).encode()
+""" % (self.project_name, '.'.join(version))).encode('utf-8')
 
     def _generateContent(self, subjects):
         """
@@ -69,7 +69,7 @@ class SphinxInventory(object):
         for obj in subjects:
             if not obj.isVisible:
                 continue
-            content.append(self._generateLine(obj).encode())
+            content.append(self._generateLine(obj).encode('utf-8'))
             content.append(self._generateContent(obj.orderedcontents))
 
         return b''.join(content)

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -252,7 +252,7 @@ def test_getPayload_content():
     assert payload == result
 
 
-def test_getPayload_invalid():
+def test_getPayload_invalid_uncompress():
     """
     Return empty string and log an error when failing to uncompress data.
     """
@@ -267,6 +267,25 @@ not-valid-zlib-content"""
     assert '' == result
     assert [(
         'sphinx', 'Failed to uncompress inventory from http://tm.tld', -1,
+        )] == log
+
+
+def test_getPayload_invalid_decode():
+    """
+    Return empty string and log an error when failing to uncompress data.
+    """
+    payload = b'\x80'
+    sut, log = make_SphinxInventoryWithLog()
+    base_url = 'http://tm.tld'
+    content = b"""# Project: some-name
+# Version: 2.0
+%s""" % (zlib.compress(payload),)
+
+    result = sut._getPayload(base_url, content)
+
+    assert '' == result
+    assert [(
+        'sphinx', 'Failed to decode inventory from http://tm.tld', -1,
         )] == log
 
 

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -630,7 +630,7 @@ class TestStubCache(object):
     clearCache=st.booleans(),
     enableCache=st.booleans(),
     cacheDirectoryName=st.text(
-        alphabet=sorted(set(string.printable) - set('\/:*?"<>|\x0c\x0b\n')),
+        alphabet=sorted(set(string.printable) - set('\\/:*?"<>|\x0c\x0b\n')),
         min_size=3,             # Avoid ..
         max_size=32,            # Avoid upper length on path
     ),

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -239,13 +239,13 @@ def test_getPayload_content():
     """
     Return content as string.
     """
-    payload = 'first_line\nsecond line'
+    payload = u"first_line\nsecond line\nit's a snake: \U0001F40D"
     sut = make_SphinxInventory()
     content = b"""# Ignored line
 # Project: some-name
 # Version: 2.0
 # commented line.
-%s""" % (zlib.compress(payload.encode()),)
+%s""" % (zlib.compress(payload.encode('utf-8')),)
 
     result = sut._getPayload('http://base.ignore', content)
 


### PR DESCRIPTION
This PR fixes the following errors from the Twisted API docs build:
```
Failed to uncompress inventory from https://docs.python.org/2
Failed to uncompress inventory from https://docs.python.org/3
Failed to uncompress inventory from https://pyopenssl.readthedocs.io/en/stable
Failed to uncompress inventory from https://zopeinterface.readthedocs.io/en/latest
```
The first commit improves the error reporting, the second commit fixes the actual bug.
