### PR TITLE
Provide source links for attributes

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -325,12 +325,13 @@ class ModuleVistor(ast.NodeVisitor):
                 self._handleInstanceVar(targetNode.attr, annotation, lineno)
 
     def visit_Assign(self, node):
-        if len(node.targets) == 1:
-            expr = node.value
-            annotation = _annotation_from_attrib(expr, self.builder.current)
-            if annotation is None:
-                annotation = _infer_type(expr)
-            self._handleAssignment(node.targets[0], annotation, expr, node.lineno)
+        lineno = node.lineno
+        expr = node.value
+        annotation = _annotation_from_attrib(expr, self.builder.current)
+        if annotation is None:
+            annotation = _infer_type(expr)
+        for target in node.targets:
+            self._handleAssignment(target, annotation, expr, lineno)
 
     def visit_AnnAssign(self, node):
         annotation = _unstring_annotation(node.annotation)

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -259,6 +259,8 @@ class ModuleVistor(ast.NodeVisitor):
         return False
 
     def _handleAliasing(self, target, expr):
+        if target in self.builder.current.contents:
+            return False
         ctx = self.builder.current
         full_name = node2fullname(expr, ctx)
         if full_name is None:

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -69,7 +69,7 @@ class ModuleVistor(ast.NodeVisitor):
 
         if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
             self.module.docstring = node.body[0].value.s
-        self.builder.push(self.module)
+        self.builder.push(self.module, 0)
         self.default(node)
         self.builder.pop(self.module)
 
@@ -500,15 +500,14 @@ class ASTBuilder(object):
     def _push(self, cls, name, docstring, lineno):
         obj = cls(self.system, name, docstring, self.current)
         self.system.addObject(obj)
-        self.push(obj)
-        obj.setLineNumber(lineno)
+        self.push(obj, lineno)
         return obj
 
     def _pop(self, cls):
         assert isinstance(self.current, cls)
         self.pop(self.current)
 
-    def push(self, obj):
+    def push(self, obj, lineno):
         self._stack.append(self.current)
         self.current = obj
         if isinstance(obj, model.Module):
@@ -521,6 +520,8 @@ class ASTBuilder(object):
                 obj.parentMod = self.currentMod
         else:
             assert obj.parentMod is None
+        if lineno:
+            obj.setLineNumber(lineno)
         if not isinstance(obj, model.Function):
             epydoc2stan.extract_fields(obj)
 

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -269,10 +269,11 @@ class ModuleVistor(ast.NodeVisitor):
     def _handleModuleVar(self, target, annotation, lineno):
         obj = self.builder.current.resolveName(target)
         if obj is None:
-            obj = self.builder.addAttribute(target, None, None, lineno)
+            obj = self.builder.addAttribute(target, None, None)
         if isinstance(obj, model.Attribute):
             obj.kind = 'Variable'
             obj.annotation = annotation
+            obj.setLineNumber(lineno)
             self.newAttr = obj
 
     def _handleAssignmentInModule(self, target, annotation, expr, lineno):
@@ -282,10 +283,11 @@ class ModuleVistor(ast.NodeVisitor):
     def _handleClassVar(self, target, annotation, lineno):
         obj = self.builder.current.contents.get(target)
         if not isinstance(obj, model.Attribute):
-            obj = self.builder.addAttribute(target, None, None, lineno)
+            obj = self.builder.addAttribute(target, None, None)
         if obj.kind is None:
             obj.kind = 'Class Variable'
         obj.annotation = annotation
+        obj.setLineNumber(lineno)
         self.newAttr = obj
 
     def _handleInstanceVar(self, target, annotation, lineno):
@@ -297,10 +299,11 @@ class ModuleVistor(ast.NodeVisitor):
             return
         obj = cls.contents.get(target)
         if obj is None:
-            obj = self.builder.addAttribute(target, None, None, lineno, cls)
+            obj = self.builder.addAttribute(target, None, None, cls)
         if isinstance(obj, model.Attribute):
             obj.kind = 'Instance Variable'
             obj.annotation = annotation
+            obj.setLineNumber(lineno)
             self.newAttr = obj
 
     def _handleAssignmentInClass(self, target, annotation, expr, lineno):
