### PR TITLE
Remove project base directory auto-detection

### DIFF
--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -239,7 +239,11 @@ def main(args):
         system = systemclass(options)
         system.fetchIntersphinxInventories(cache)
 
-        system.sourcebase = options.htmlsourcebase
+        if options.htmlsourcebase:
+            if options.projectbasedirectory is None:
+                error("you must specify --project-base-dir "
+                      "when using --html-viewsource-base")
+            system.sourcebase = options.htmlsourcebase
 
         if options.abbrevmapping:
             for thing in options.abbrevmapping.split(','):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -11,7 +11,6 @@ from __future__ import print_function, unicode_literals
 import datetime
 import imp
 import os
-import posixpath
 import sys
 import types
 from enum import Enum
@@ -447,27 +446,11 @@ class System(object):
     def setSourceHref(self, mod):
         if self.sourcebase is None:
             mod.sourceHref = None
-            return
-
-        projBaseDir = mod.system.options.projectbasedirectory
-        if projBaseDir is not None:
+        else:
+            projBaseDir = mod.system.options.projectbasedirectory
             mod.sourceHref = (
                 self.sourcebase +
                 mod.filepath[len(projBaseDir):])
-            return
-
-        trailing = []
-        dir, fname = os.path.split(mod.filepath)
-        while os.path.exists(os.path.join(dir, '.svn')):
-            dir, dirname = os.path.split(dir)
-            trailing.append(dirname)
-
-        # now trailing[-1] would be 'Divmod' in the above example
-        del trailing[-1]
-        trailing.reverse()
-        trailing.append(fname)
-
-        mod.sourceHref = posixpath.join(mod.system.sourcebase, *trailing)
 
     def addModule(self, modpath, modname, parentPackage=None):
         mod = self.Module(self, modname, None, parentPackage)


### PR DESCRIPTION
The auto-detection only worked when using Subversion, since it looked for `.svn` directories and crashed if it didn't find any.

This PR removes the broken auto-detection by making it mandatory to pass `--project-base-dir` when using `--html-viewsource-base`.

Fixes #179