### PR TITLE
Improve error reporting

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -67,9 +67,10 @@ class ModuleVistor(ast.NodeVisitor):
     def visit_Module(self, node):
         assert self.module.docstring is None
 
+        self.builder.push(self.module, 0)
         if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
             self.module.docstring = node.body[0].value.s
-        self.builder.push(self.module, 0)
+            epydoc2stan.extract_fields(self.module)
         self.default(node)
         self.builder.pop(self.module)
 
@@ -92,15 +93,15 @@ class ModuleVistor(ast.NodeVisitor):
                 baseobj = None
             baseobjects.append(baseobj)
 
-        doc = None
-        if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
-            doc = node.body[0].value.s
-
-        cls = self.builder.pushClass(node.name, doc, node.lineno)
+        cls = self.builder.pushClass(node.name, node.lineno)
         cls.decorators = []
         cls.rawbases = rawbases
         cls.bases = bases
         cls.baseobjects = baseobjects
+
+        if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
+            cls.docstring = node.body[0].value.s
+            epydoc2stan.extract_fields(cls)
 
         def node2data(node):
             dotted_name = node2dottedname(node)
@@ -392,10 +393,9 @@ class ModuleVistor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_FunctionDef(self, node):
-        doc = None
+        func = self.builder.pushFunction(node.name, node.lineno)
         if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
-            doc = node.body[0].value.s
-        func = self.builder.pushFunction(node.name, doc, node.lineno)
+            func.docstring = node.body[0].value.s
         func.decorators = node.decorator_list
         if isinstance(func.parent, model.Class) and node.decorator_list:
             isclassmethod = False
@@ -534,8 +534,8 @@ class ASTBuilder(object):
         self._stack = []
         self.ast_cache = {}
 
-    def _push(self, cls, name, docstring, lineno):
-        obj = cls(self.system, name, docstring, self.current)
+    def _push(self, cls, name, lineno):
+        obj = cls(self.system, name, None, self.current)
         self.system.addObject(obj)
         self.push(obj, lineno)
         return obj
@@ -559,8 +559,6 @@ class ASTBuilder(object):
             assert obj.parentMod is None
         if lineno:
             obj.setLineNumber(lineno)
-        if not isinstance(obj, model.Function):
-            epydoc2stan.extract_fields(obj)
 
     def pop(self, obj):
         assert self.current is obj, "%r is not %r"%(self.current, obj)
@@ -568,13 +566,13 @@ class ASTBuilder(object):
         if isinstance(obj, model.Module):
             self.currentMod = None
 
-    def pushClass(self, name, docstring, lineno):
-        return self._push(self.system.Class, name, docstring, lineno)
+    def pushClass(self, name, lineno):
+        return self._push(self.system.Class, name, lineno)
     def popClass(self):
         self._pop(self.system.Class)
 
-    def pushFunction(self, name, docstring, lineno):
-        return self._push(self.system.Function, name, docstring, lineno)
+    def pushFunction(self, name, lineno):
+        return self._push(self.system.Function, name, lineno)
     def popFunction(self):
         self._pop(self.system.Function)
 

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -69,7 +69,7 @@ class ModuleVistor(ast.NodeVisitor):
 
         self.builder.push(self.module, 0)
         if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
-            self.module.docstring = node.body[0].value.s
+            self.module.setDocstring(node.body[0].value)
             epydoc2stan.extract_fields(self.module)
         self.default(node)
         self.builder.pop(self.module)
@@ -100,7 +100,7 @@ class ModuleVistor(ast.NodeVisitor):
         cls.baseobjects = baseobjects
 
         if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
-            cls.docstring = node.body[0].value.s
+            cls.setDocstring(node.body[0].value)
             epydoc2stan.extract_fields(cls)
 
         def node2data(node):
@@ -388,14 +388,14 @@ class ModuleVistor(ast.NodeVisitor):
         if isinstance(value, ast.Str):
             attr = self.currAttr
             if attr is not None:
-                attr.docstring = value.s
+                attr.setDocstring(value)
 
         self.generic_visit(node)
 
     def visit_FunctionDef(self, node):
         func = self.builder.pushFunction(node.name, node.lineno)
         if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
-            func.docstring = node.body[0].value.s
+            func.setDocstring(node.body[0].value)
         func.decorators = node.decorator_list
         if isinstance(func.parent, model.Class) and node.decorator_list:
             isclassmethod = False

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -408,9 +408,8 @@ class ModuleVistor(ast.NodeVisitor):
                         isstaticmethod = True
             if isstaticmethod:
                 if isclassmethod:
-                    self.system.msg(
-                        'ast', '%r is both class- and static-method?'%(
-                        func.fullName(),), thresh=-1)
+                    func.report('%s is both classmethod and staticmethod' % (
+                                func.fullName(),))
                 else:
                     func.kind = 'Static Method'
             elif isclassmethod:

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -272,7 +272,7 @@ class ModuleVistor(ast.NodeVisitor):
     def _handleModuleVar(self, target, annotation, lineno):
         obj = self.builder.current.resolveName(target)
         if obj is None:
-            obj = self.builder.addAttribute(target, None, None)
+            obj = self.builder.addAttribute(target, None)
         if isinstance(obj, model.Attribute):
             obj.kind = 'Variable'
             obj.annotation = annotation
@@ -286,7 +286,7 @@ class ModuleVistor(ast.NodeVisitor):
     def _handleClassVar(self, target, annotation, lineno):
         obj = self.builder.current.contents.get(target)
         if not isinstance(obj, model.Attribute):
