### PR TITLE
Make coloring of variable entries in tables more consistent

### DIFF
--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -113,11 +113,11 @@ tr.module {
     background-color: #fff8e1;
 }
 
-tr.class {
+tr.class, tr.classvariable, tr.baseclassvariable {
     background-color: #fffde7;
 }
 
-tr.instancevariable, tr.variable, tr.baseclassvariable, tr.attribute {
+tr.instancevariable, tr.baseinstancevariable, tr.variable, tr.attribute {
     background-color: #f3e5f5;
 }
 


### PR DESCRIPTION
Inherited instance variables are now colored the same as non-inherited
ones. It is still easy to tell them apart as they are in separate
tables.

Class variables are now colored the same as classes themselves. Again
there is no risk of confusion as they are on separate pages.