### PR TITLE
Add inheritance of attribute docstrings

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -540,7 +540,7 @@ class ASTBuilder(object):
             parent = self.current
         system = self.system
         parentMod = self.currentMod
-        attr = model.Attribute(system, target, docstring, parent)
+        attr = system.Attribute(system, target, docstring, parent)
         attr.kind = kind
         attr.parentMod = parentMod
         attr.linenumber = lineno

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -262,14 +262,10 @@ class Class(CanContainImportsDocumentable):
             return self.parent._localNameToFullName(name)
 
 
-class Function(Documentable):
+class Inheritable(Documentable):
     documentation_location = DocLocation.PARENT_PAGE
-    kind = "Function"
     linenumber = 0
-    def setup(self):
-        super(Function, self).setup()
-        if isinstance(self.parent, Class):
-            self.kind = "Method"
+
     def docsources(self):
         yield self
         if not isinstance(self.parent, Class):
@@ -277,17 +273,21 @@ class Function(Documentable):
         for b in self.parent.allbases(include_self=False):
             if self.name in b.contents:
                 yield b.contents[self.name]
+
     def _localNameToFullName(self, name):
         return self.parent._localNameToFullName(name)
 
-class Attribute(Documentable):
+class Function(Inheritable):
+    kind = "Function"
 
-    linenumber = 0
+    def setup(self):
+        super(Function, self).setup()
+        if isinstance(self.parent, Class):
+            self.kind = "Method"
+
+class Attribute(Inheritable):
     kind = "Attribute"
-    documentation_location = DocLocation.PARENT_PAGE
 
-    def _localNameToFullName(self, name):
-        return self.parent._localNameToFullName(name)
 
 class PrivacyClass(Enum):
     """L{Enum} containing values indicating how private an object should be.

--- a/pydoctor/templates/attribute-child.html
+++ b/pydoctor/templates/attribute-child.html
@@ -10,6 +10,7 @@
     <t:transparent t:render="attribute">attribute</t:transparent> =
   </div>
   <div class="functionBody">
+    <t:transparent t:render="functionExtras" />
     <t:transparent t:render="functionBody">
       Docstring.
     </t:transparent>

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -163,7 +163,7 @@ class CommonPage(Element):
             if isinstance(c, model.Function):
                 r.append(FunctionChild(self.docgetter, c, self.functionExtras(c)))
             else:
-                r.append(AttributeChild(self.docgetter, c))
+                r.append(AttributeChild(self.docgetter, c, self.functionExtras(c)))
         return r
 
     def functionExtras(self, data):

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -8,9 +8,10 @@ class AttributeChild(Element):
 
     loader = XMLFile(util.templatefilepath('attribute-child.html'))
 
-    def __init__(self, docgetter, ob):
+    def __init__(self, docgetter, ob, functionExtras):
         self.docgetter = docgetter
         self.ob = ob
+        self._functionExtras = functionExtras
 
     @renderer
     def class_(self, request, tag):
@@ -30,6 +31,10 @@ class AttributeChild(Element):
     @renderer
     def attribute(self, request, tag):
         return self.ob.name
+
+    @renderer
+    def functionExtras(self, request, tag):
+        return self._functionExtras
 
     @renderer
     def functionBody(self, request, tag):

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -7,6 +7,7 @@ import zlib
 
 from pydoctor import model, sphinx
 from pydoctor.driver import parse_args
+from pydoctor.test.test_astbuilder import fromText
 
 
 class FakeOptions(object):
@@ -122,3 +123,17 @@ def test_fetchIntersphinxInventories_content():
         'file:///twisted/tm.html' ==
         sut.intersphinx.getLink('twisted.package')
         )
+
+
+def test_docsources_class_attribute():
+    src = '''
+    class Base:
+        attr = False
+        """documentation"""
+    class Sub(Base):
+        attr = True
+    '''
+    mod = fromText(src)
+    base_attr = mod.contents['Base'].contents['attr']
+    sub_attr = mod.contents['Sub'].contents['attr']
+    assert base_attr in list(sub_attr.docsources())

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -237,6 +237,20 @@ def test_docsources_includes_baseinterface():
     method = mod.contents['Implementation'].contents['method']
     assert imethod in method.docsources(), list(method.docsources())
 
+def test_docsources_interface_attribute():
+    src = '''
+    from zope import interface
+    class IInterface(interface.Interface):
+        attr = interface.Attribute("""documentation""")
+    @interface.implementer(IInterface)
+    class Implementation:
+        attr = True
+    '''
+    mod = fromText(src, systemcls=ZopeInterfaceSystem)
+    iattr = mod.contents['IInterface'].contents['attr']
+    attr = mod.contents['Implementation'].contents['attr']
+    assert iattr in list(attr.docsources())
+
 def test_implementer_decoration():
     src = '''
     from zope.interface import Interface, implementer

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -64,18 +64,30 @@ class ZopeInterfaceClass(model.Class):
         return r
 
 
+def _inheritedDocsources(obj):
+    if not isinstance(obj.parent, (model.Class, model.Module)):
+        return
+    name = obj.name
+    for interface in obj.parent.allImplementedInterfaces:
+        io = obj.system.objForFullName(interface)
+        if io is not None:
+            for io2 in io.allbases(include_self=True):
+                if name in io2.contents:
+                    yield io2.contents[name]
+
 class ZopeInterfaceFunction(model.Function):
     def docsources(self):
         for source in super(ZopeInterfaceFunction, self).docsources():
             yield source
-        if not isinstance(self.parent, (model.Class, model.Module)):
-            return
-        for interface in self.parent.allImplementedInterfaces:
-            io = self.system.objForFullName(interface)
-            if io is not None:
-                for io2 in io.allbases(include_self=True):
-                    if self.name in io2.contents:
-                        yield io2.contents[self.name]
+        for source in _inheritedDocsources(self):
+            yield source
+
+class ZopeInterfaceAttribute(model.Attribute):
+    def docsources(self):
+        for source in super(ZopeInterfaceAttribute, self).docsources():
+            yield source
+        for source in _inheritedDocsources(self):
+            yield source
 
 def addInterfaceInfoToScope(scope, interfaceargs):
     for arg in interfaceargs:
@@ -281,4 +293,5 @@ class ZopeInterfaceSystem(model.System):
     Module = ZopeInterfaceModule
     Class = ZopeInterfaceClass
     Function = ZopeInterfaceFunction
+    Attribute = ZopeInterfaceAttribute
     defaultBuilder = ZopeInterfaceASTBuilder


### PR DESCRIPTION
As noted in [this comment](https://github.com/twisted/pydoctor/issues/181#issuecomment-579371226), docstrings for attributes such as `twisted.web.resource.Resource.isLeaf` were not inherited.

It turns out docstring inheritance was just never implemented for attributes, only for functions. This PR makes attributes share the inheritance implementations that existed for functions.