-            obj = self.builder.addAttribute(target, None, None)
+            obj = self.builder.addAttribute(target, None)
         if obj.kind is None:
             obj.kind = 'Class Variable'
         obj.annotation = annotation
@@ -302,7 +302,7 @@ class ModuleVistor(ast.NodeVisitor):
             return
         obj = cls.contents.get(target)
         if obj is None:
-            obj = self.builder.addAttribute(target, None, None, cls)
+            obj = self.builder.addAttribute(target, None, cls)
         if isinstance(obj, model.Attribute):
             obj.kind = 'Instance Variable'
             obj.annotation = annotation
@@ -535,7 +535,7 @@ class ASTBuilder(object):
         self.ast_cache = {}
 
     def _push(self, cls, name, lineno):
-        obj = cls(self.system, name, None, self.current)
+        obj = cls(self.system, name, self.current)
         self.system.addObject(obj)
         self.push(obj, lineno)
         return obj
@@ -576,12 +576,12 @@ class ASTBuilder(object):
     def popFunction(self):
         self._pop(self.system.Function)
 
-    def addAttribute(self, target, docstring, kind, parent=None):
+    def addAttribute(self, target, kind, parent=None):
         if parent is None:
             parent = self.current
         system = self.system
         parentMod = self.currentMod
-        attr = system.Attribute(system, target, docstring, parent)
+        attr = system.Attribute(system, target, parent)
         attr.kind = kind
         attr.parentMod = parentMod
         system.addObject(attr)

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -335,8 +335,6 @@ def main(args=sys.argv[1:]):
             writer.system = system
             writer.prepOutputDirectory()
 
-            system.epytextproblems = []
-
             if options.htmlsubjects:
                 subjects = []
                 for fn in options.htmlsubjects:

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -346,13 +346,13 @@ def main(args=sys.argv[1:]):
                 writer.writeModuleIndex(system)
                 subjects = system.rootobjects
             writer.writeIndividualFiles(subjects, options.htmlfunctionpages)
-            if system.epytextproblems:
+            if system.docstring_syntax_errors:
                 def p(msg):
                     system.msg(('epytext', 'epytext-summary'), msg, thresh=-1, topthresh=1)
-                p("these %s objects' docstrings are not proper epytext:"
-                  %(len(system.epytextproblems),))
+                p("these %s objects' docstrings contain syntax errors:"
+                  %(len(system.docstring_syntax_errors),))
                 exitcode = 2
-                for fn in system.epytextproblems:
+                for fn in sorted(system.docstring_syntax_errors):
                     p('    '+fn)
 
         if options.makeintersphinx:

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -283,9 +283,9 @@ def main(args=sys.argv[1:]):
             if options.prependedpackage:
                 for m in options.prependedpackage.split('.'):
                     prependedpackage = system.Package(
-                        system, m, None, prependedpackage)
+                        system, m, prependedpackage)
                     system.addObject(prependedpackage)
-                    initmodule = system.Module(system, '__init__', None, prependedpackage)
+                    initmodule = system.Module(system, '__init__', prependedpackage)
                     system.addObject(initmodule)
             for path in args:
                 path = os.path.abspath(path)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -447,8 +447,8 @@ def reportErrors(obj, errs):
         obj.system.msg(
             'epydoc2stan2',
             '%s:%s epytext error %r' % (obj.fullName(), linenumber, descr))
-    if errs and obj.fullName() not in obj.system.epytextproblems:
-        obj.system.epytextproblems.append(obj.fullName())
+    if errs and obj.fullName() not in obj.system.docstring_syntax_errors:
+        obj.system.docstring_syntax_errors.add(obj.fullName())
         obj.system.msg('epydoc2stan',
                        'epytext error in %s'%(obj,), thresh=1)
         p = lambda m:obj.system.msg('epydoc2stan', m, thresh=2)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -113,11 +113,11 @@ class _EpydocLinker(DocstringLinker):
         if len(potential_targets) == 1:
             return potential_targets[0]
         elif len(potential_targets) > 1:
-            self.obj.system.msg(
-                "translate_identifier_xref", "%s:%s ambiguous ref to %s, could be %s" % (
-                    self.obj.fullName(), self.obj.linenumber, name,
-            ', '.join([ob.fullName() for ob in potential_targets])),
-                thresh=-1)
+            self.obj.report(
+                "ambiguous ref to %s, could be %s" % (
+                    name,
+                    ', '.join(ob.fullName() for ob in potential_targets)),
+                section='translate_identifier_xref')
         return None
 
     def look_for_intersphinx(self, name):
@@ -188,11 +188,9 @@ class _EpydocLinker(DocstringLinker):
         if target:
             return tags.a(tags.code(prettyID), href=target)
         if fullID != fullerID:
-            self.obj.system.msg(
-                "translate_identifier_xref", "%s:%s invalid ref to '%s' "
-                "resolved as '%s'" % (
-                    self.obj.fullName(), self.obj.linenumber, fullID, fullerID),
-                thresh=-1)
+            self.obj.report(
+                "invalid ref to '%s' resolved as '%s'" % (fullID, fullerID),
+                section='translate_identifier_xref')
         return tags.code(prettyID)
 
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -438,25 +438,21 @@ def reportErrors(obj, errs):
     if errs and obj.fullName() not in obj.system.docstring_syntax_errors:
         obj.system.docstring_syntax_errors.add(obj.fullName())
 