@@ -528,7 +531,7 @@ class ASTBuilder(object):
     def popFunction(self):
         self._pop(self.system.Function)
 
-    def addAttribute(self, target, docstring, kind, lineno, parent=None):
+    def addAttribute(self, target, docstring, kind, parent=None):
         if parent is None:
             parent = self.current
         system = self.system
@@ -536,7 +539,6 @@ class ASTBuilder(object):
         attr = system.Attribute(system, target, docstring, parent)
         attr.kind = kind
         attr.parentMod = parentMod
-        attr.setLineNumber(lineno)
         system.addObject(attr)
         return attr
 

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -487,16 +487,9 @@ class ASTBuilder(object):
 
     def _push(self, cls, name, docstring, lineno):
         obj = cls(self.system, name, docstring, self.current)
-        obj.linenumber = lineno
         self.system.addObject(obj)
         self.push(obj)
-
-        parentMod = obj.parentMod
-        if parentMod is not None:
-            sourceHref = parentMod.sourceHref
-            if sourceHref is not None:
-                obj.sourceHref = sourceHref + '#L' + str(lineno)
-
+        obj.setLineNumber(lineno)
         return obj
 
     def _pop(self, cls):
@@ -543,9 +536,7 @@ class ASTBuilder(object):
         attr = system.Attribute(system, target, docstring, parent)
         attr.kind = kind
         attr.parentMod = parentMod
-        attr.linenumber = lineno
-        if parentMod.sourceHref:
-            attr.sourceHref = '%s#L%d' % (parentMod.sourceHref, lineno)
+        attr.setLineNumber(lineno)
         system.addObject(attr)
         return attr
 

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -331,7 +331,13 @@ class ModuleVistor(ast.NodeVisitor):
         if annotation is None:
             annotation = _infer_type(expr)
         for target in node.targets:
-            self._handleAssignment(target, annotation, expr, lineno)
+            if isinstance(target, ast.Tuple):
+                for elem in target.elts:
+                    # Note: We skip type and aliasing analysis for this case,
+                    #       but we do record line numbers.
+                    self._handleAssignment(elem, None, None, lineno)
+            else:
+                self._handleAssignment(target, annotation, expr, lineno)
 
     def visit_AnnAssign(self, node):
         annotation = _unstring_annotation(node.annotation)

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -143,11 +143,12 @@ class Field:
     Tags are automatically downcased and stripped; and arguments are
     automatically stripped.
     """
-    def __init__(self, tag, arg, body):
+    def __init__(self, tag, arg, body, lineno):
         self._tag = tag.lower().strip()
         if arg is None: self._arg = None
         else: self._arg = arg.strip()
         self._body = body
+        self.lineno = lineno
 
     def tag(self):
         """

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -484,7 +484,7 @@ def _add_list(doc, bullet_token, stack, indent_stack, errors):
     # are adjoined directly into the 'epytext' node, not into
     # the 'fieldlist' node.
     if list_type == 'fieldlist':
-        li = Element('field')
+        li = Element('field', lineno=str(bullet_token.startline))
         token_words = bullet_token.contents[1:-1].split(None, 1)
         tag_elt = Element('tag')
         tag_elt.children.append(token_words[0])
@@ -1239,7 +1239,9 @@ def parse_docstring(docstring, errors):
 
             # Process the field.
             field.tag = 'epytext'
-            fields.append(Field(tag, arg, ParsedEpytextDocstring(field, ())))
+            fieldDoc = ParsedEpytextDocstring(field, ())
+            lineno = int(field.attribs['lineno'])
+            fields.append(Field(tag, arg, fieldDoc, lineno))
 
     # Save the remaining docstring as the description.
     if tree.children and tree.children[0].children:

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -251,17 +251,18 @@ class _SplitFieldsTranslator(NodeVisitor):
                         # Use a @newfield to let it be displayed as-is.
                         if tagname.lower() not in self._newfields:
                             newfield = Field('newfield', tagname.lower(),
-                                             ParsedPlaintextDocstring(tagname))
+                                             ParsedPlaintextDocstring(tagname),
+                                             node.line - 1)
                             self.fields.append(newfield)
                             self._newfields.add(tagname.lower())
 
