### PR TITLE
Ignore documentables inside functions

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -75,6 +75,11 @@ class ModuleVistor(ast.NodeVisitor):
         self.builder.pop(self.module)
 
     def visit_ClassDef(self, node):
+        # Ignore classes within functions.
+        parent = self.builder.current
+        if isinstance(parent, model.Function):
+            return
+
         rawbases = []
         bases = []
         baseobjects = []
@@ -86,7 +91,7 @@ class ModuleVistor(ast.NodeVisitor):
                 str_base = astor.to_source(n).strip()
 
             rawbases.append(str_base)
-            full_name = self.builder.current.expandName(str_base)
+            full_name = parent.expandName(str_base)
             bases.append(full_name)
             baseobj = self.system.objForFullName(full_name)
             if not isinstance(baseobj, model.Class):
@@ -397,6 +402,10 @@ class ModuleVistor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_FunctionDef(self, node):
+        # Ignore inner functions.
+        if isinstance(self.builder.current, model.Function):
+            return
+
         lineno = node.lineno
         if node.decorator_list:
             lineno = node.decorator_list[0].lineno

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -918,3 +918,21 @@ def test_detupling_assignment(systemcls):
     a, b, c = range(3)
     ''', modname='test', systemcls=systemcls)
     assert sorted(mod.contents.keys()) == ['a', 'b', 'c']
+
+@systemcls_param
+def test_ignore_function_contents(systemcls):
+    mod = fromText('''
+    def outer():
+        """Outer function."""
+
+        class Clazz:
+            """Inner class."""
+
+        def func():
+            """Inner function."""
+
+        var = 1
+        """Local variable."""
+    ''', systemcls=systemcls)
+    outer = mod.contents['outer']
+    assert not outer.contents

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -247,7 +247,9 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
 
     def visit_ClassDef(self, node):
         super(ZopeInterfaceModuleVisitor, self).visit_ClassDef(node)
-        cls = self.builder.current.contents[node.name]
+        cls = self.builder.current.contents.get(node.name)
+        if cls is None:
+            return
 
         bases = []
 


### PR DESCRIPTION
These cannot be called directly, so they should not be considered to
be part of the API.

In theory they could be returned from the function and then exposed,
but I don't think our aliasing support is powerful enough to support
that anyway.

Note that documented local variables were never included in the
output, but I added them to the test case to make sure that won't
happen in the future either.

Closes #195