-        moduleDesc = None
-        if obj.parentMod is not None:
-            moduleDesc = getattr(obj.parentMod, 'filepath', None)
-        if moduleDesc is None:
-            moduleDesc = obj.fullName()
-
         for err in errs:
-            linenumber = obj.linenumber
+            lineno_offset = 0
             if isinstance(err, string_types):
                 descr = err
             elif isinstance(err, ParseError):
-                linenumber += err.linenum()
                 descr = err.descr()
+                lineno_offset = err.linenum()
             else:
                 raise TypeError(type(err).__name__)
 
-            obj.system.msg(
-                'docstring',
-                '%s:%s: bad docstring: %s' % (moduleDesc, linenumber, descr))
+            obj.report(
+                'bad docstring: ' + descr,
+                lineno_offset=lineno_offset,
+                section='docstring'
+                )
 
 
 def parse_docstring(obj, doc, source):

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 import astor
 
 from importlib import import_module
-import inspect
 import itertools
 import os
 import sys
@@ -50,26 +49,12 @@ def get_parser(obj):
 def get_docstring(obj):
     for source in obj.docsources():
         doc = source.docstring
+        if doc:
+            return doc, source
         if doc is not None:
-            # Note: We approximate the line number: it is correct
-            #       if the docstring starts on the first line of the
-            #       class/function and does not contain explicit
-            #       newlines ('\n') or joined lines ('\' at end of line).
-            #       The AST (as of Python 3.7) does not contain sufficient
-            #       detail to match a position within the docstring to
-            #       an exact position in the source.
-            lineno = obj.linenumber + 1
-            # Leading blank lines are stripped by cleandoc(), so we must
-            # return the line number of the first non-blank line.
-            for ch in doc:
-                if ch == '\n':
-                    lineno += 1
-                elif not ch.isspace():
-                    return inspect.cleandoc(doc), source, lineno
-            else:
-                # Treat empty docstring as undocumented.
-                return None, source, None
-    return None, None, None
+            # Treat empty docstring as undocumented.
+            return None, source
+    return None, None
 
 
 def stdlib_doc_link_for_name(name):
@@ -444,7 +429,7 @@ def reportErrors(obj, errs):
                 descr = err
             elif isinstance(err, ParseError):
                 descr = err.descr()
-                lineno_offset = err.linenum()
+                lineno_offset = err.linenum() - 1
             else:
                 raise TypeError(type(err).__name__)
 
@@ -477,7 +462,7 @@ def parse_docstring(obj, doc, source):
 def format_docstring(obj):
     """Generate an HTML representation of a docstring"""
 
-    doc, source, lineno = get_docstring(obj)
+    doc, source = get_docstring(obj)
 
     # Use cached or split version if possible.
     pdoc = getattr(obj, 'parsed_docstring', None)
@@ -517,7 +502,7 @@ def format_docstring(obj):
 def format_summary(obj):
     """Generate an shortened HTML representation of a docstring."""
 
-    doc, source, lineno = get_docstring(obj)
+    doc, source = get_docstring(obj)
     if doc is None:
         # Attributes can be documented as fields in their parent's docstring.
         if isinstance(obj, model.Attribute):