-        self._add_field(tagname, arg, fbody)
+        self._add_field(tagname, arg, fbody, node.line)
 
-    def _add_field(self, tagname, arg, fbody):
+    def _add_field(self, tagname, arg, fbody, lineno):
         field_doc = self.document.copy()
         for child in fbody: field_doc.append(child)
         field_pdoc = ParsedRstDocstring(field_doc, ())
-        self.fields.append(Field(tagname, arg, field_pdoc))
+        self.fields.append(Field(tagname, arg, field_pdoc, lineno - 1))
 
     def visit_field_list(self, node):
         # Remove the field list from the tree.  The visitor will still walk
@@ -334,7 +335,7 @@ class _SplitFieldsTranslator(NodeVisitor):
                         )
 
             # Wrap the field body, and add a new field
-            self._add_field(tagname, arg, fbody)
+            self._add_field(tagname, arg, fbody, fbody[0].line)
 
     def handle_consolidated_definition_list(self, items, tagname):
         # Check the list contents.
@@ -362,12 +363,13 @@ class _SplitFieldsTranslator(NodeVisitor):
         for item in items:
             # The basic field.
             arg = item[0][0].astext()
+            lineno = item[0].line
             fbody = item[-1]
-            self._add_field(tagname, arg, fbody)
+            self._add_field(tagname, arg, fbody, lineno)
             # If there's a classifier, treat it as a type.
             if len(item) == 3:
                 type_descr = item[1]
-                self._add_field('type', arg, type_descr)
+                self._add_field('type', arg, type_descr, lineno)
 
     def unknown_visit(self, node):
         'Ignore all unknown nodes'

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -623,6 +623,7 @@ def extract_fields(obj):
             if attrobj is None:
                 attrobj = obj.system.Attribute(obj.system, arg, None, obj)
                 attrobj.kind = None
+                attrobj.parentMod = obj.parentMod
                 obj.system.addObject(attrobj)
             if tag == 'type':
                 attrobj.parsed_type = field.body()

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -274,14 +274,15 @@ class Field(object):
     def __init__(self, field, obj):
         self.tag = field.tag()
         self.arg = field.arg()
+        self.lineno = field.lineno
         self.body = field.body().to_stan(_EpydocLinker(obj))
 
     def __repr__(self):
         r = repr(self.body)
         if len(r) > 25:
             r = r[:20] + '...' + r[-2:]
-        return "<%s %r %r %s>"%(self.__class__.__name__,
-                             self.tag, self.arg, r)
+        return "<%s %r %r %s %d>"%(self.__class__.__name__,
+                             self.tag, self.arg, self.lineno, r)
 
 class FieldHandler(object):
     def __init__(self, obj):
@@ -625,6 +626,14 @@ def extract_fields(obj):
                 attrobj.kind = None
                 attrobj.parentMod = obj.parentMod
                 obj.system.addObject(attrobj)
