### PR TITLE
Support Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
       env: TOX_ENV=test-py27-codecov-travis
     - python: 3.6
       env: TOX_ENV=test-py36-codecov-travis
+    - python: 3.7
+      env: TOX_ENV=test-py37
+    - python: 3.8
+      env: TOX_ENV=test-py38
     - python: 2.7
       env: TOX_ENV=twisted-apidoc
 

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -93,7 +93,11 @@ class ModuleVistor(ast.NodeVisitor):
                 baseobj = None
             baseobjects.append(baseobj)
 
-        cls = self.builder.pushClass(node.name, node.lineno)
+        lineno = node.lineno
+        if node.decorator_list:
+            lineno = node.decorator_list[0].lineno
+
+        cls = self.builder.pushClass(node.name, lineno)
         cls.decorators = []
         cls.rawbases = rawbases
         cls.bases = bases
@@ -393,7 +397,11 @@ class ModuleVistor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_FunctionDef(self, node):
-        func = self.builder.pushFunction(node.name, node.lineno)
+        lineno = node.lineno
+        if node.decorator_list:
+            lineno = node.decorator_list[0].lineno
+
+        func = self.builder.pushFunction(node.name, lineno)
         if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
             func.setDocstring(node.body[0].value)
         func.decorators = node.decorator_list

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 ;
 [tox]
 envlist =
-    test-{py27,py36,pypy},pyflakes,twisted-apidoc
+    test-{py27,py36,py37,py38,pypy},pyflakes,twisted-apidoc
 
 [testenv:pyflakes]
 basepython = /usr/bin/python


### PR DESCRIPTION
This PR enables CPython 3.7 and 3.8 in `tox.ini` and Travis, to make sure we test on those as well.

Some unit tests were failing on 3.8 because line numbers reported in warnings issued by pydoctor were different than expected. Class and function nodes produced by 3.8's `ast` module have the line number of the `class`/`def` statement, while 3.6 and 3.7 they got the line number from the first decoration.