@@ -614,7 +599,7 @@ field_name_to_human_name = {
 
 
 def extract_fields(obj):
-    doc, source, lineno = get_docstring(obj)
+    doc, source = get_docstring(obj)
     if doc is None:
         return
 
@@ -635,7 +620,7 @@ def extract_fields(obj):
                 attrobj.kind = None
                 attrobj.parentMod = obj.parentMod
                 obj.system.addObject(attrobj)
-            attrobj.setLineNumber(lineno + field.lineno)
+            attrobj.setLineNumber(source.docstring_lineno + field.lineno)
             if tag == 'type':
                 attrobj.parsed_type = field.body()
             else:

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -634,7 +634,7 @@ def extract_fields(obj):
                 continue
             attrobj = obj.contents.get(arg)
             if attrobj is None:
-                attrobj = obj.system.Attribute(obj.system, arg, None, obj)
+                attrobj = obj.system.Attribute(obj.system, arg, obj)
                 attrobj.kind = None
                 attrobj.parentMod = obj.parentMod
                 obj.system.addObject(attrobj)

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -55,6 +55,7 @@ class Documentable(object):
     @ivar kind: ...
     """
     documentation_location = DocLocation.OWN_PAGE
+    docstring = None
     linenumber = 0
     sourceHref = None
 
@@ -66,10 +67,9 @@ class Documentable(object):
             class_ += ' private'
         return class_
 
-    def __init__(self, system, name, docstring, parent=None):
+    def __init__(self, system, name, parent=None):
         self.system = system
         self.name = name
-        self.docstring = docstring
         self.parent = parent
         self.parentMod = None
         self.setup()
@@ -461,7 +461,7 @@ class System(object):
                 mod.filepath[len(projBaseDir):])
 
     def addModule(self, modpath, modname, parentPackage=None):
-        mod = self.Module(self, modname, None, parentPackage)
+        mod = self.Module(self, modname, parentPackage)
         self.addObject(mod)
         self.progress(
             "addModule", len(self.allobjects),
@@ -480,7 +480,7 @@ class System(object):
         else:
             parent_package = None
             module_name = module_full_name
-        module = self.Module(self, module_name, None, parent_package)
+        module = self.Module(self, module_name, parent_package)
         self.addObject(module)
         return module
 
@@ -493,24 +493,26 @@ class System(object):
         else:
             parent_package = None
             package_name = package_full_name
-        package = self.Package(self, package_name, None, parent_package)
+        package = self.Package(self, package_name, parent_package)
         self.addObject(package)
         return package
 
     def _introspectThing(self, thing, parent, parentMod):
         for k, v in thing.__dict__.items():
             if isinstance(v, (types.BuiltinFunctionType, type(dict.keys))):
-                f = self.Function(self, k, v.__doc__, parent)
+                f = self.Function(self, k, parent)
                 f.parentMod = parentMod
+                f.docstring = v.__doc__
                 f.decorators = None
                 f.argspec = ((), None, None, ())
                 self.addObject(f)
             elif isinstance(v, type):
-                c = self.Class(self, k, v.__doc__, parent)
+                c = self.Class(self, k, parent)
                 c.bases = []
                 c.baseobjects = []
                 c.rawbases = []
                 c.parentMod = parentMod
+                c.docstring = v.__doc__
                 self.addObject(c)
                 self._introspectThing(v, c, parentMod)
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -343,7 +343,10 @@ class System(object):
 
         self.abbrevmapping = {}
         self.projectname = 'my project'
-        self.epytextproblems = [] # fullNames of objects that failed to epytext properly
+
+        self.docstring_syntax_errors = set()
+        """FullNames of objects for which the docstring failed to parse."""
+
         self.verboselevel = 0
         self.needsnl = False
         self.once_msgs = set()

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -542,7 +542,8 @@ class System(object):
 
     def _introspectThing(self, thing, parent, parentMod):
         for k, v in thing.__dict__.items():
-            if isinstance(v, (types.BuiltinFunctionType, type(dict.keys))):
+            if isinstance(v, (types.BuiltinFunctionType,
+                              types.FunctionType)):
                 f = self.Function(self, k, parent)
                 f.parentMod = parentMod
                 f.docstring = v.__doc__
@@ -563,7 +564,6 @@ class System(object):
         module = self.ensureModule(module_full_name)
         module.docstring = py_mod.__doc__
         self._introspectThing(py_mod, module, module)
-        print(py_mod)
 
     def addPackage(self, dirpath, parentPackage=None):
         if not os.path.exists(dirpath):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -195,6 +195,31 @@ class Documentable(object):
         """
         return self.privacyClass is not PrivacyClass.HIDDEN
 
+    @property
+    def module(self):
+        """This object's L{Module}.
+
+        For modules, this returns the object itself, otherwise
+        the module containing the object is returned.
+        """
+        parentMod = self.parentMod
+        assert parentMod is not None
+        return parentMod
+
+    def report(self, descr, section='parsing', lineno_offset=0):
+        """Log an error or warning about this documentable object."""
+
+        linenumber = self.linenumber
+        if linenumber:
+            linenumber += lineno_offset
+        else:
+            linenumber = '???'
+
+        self.system.msg(
+            section,
+            '%s:%s: %s' % (self.module.description, linenumber, descr),
+            thresh=-1)
+
 
 class Package(Documentable):
     kind = "Package"
@@ -202,6 +227,9 @@ class Package(Documentable):
         yield self.contents['__init__']
     @property
     def doctarget(self):
+        return self.contents['__init__']
+    @property
+    def module(self):
         return self.contents['__init__']
     @property
     def state(self):
@@ -245,6 +273,21 @@ class Module(CanContainImportsDocumentable):
             return name
         else:
             return name
+
+    @property
+    def module(self):
+        return self
+
+    @property
+    def description(self):
+        """A string describing this module to the user.
+
+        If this module's code was read from a file, this returns
+        its file path. In other cases, such as during unit testing,
+        the module's full name is returned.
+        """
+        filepath = getattr(self, 'filepath', None)
+        return self.fullName() if filepath is None else filepath
 
 
 class Class(CanContainImportsDocumentable):

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -22,7 +22,7 @@ def fromText(text, modname='<test>', system=None,
     if buildercls is None:
         buildercls = _system.defaultBuilder
     builder = buildercls(_system)
-    mod = builder._push(_system.Module, modname, None, None)
+    mod = builder._push(_system.Module, modname, None)
     builder._pop(_system.Module)
     ast = astbuilder.parse(textwrap.dedent(text))
     builder.processModuleAST(ast, mod)

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -365,6 +365,33 @@ def test_classdecorator_with_args():
       C.decorators
 
 
+def test_methoddecorator(capsys):
+    mod = fromText('''
+    class C:
+        def method_undecorated():
+            pass
+
+        @staticmethod
+        def method_static():
+            pass
+
+        @classmethod
+        def method_class(cls):
+            pass
+
+        @staticmethod
+        @classmethod
+        def method_both():
+            pass
+    ''', modname='mod')
+    C = mod.contents['C']
+    assert C.contents['method_undecorated'].kind == 'Method'
+    assert C.contents['method_static'].kind == 'Static Method'
+    assert C.contents['method_class'].kind == 'Class Method'
+    captured = capsys.readouterr().out
+    assert captured == "mod:14: mod.C.method_both is both classmethod and staticmethod\n"
+
+
 def test_import_star():
     mod_a = fromText('''
     def f(): pass

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -79,7 +79,7 @@ def test_EpydocLinker_look_for_intersphinx_no_link():
     Return None if inventory had no link for our markup.
     """
     system = model.System()
-    target = model.Module(system, 'ignore-name', 'ignore-docstring')
+    target = model.Module(system, 'ignore-name')
     sut = epydoc2stan._EpydocLinker(target)
 
     result = sut.look_for_intersphinx('base.module')
@@ -95,7 +95,7 @@ def test_EpydocLinker_look_for_intersphinx_hit():
     inventory = SphinxInventory(system.msg)
     inventory._links['base.module.other'] = ('http://tm.tld', 'some.html')
     system.intersphinx = inventory
-    target = model.Module(system, 'ignore-name', 'ignore-docstring')
+    target = model.Module(system, 'ignore-name')
     sut = epydoc2stan._EpydocLinker(target)
 
     result = sut.look_for_intersphinx('base.module.other')
@@ -113,7 +113,7 @@ def test_EpydocLinker_translate_identifier_xref_intersphinx_absolute_id():
     inventory = SphinxInventory(system.msg)
     inventory._links['base.module.other'] = ('http://tm.tld', 'some.html')
     system.intersphinx = inventory
-    target = model.Module(system, 'ignore-name', 'ignore-docstring')
+    target = model.Module(system, 'ignore-name')
     sut = epydoc2stan._EpydocLinker(target)
 
     result = sut.translate_identifier_xref(
@@ -134,12 +134,12 @@ def test_EpydocLinker_translate_identifier_xref_intersphinx_relative_id():
     inventory = SphinxInventory(system.msg)
     inventory._links['ext_package.ext_module'] = ('http://tm.tld', 'some.html')
     system.intersphinx = inventory
-    target = model.Module(system, 'ignore-name', 'ignore-docstring')
+    target = model.Module(system, 'ignore-name')
     # Here we set up the target module as it would have this import.
     # from ext_package import ext_module
-    ext_package = model.Module(system, 'ext_package', 'ignore-docstring')
+    ext_package = model.Module(system, 'ext_package')
     target.contents['ext_module'] = model.Module(
-        system, 'ext_module', 'ignore-docstring', parent=ext_package)
+        system, 'ext_module', parent=ext_package)
 
     sut = epydoc2stan._EpydocLinker(target)
 
@@ -160,12 +160,12 @@ def test_EpydocLinker_translate_identifier_xref_intersphinx_link_not_found():
     The message contains the full name under which the reference was resolved.
     """
     system = model.System()
-    target = model.Module(system, 'ignore-name', 'ignore-docstring')
+    target = model.Module(system, 'ignore-name')
     # Here we set up the target module as it would have this import.
     # from ext_package import ext_module
-    ext_package = model.Module(system, 'ext_package', 'ignore-docstring')
+    ext_package = model.Module(system, 'ext_package')
     target.contents['ext_module'] = model.Module(
-        system, 'ext_module', 'ignore-docstring', parent=ext_package)
+        system, 'ext_module', parent=ext_package)
     stdout = StringIO()
     sut = epydoc2stan._EpydocLinker(target)
 

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -174,7 +174,7 @@ def test_EpydocLinker_translate_identifier_xref_intersphinx_link_not_found(capsy
 
     captured = capsys.readouterr().out
     expected = (
-        "ignore-name:0 invalid ref to 'ext_module' "
+        "ignore-name:???: invalid ref to 'ext_module' "
         "resolved as 'ext_package.ext_module'\n"
         )
     assert expected == captured

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -1,8 +1,5 @@
 from __future__ import print_function
 
-import sys
-from io import StringIO
-
 from pydoctor import epydoc2stan, model
 from pydoctor.epydoc.markup import flatten
 from pydoctor.sphinx import SphinxInventory
@@ -153,11 +150,13 @@ def test_EpydocLinker_translate_identifier_xref_intersphinx_relative_id():
     assert expected == flatten(result)
 
 
-def test_EpydocLinker_translate_identifier_xref_intersphinx_link_not_found():
+def test_EpydocLinker_translate_identifier_xref_intersphinx_link_not_found(capsys):
     """
     A message is sent to stdout when no link could be found for the reference,
     while returning the reference name without an A link tag.
     The message contains the full name under which the reference was resolved.
+    FIXME: Use a proper logging system instead of capturing stdout.
+           https://github.com/twisted/pydoctor/issues/112
     """
     system = model.System()
     target = model.Module(system, 'ignore-name')
@@ -166,26 +165,16 @@ def test_EpydocLinker_translate_identifier_xref_intersphinx_link_not_found():
     ext_package = model.Module(system, 'ext_package')
     target.contents['ext_module'] = model.Module(
         system, 'ext_module', parent=ext_package)
-    stdout = StringIO()
     sut = epydoc2stan._EpydocLinker(target)
 
-    try:
-        # FIXME: https://github.com/twisted/pydoctor/issues/112
-        # We no have this ugly hack to capture stdout.
-        previousStdout = sys.stdout
-        sys.stdout = stdout
-        # This is called for the L{ext_module} markup.
-        result = sut.translate_identifier_xref(
-            fullID='ext_module', prettyID='ext_module')
-    finally:
-        sys.stdout = previousStdout
-
-
+    # This is called for the L{ext_module} markup.
+    result = sut.translate_identifier_xref(
+        fullID='ext_module', prettyID='ext_module')
     assert '<code>ext_module</code>' == flatten(result)
 
+    captured = capsys.readouterr().out
     expected = (
         "ignore-name:0 invalid ref to 'ext_module' "
         "resolved as 'ext_package.ext_module'\n"
         )
-
-    assert expected == stdout.getvalue()
+    assert expected == captured

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -3,6 +3,7 @@ Unit tests for model.
 """
 from __future__ import print_function
 
+import sys
 import zlib
 
 from pydoctor import model, sphinx
@@ -137,3 +138,23 @@ def test_docsources_class_attribute():
     base_attr = mod.contents['Base'].contents['attr']
     sub_attr = mod.contents['Sub'].contents['attr']
     assert base_attr in list(sub_attr.docsources())
+
+
+class Dummy(object):
+    def crash(self):
+        """Mmm"""
+
+def test_introspection():
+    """Find docstrings from this test using introspection."""
+    system = model.System()
+    py_mod = sys.modules[__name__]
+    system.introspectModule(py_mod, __name__)
+
+    module = system.objForFullName(__name__)
+    assert module.docstring == __doc__
+
+    func = module.contents['test_introspection']
+    assert func.docstring == "Find docstrings from this test using introspection."
+
+    method = system.objForFullName(__name__ + '.Dummy.crash')
+    assert method.docstring == "Mmm"

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -98,9 +98,9 @@ def test_generateContent():
     sut = sphinx.SphinxInventoryWriter(logger=object(),
                                        project_name='project_name')
     system = model.System()
-    root1 = model.Package(system, 'package1', 'docstring1')
-    root2 = model.Package(system, 'package2', 'docstring2')
-    child1 = model.Package(system, 'child1', 'docstring3', parent=root2)
+    root1 = model.Package(system, 'package1')
+    root2 = model.Package(system, 'package2')
+    child1 = model.Package(system, 'child1', parent=root2)
     system.addObject(child1)
     subjects = [root1, root2]
 
@@ -122,7 +122,7 @@ def test_generateLine_package():
                                        project_name='project_name')
 
     result = sut._generateLine(
-        model.Package('ignore-system', 'package1', 'ignore-docstring'))
+        model.Package('ignore-system', 'package1'))
 
     assert 'package1 py:module -1 package1.html -\n' == result
 
@@ -135,7 +135,7 @@ def test_generateLine_module():
                                        project_name='project_name')
 
     result = sut._generateLine(
-        model.Module('ignore-system', 'module1', 'ignore-docstring'))
+        model.Module('ignore-system', 'module1'))
 
     assert 'module1 py:module -1 module1.html -\n' == result
 
@@ -148,7 +148,7 @@ def test_generateLine_class():
                                        project_name='project_name')
 
     result = sut._generateLine(
-        model.Class('ignore-system', 'class1', 'ignore-docstring'))
+        model.Class('ignore-system', 'class1'))
 
     assert 'class1 py:class -1 class1.html -\n' == result
 
@@ -161,10 +161,10 @@ def test_generateLine_function():
     """
     sut = sphinx.SphinxInventoryWriter(logger=object(),
                                        project_name='project_name')
-    parent = model.Module('ignore-system', 'module1', 'docstring')
+    parent = model.Module('ignore-system', 'module1')
 
     result = sut._generateLine(
-        model.Function('ignore-system', 'func1', 'ignore-docstring', parent))
+        model.Function('ignore-system', 'func1', parent))
 
     assert 'module1.func1 py:function -1 module1.html#func1 -\n' == result
 
@@ -177,10 +177,10 @@ def test_generateLine_method():
     """
     sut = sphinx.SphinxInventoryWriter(logger=object(),
                                        project_name='project_name')
-    parent = model.Class('ignore-system', 'class1', 'docstring')
+    parent = model.Class('ignore-system', 'class1')
 
     result = sut._generateLine(
-        model.Function('ignore-system', 'meth1', 'ignore-docstring', parent))
+        model.Function('ignore-system', 'meth1', parent))
 
     assert 'class1.meth1 py:method -1 class1.html#meth1 -\n' == result
 
@@ -191,10 +191,10 @@ def test_generateLine_attribute():
     """
     sut = sphinx.SphinxInventoryWriter(logger=object(),
                                        project_name='project_name')
-    parent = model.Class('ignore-system', 'class1', 'docstring')
+    parent = model.Class('ignore-system', 'class1')
 
     result = sut._generateLine(
-        model.Attribute('ignore-system', 'attr1', 'ignore-docstring', parent))
+        model.Attribute('ignore-system', 'attr1', parent))
 
     assert 'class1.attr1 py:attribute -1 class1.html#attr1 -\n' == result
 
@@ -216,7 +216,7 @@ def test_generateLine_unknown():
         )
 
     result = sut._generateLine(
-        UnknownType('ignore-system', 'unknown1', 'ignore-docstring'))
+        UnknownType('ignore-system', 'unknown1'))
 
     assert 'unknown1 py:obj -1 unknown1.html -\n' == result
 

--- a/pydoctor/test/test_twistedmodel.py
+++ b/pydoctor/test/test_twistedmodel.py
@@ -6,22 +6,22 @@ from pydoctor.twistedmodel import TwistedSystem
 
 def test_include_private():
     system = TwistedSystem()
-    c = Class(system, "_private", "some doc")
+    c = Class(system, "_private")
     assert c.isVisible
 
 
 def test_include_private_not_in_all():
     system = TwistedSystem()
-    m = Module(system, "somemodule", "module doc")
+    m = Module(system, "somemodule")
     m.all = []
-    c = Class(system, "_private", "some doc", m)
+    c = Class(system, "_private", m)
     assert c.isVisible
 
 
 def test_doesnt_include_test_package():
     system = TwistedSystem()
-    c = Class(system, "test", "some doc")
+    c = Class(system, "test")
     assert c.isVisible
 
-    p = Package(system, "test", "package doc")
+    p = Package(system, "test")
     assert not p.isVisible

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -113,18 +113,25 @@ def test_multiply_inheriting_interfaces():
     mod = fromText(src, 'zi', systemcls=ZopeInterfaceSystem)
     assert len(mod.contents['Both'].allImplementedInterfaces) == 2
 
-def test_attribute():
+def test_attribute(capsys):
     src = '''
     import zope.interface as zi
     class C(zi.Interface):
         attr = zi.Attribute("documented attribute")
+        bad_attr = zi.Attribute(0)
     '''
-    mod = fromText(src, systemcls=ZopeInterfaceSystem)
-    assert len(mod.contents['C'].contents) == 1
+    mod = fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
+    assert len(mod.contents['C'].contents) == 2
     attr = mod.contents['C'].contents['attr']
     assert attr.kind == 'Attribute'
     assert attr.name == 'attr'
     assert attr.docstring == "documented attribute"
+    bad_attr = mod.contents['C'].contents['bad_attr']
+    assert bad_attr.kind == 'Attribute'
+    assert bad_attr.name == 'bad_attr'
+    assert bad_attr.docstring is None
+    captured = capsys.readouterr().out
+    assert captured == 'mod:5: definition of attribute "bad_attr" should have docstring as its sole argument\n'
 
 def test_interfaceclass():
     system = processPackage('interfaceclass', systemcls=ZopeInterfaceSystem)

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -148,16 +148,26 @@ def test_warnerproofing():
     mod = fromText(src, systemcls=ZopeInterfaceSystem)
     assert mod.contents['IMyInterface'].isinterface
 
-def test_zopeschema():
+def test_zopeschema(capsys):
     src = '''
     from zope import schema, interface
     class IMyInterface(interface.Interface):
         text = schema.TextLine(description="fun in a bun")
+        undoc = schema.Bool()
+        bad = schema.ASCII(description=False)
     '''
-    mod = fromText(src, systemcls=ZopeInterfaceSystem)
+    mod = fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
     text = mod.contents['IMyInterface'].contents['text']
     assert text.docstring == 'fun in a bun'
     assert text.kind == "TextLine"
+    undoc = mod.contents['IMyInterface'].contents['undoc']
+    assert undoc.docstring is None
+    assert undoc.kind == "Bool"
+    bad = mod.contents['IMyInterface'].contents['bad']
+    assert bad.docstring is None
+    assert bad.kind == "ASCII"
+    captured = capsys.readouterr().out
+    assert captured == 'mod:6: description of field "bad" is not a string literal\n'
 
 def test_aliasing_in_class():
     src = '''

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -322,3 +322,20 @@ def test_implementer_with_none():
     iface = mod.contents['IMyInterface']
     impl = mod.contents['Implementation']
     assert impl.implements_directly == [iface.fullName()]
+
+def test_implementer_nonclass(capsys):
+    """
+    Check rejection of non-class arguments passed to @implementer.
+    """
+    src = '''
+    from zope.interface import Interface, implementer
+    var = 'not a class'
+    @implementer(var)
+    class Implementation(object):
+        pass
+    '''
+    mod = fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
+    impl = mod.contents['Implementation']
+    assert impl.implements_directly == []
+    captured = capsys.readouterr().out
+    assert captured == "mod:4: probable interface mod.var not detected as a class\n"

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -136,6 +136,8 @@ def test_attribute(capsys):
 def test_interfaceclass():
     system = processPackage('interfaceclass', systemcls=ZopeInterfaceSystem)
     mod = system.allobjects['interfaceclass.mod']
+    assert mod.contents['MyInterface'].isinterface
+    assert mod.contents['MyInterface'].docstring == "This is my interface."
     assert mod.contents['AnInterface'].isinterface
 
 def test_warnerproofing():

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -339,3 +339,25 @@ def test_implementer_nonclass(capsys):
     assert impl.implements_directly == []
     captured = capsys.readouterr().out
     assert captured == "mod:4: probable interface mod.var not detected as a class\n"
+
+def test_implementer_plainclass(capsys):
+    """
+    Check patching of non-interface classes passed to @implementer.
+    """
+    src = '''
+    from zope.interface import Interface, implementer
+    class C(object):
+        pass
+    @implementer(C)
+    class Implementation(object):
+        pass
+    '''
+    mod = fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
+    C = mod.contents['C']
+    impl = mod.contents['Implementation']
+    assert C.isinterface
+    assert C.kind == "Interface"
+    assert C.implementedby_directly == [impl]
+    assert impl.implements_directly == ['mod.C']
+    captured = capsys.readouterr().out
+    assert captured == "mod:5: probable interface mod.C not marked as such\n"

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -152,22 +152,6 @@ def test_zopeschema():
     assert text.docstring == 'fun in a bun'
     assert text.kind == "TextLine"
 
-def test_with_underscore():
-    src = '''
-    from zope import schema, interface
-    class IMyInterface(interface.Interface):
-        attribute = interface.Attribute(_("fun in a bun"))
-        text = schema.TextLine(description=_("fun in a bap"))
-    '''
-    mod = fromText(src, systemcls=ZopeInterfaceSystem)
-    text = mod.contents['IMyInterface'].contents['attribute']
-    assert text.docstring == 'fun in a bun'
-    assert text.kind == "Attribute"
-
-    text = mod.contents['IMyInterface'].contents['text']
-    assert text.docstring == 'fun in a bap'
-    assert text.kind == "TextLine"
-
 def test_aliasing_in_class():
     src = '''
     from zope import interface

--- a/pydoctor/test/testpackages/interfaceclass/mod.py
+++ b/pydoctor/test/testpackages/interfaceclass/mod.py
@@ -4,7 +4,10 @@ import zope.schema as zs
 
 class MyInterfaceClass(zi.interface.InterfaceClass):
     pass
+
 MyInterface = MyInterfaceClass("MyInterface")
+"""This is my interface."""
+
 class AnInterface(MyInterface):
     def foo():
         pass

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -174,7 +174,9 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             return
         ob = self.system.objForFullName(funcName)
         if isinstance(ob, model.Class) and ob.isinterfaceclass:
-            interface = self.builder.pushClass(target, "...", lineno)
+            interface = self.builder.pushClass(target, lineno)
+            # TODO: Why not leave the docstring as None instead?
+            interface.docstring = "..."
             self.builder.system.msg('parsing', 'new interface')
             interface.isinterface = True
             interface.implementedby_directly = []

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -104,10 +104,9 @@ def addInterfaceInfoToScope(scope, interfaceargs):
         if isinstance(obj, ZopeInterfaceClass):
             scope.implements_directly.append(fullName)
             if not obj.isinterface:
-                obj.system.msg(
-                    'zopeinterface',
-                    'probable interface %r not marked as such'%obj,
-                    thresh=1)
+                scope.report(
+                    'probable interface %s not marked as such' % fullName,
+                    section='zopeinterface')
                 obj.isinterface = True
                 obj.kind = "Interface"
                 obj.implementedby_directly = []

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -264,8 +264,7 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
         if 'zope.interface.interface.InterfaceClass' in bases:
             cls.isinterfaceclass = True
 
-        if len([b for b in cls.bases
-                if namesInterface(self.system, b)]) > 0:
+        if any(namesInterface(self.system, b) for b in cls.bases):
             cls.isinterface = True
             cls.kind = "Interface"
             cls.implementedby_directly = []

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -178,7 +178,7 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             keywords = {arg.arg: arg.value for arg in expr.keywords}
             descrNode = keywords.get('description')
             if isinstance(descrNode, ast.Str):
-                attr.docstring = descrNode.s
+                attr.setDocstring(descrNode)
             elif descrNode is not None:
                 attr.report(
                     'description of field "%s" is not a string literal'
@@ -194,7 +194,7 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             attr.kind = 'Attribute'
             args = expr.args
             if len(args) == 1 and isinstance(args[0], ast.Str):
-                attr.docstring = args[0].s
+                attr.setDocstring(args[0])
             else:
                 attr.report(
                     'definition of attribute "%s" should have docstring '

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -195,10 +195,15 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
         if funcName is None:
             return
         if funcName == 'zope.interface.Attribute':
+            attr.kind = 'Attribute'
             args = expr.args
-            if args is not None and len(args) == 1:
-                attr.kind = 'Attribute'
-                attr.docstring = extractStringLiteral(expr.args[0])
+            if len(args) == 1 and isinstance(args[0], ast.Str):
+                attr.docstring = args[0].s
+            else:
+                attr.report(
+                    'definition of attribute "%s" should have docstring '
+                    'as its sole argument' % attr.name,
+                    section='zopeinterface')
         elif schema_prog.match(funcName):
             attr.kind = schema_prog.match(funcName).group(1)
             handleSchemaField()

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -163,13 +163,12 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             return
         ob = self.system.objForFullName(funcName)
         if isinstance(ob, model.Class) and ob.isinterfaceclass:
+            # TODO: Process 'bases' and '__doc__' arguments.
             interface = self.builder.pushClass(target, lineno)
-            # TODO: Why not leave the docstring as None instead?
-            interface.docstring = "..."
-            self.builder.system.msg('parsing', 'new interface')
             interface.isinterface = True
             interface.implementedby_directly = []
             self.builder.popClass()
+            self.newAttr = interface
 
     def _handleAssignmentInClass(self, target, annotation, expr, lineno):
         super(ZopeInterfaceModuleVisitor, self)._handleAssignmentInClass(

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -113,9 +113,9 @@ def addInterfaceInfoToScope(scope, interfaceargs):
                 obj.implementedby_directly = []
             obj.implementedby_directly.append(scope)
         elif obj is not None:
-            obj.system.msg(
-                'zopeinterface',
-                'probable interface %r not detected as class'%obj)
+            scope.report(
+                'probable interface %s not detected as a class' % fullName,
+                section='zopeinterface')
 
 def addInterfaceInfoToModule(module, interfaceargs):
     addInterfaceInfoToScope(module, interfaceargs)

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -142,10 +142,6 @@ def namesInterface(system, name):
 def extractStringLiteral(node):
     if isinstance(node, ast.Str):
         return node.s
-    elif isinstance(node, ast.Name):
-        return node.id
-    elif isinstance(node, ast.Call):
-        return node.args[0].s
     else:
         raise TypeError("cannot extract string from %r" % (node,))
 


### PR DESCRIPTION
This series of commits improves various aspects of error reporting by pydoctor. It also improves unit test coverage of error reporting.

Please read the individual commit comments for details.

There are still some minor issues left after this. For example epydoc sometimes seems to produce incorrect line number offsets (I got one problem reported one line off). And xref problems are reported on the line number of the documented object instead of the line number of the reference itself. But those present only a small inconvenience to the user.