+            # Note: This is only an approximation of the line number: it is
+            #       correct assuming the docstring starts on the first line
+            #       of the class/function and does not contain explicit
+            #       newlines ('\n') or joined lines ('\' at end of line).
+            #       The AST (as of Python 3.7) does not contain sufficient
+            #       detail to match a position within the docstring to an
+            #       exact position in the source.
+            attrobj.setLineNumber(obj.linenumber + 1 + field.lineno)
             if tag == 'type':
                 attrobj.parsed_type = field.body()
             else:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -55,6 +55,7 @@ class Documentable(object):
     @ivar kind: ...
     """
     documentation_location = DocLocation.OWN_PAGE
+    linenumber = 0
     sourceHref = None
 
     @property
@@ -77,6 +78,15 @@ class Documentable(object):
 
     def setup(self):
         self.contents = OrderedDict()
+
+    def setLineNumber(self, lineno):
+        if not self.linenumber:
+            self.linenumber = lineno
+            parentMod = self.parentMod
+            if parentMod is not None:
+                parentSourceHref = parentMod.sourceHref
+                if parentSourceHref:
+                    self.sourceHref = '%s#L%d' % (parentSourceHref, lineno)
 
     def fullName(self):
         parent = self.parent
@@ -220,7 +230,7 @@ class CanContainImportsDocumentable(Documentable):
 class Module(CanContainImportsDocumentable):
     kind = "Module"
     state = ProcessingState.UNPROCESSED
-    linenumber = 0
+
     def setup(self):
         super(Module, self).setup()
         self.all = None
@@ -264,7 +274,6 @@ class Class(CanContainImportsDocumentable):
 
 class Inheritable(Documentable):
     documentation_location = DocLocation.PARENT_PAGE
-    linenumber = 0
 
     def docsources(self):
         yield self

--- a/pydoctor/templates/attribute-child.html
+++ b/pydoctor/templates/attribute-child.html
@@ -8,6 +8,10 @@
   </a>
   <div class="functionHeader">
     <t:transparent t:render="attribute">attribute</t:transparent> =
+    <a class="functionSourceLink" t:render="sourceLink">
+      <t:attr name="href"><t:slot name="sourceHref" /></t:attr>
+      (source)
+    </a>
   </div>
   <div class="functionBody">
     <t:transparent t:render="functionExtras" />

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -33,6 +33,13 @@ class AttributeChild(Element):
         return self.ob.name
 
     @renderer
+    def sourceLink(self, request, tag):
+        if self.ob.sourceHref:
+            return tag.fillSlots(sourceHref=self.ob.sourceHref)
+        else:
+            return ()
+
+    @renderer
     def functionExtras(self, request, tag):
         return self._functionExtras
 

--- a/pydoctor/test/epydoc/epytext.doctest
+++ b/pydoctor/test/epydoc/epytext.doctest
@@ -34,14 +34,14 @@ Make sure that unindented fields are allowed:
     ...
     ...     @foo: This is a field."""))
     <para>This is a paragraph.</para>
-    <fieldlist><field><tag>foo</tag>
+    <fieldlist><field lineno='3'><tag>foo</tag>
     <para inline=True>This is a field.</para></field></fieldlist>
 
     >>> print(testparse("""
     ...     This is a paragraph.
     ...     @foo: This is a field."""))
     <para>This is a paragraph.</para>
-    <fieldlist><field><tag>foo</tag>
+    <fieldlist><field lineno='2'><tag>foo</tag>
     <para inline=True>This is a field.</para></field></fieldlist>
 
     >>> print(testparse("""
@@ -49,23 +49,23 @@ Make sure that unindented fields are allowed:
     ...       @foo: This is a field.
     ...         Hello."""))
     <para>This is a paragraph.</para>
-    <fieldlist><field><tag>foo</tag>
+    <fieldlist><field lineno='2'><tag>foo</tag>
     <para inline=True>This is a field. Hello.</para></field>
     </fieldlist>
 
     >>> print(testparse("""Paragraph\n@foo: field"""))
     <para>Paragraph</para>
-    <fieldlist><field><tag>foo</tag>
+    <fieldlist><field lineno='1'><tag>foo</tag>
     <para inline=True>field</para></field></fieldlist>
 
     >>> print(testparse("""Paragraph\n\n@foo: field"""))
     <para>Paragraph</para>
-    <fieldlist><field><tag>foo</tag>
+    <fieldlist><field lineno='2'><tag>foo</tag>
     <para inline=True>field</para></field></fieldlist>
 
     >>> print(testparse("""\nParagraph\n@foo: field"""))
     <para>Paragraph</para>
-    <fieldlist><field><tag>foo</tag>
+    <fieldlist><field lineno='2'><tag>foo</tag>
     <para inline=True>field</para></field></fieldlist>
 
 Make sure thta unindented lists are not allowed:

--- a/pydoctor/test/epydoc/restructuredtext.doctest
+++ b/pydoctor/test/epydoc/restructuredtext.doctest
@@ -53,6 +53,25 @@ A test function
 except "KeyError": if the key is not found
 except "ValueError": if the value is bad
 
