### PR TITLE
Tell Travis to run twisted-apidocs check under Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       env: TOX_ENV=test-py37
     - python: 3.8
       env: TOX_ENV=test-py38
-    - python: 2.7
+    - python: 3.8
       env: TOX_ENV=twisted-apidoc
 
   allow_failures:

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     ; Run current version against twisted trunk
     twisted-apidoc: rm -rf {toxworkdir}/twisted-trunk
     twisted-apidoc: git clone --depth 1 --branch trunk https://github.com/twisted/twisted.git {toxworkdir}/twisted-trunk
-    twisted-apidoc: /bin/sh -c "{toxworkdir}/twisted-trunk/bin/admin/build-apidocs {toxworkdir}/twisted-trunk/src {toxworkdir}/twisted-apidocs-build > {toxworkdir}/twisted-apidocs.log"
+    twisted-apidoc: /bin/sh -c "PYTHONPATH={toxworkdir}/twisted-trunk/src {toxworkdir}/twisted-trunk/bin/admin/build-apidocs {toxworkdir}/twisted-trunk/src {toxworkdir}/twisted-apidocs-build > {toxworkdir}/twisted-apidocs.log"
     twisted-apidoc: /bin/cat {toxworkdir}/twisted-apidocs.log
     ; Fail if the output of running pydoctor on Twisted is not emtpy.
     twisted-apidoc: /bin/sh -c "test ! -s {toxworkdir}/twisted-apidocs.log"


### PR DESCRIPTION
Twisted trunk no longer supports Python 2.7, so we need a Python 3.x
to be able to execute its release script and parse its code.

I picked 3.8 since the ast module has optional support for parsing
type comments since Python 3.8, see #202.