+>>> parse_and_print(
+... """
+... Return the maximum speed for a fox.
+...
+... :Parameters:
+...   size
+...     The size of the fox (in meters)
+...   weight : float
+...     The weight of the fox (in stones)
+...   age : int
+...     The age of the fox (in years)
+... """)
+Return the maximum speed for a fox.
+param "size": The size of the fox (in meters)
+param "weight": The weight of the fox (in stones)
+type "weight": float
+param "age": The age of the fox (in years)
+type "age": int
+
 Python code
 ===========
 reStructuredText markup defines a ``python`` directive to represent a block

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -772,3 +772,9 @@ def test_type_from_attrib():
     assert type2str(C.contents['b'].annotation) == 'int'
     assert type2str(C.contents['c'].annotation) == 'C'
     assert type2str(C.contents['d'].annotation) == 'bool'
+
+def test_detupling_assignment():
+    mod = fromText('''
+    a, b, c = range(3)
+    ''', modname='test')
+    assert sorted(mod.contents.keys()) == ['a', 'b', 'c']

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -251,6 +251,28 @@ def test_aliasing_recursion():
     mod = fromText(src, 'mod', system)
     assert mod.contents['D'].bases == ['mod.C'], mod.contents['D'].bases
 
+def test_documented_no_alias():
+    """A variable that is documented should not be considered an alias."""
+    # TODO: We should also verify this for inline docstrings, but the code
+    #       currently doesn't support that. We should perhaps store aliases
+    #       as Documentables as well, so we can change their 'kind' when
+    #       an inline docstring follows the assignment.
+    mod = fromText('''
+    class SimpleClient:
+        pass
+    class Processor:
+        """
+        @ivar clientFactory: Callable that returns a client.
+        """
+        clientFactory = SimpleClient
+    ''')
+    P = mod.contents['Processor']
+    f = P.contents['clientFactory']
+    assert unwrap(f.parsed_docstring) == """Callable that returns a client."""
+    assert f.privacyClass is model.PrivacyClass.VISIBLE
+    assert f.kind == 'Instance Variable'
+    assert f.linenumber
+
 def test_subclasses():
     src = '''
     class A:

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -582,6 +582,8 @@ def test_variable_types():
         @ivar e: fifth
 
         @type f: string
+
+        @type g: string
         """
 
         a = "A"
@@ -599,10 +601,13 @@ def test_variable_types():
 
             self.f = "F"
             """sixth"""
+
+            self.g = g = "G"
+            """seventh"""
     ''', modname='test')
     C = mod.contents['C']
     assert sorted(C.contents.keys()) == [
-        '__init__', 'a', 'b', 'c', 'd', 'e', 'f'
+        '__init__', 'a', 'b', 'c', 'd', 'e', 'f', 'g'
         ]
     a = C.contents['a']
     assert unwrap(a.parsed_docstring) == """first"""
@@ -628,6 +633,10 @@ def test_variable_types():
     assert f.docstring == """sixth"""
     assert str(unwrap(f.parsed_type)) == 'string'
     assert f.kind == 'Instance Variable'
+    g = C.contents['g']
+    assert g.docstring == """seventh"""
+    assert str(unwrap(g.parsed_type)) == 'string'
+    assert g.kind == 'Instance Variable'
 
 @py3only
 def test_annotated_variables():
@@ -715,6 +724,7 @@ def test_inferred_variable_types():
         y = [n for n in range(10) if n % 2]
         def __init__(self):
             self.s = ['S']
+            self.t = t = 'T'
     m = b'octets'
     ''', modname='test')
     C = mod.contents['C']
@@ -741,6 +751,8 @@ def test_inferred_variable_types():
     # Type inference isn't different for module and instance variables,
     # so we don't need to re-test everything.
     assert type2str(C.contents['s'].annotation) == 'List[str]'
+    # Check that type is inferred on assignments with multiple targets.
+    assert type2str(C.contents['t'].annotation) == 'str'
     # On Python 2.7, bytes literals are parsed into ast.Str objects,
     # so there is no way to tell them apart from ASCII strings.
     assert type2str(mod.contents['m'].annotation) in ('bytes', 'str')

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -173,7 +173,6 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             self.builder.system.msg('parsing', 'new interface')
             interface.isinterface = True
             interface.implementedby_directly = []
-            interface.linenumber = lineno
             self.builder.popClass()
 
     def _handleAssignmentInClass(self, target, annotation, expr, lineno):


### PR DESCRIPTION
For classes and functions pydoctor could already link to their location in a source viewer, but for attributes/variables this was not implemented yet.