### PR TITLE
Improve resolving of cross-references

### DIFF
--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -24,8 +24,8 @@ The C{ParsedDocstring} output generation method
 (L{to_stan()<ParsedDocstring.to_stan>}) uses a
 L{DocstringLinker} to link the docstring output with the rest of
 the documentation that epydoc generates.  C{DocstringLinker}s are
-responsible for translating identifier crossreferences
-(L{translate_identifier_xref() <DocstringLinker.translate_identifier_xref>}).
+responsible for resolving identifier crossreferences
+(L{resolve_identifier_xref() <DocstringLinker.resolve_identifier_xref>}).
 
 Markup errors are represented using L{ParseError}s.  These exception
 classes record information about the cause, location, and severity of
@@ -183,29 +183,21 @@ class Field:
 ##################################################
 class DocstringLinker:
     """
-    A translator for crossreference links into and out of a
-    C{ParsedDocstring}.  C{DocstringLinker} is used by
-    C{ParsedDocstring} to convert these crossreference links into
-    appropriate output formats.  For example,
-    C{ParsedDocstring.to_stan} expects a C{DocstringLinker} that
-    converts crossreference links to HTML.
+    A resolver for crossreference links out of a C{ParsedDocstring}.
+    C{DocstringLinker} is used by C{ParsedDocstring} to look up the
+    target URL for crossreference links.
     """
 
-    def translate_identifier_xref(self, identifier, label=None):
+    def resolve_identifier_xref(self, identifier):
         """
-        Translate a crossreference link to a Python identifier to the
-        appropriate output format.  The output will typically include
-        a reference or pointer to the crossreference target.
+        Resolve a crossreference link to a Python identifier.
 
         @type identifier: C{string}
         @param identifier: The name of the Python identifier that
             should be linked to.
-        @type label: C{string} or C{None}
-        @param label: The label that should be used for the identifier,
-            if it's different from the name of the identifier.  This
-            should be expressed in the target markup language.
-        @rtype: C{string}
-        @return: The translated crossreference link.
+        @rtype: C{string} or C{None}
+        @return: The URL of the target, or None if the identifier
+            could not be resolved.
         """
         raise NotImplementedError()
 

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -195,9 +195,9 @@ class DocstringLinker:
         @type identifier: C{string}
         @param identifier: The name of the Python identifier that
             should be linked to.
-        @rtype: C{string} or C{None}
-        @return: The URL of the target, or None if the identifier
-            could not be resolved.
+        @rtype: C{string}
+        @return: The URL of the target
+        @raise LookupError: If C{identifier} could not be resolved.
         """
         raise NotImplementedError()
 

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -1335,7 +1335,9 @@ class ParsedEpytextDocstring(ParsedDocstring):
         elif tree.tag == 'uri':
             return tags.a(variables[0], href=variables[1], target='_top')
         elif tree.tag == 'link':
-            return linker.translate_identifier_xref(variables[1], variables[0])
+            label = tags.code(variables[0])
+            url = linker.resolve_identifier_xref(variables[1])
+            return label if url is None else tags.a(label, href=url)
         elif tree.tag == 'target':
             value, = variables
             return value

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -1336,8 +1336,12 @@ class ParsedEpytextDocstring(ParsedDocstring):
             return tags.a(variables[0], href=variables[1], target='_top')
         elif tree.tag == 'link':
             label = tags.code(variables[0])
-            url = linker.resolve_identifier_xref(variables[1])
-            return label if url is None else tags.a(label, href=url)
+            try:
+                url = linker.resolve_identifier_xref(variables[1])
+            except LookupError:
+                return label
+            else:
+                return tags.a(label, href=url)
         elif tree.tag == 'target':
             value, = variables
             return value

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -396,9 +396,13 @@ class _EpydocHTMLTranslator(HTMLTranslator):
         m = _TARGET_RE.match(node.astext())
         if m: text, target = m.groups()
         else: target = text = node.astext()
-        url = self._linker.resolve_identifier_xref(target)
         label = tags.code(text)
-        xref = label if url is None else tags.a(label, href=url)
+        try:
+            url = self._linker.resolve_identifier_xref(target)
+        except LookupError:
+            xref = label
+        else:
+            xref = tags.a(label, href=url)
         self.body.append(flatten(xref))
         raise SkipNode()
 

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -57,6 +57,7 @@ import docutils.nodes
 import docutils.transforms.frontmatter
 import docutils.utils
 
+from twisted.web.template import tags
 from pydoctor.epydoc.doctest import colorize_codeblock, colorize_doctest
 from pydoctor.epydoc.markup import (
     Field, ParseError, ParsedDocstring, flatten, html2stan
@@ -395,7 +396,9 @@ class _EpydocHTMLTranslator(HTMLTranslator):
         m = _TARGET_RE.match(node.astext())
         if m: text, target = m.groups()
         else: target = text = node.astext()
-        xref = self._linker.translate_identifier_xref(target, text)
+        url = self._linker.resolve_identifier_xref(target)
+        label = tags.code(text)
+        xref = label if url is None else tags.a(label, href=url)
         self.body.append(flatten(xref))
         raise SkipNode()
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -207,7 +207,7 @@ class _EpydocLinker(DocstringLinker):
             self.obj.report(
                 "invalid ref to '%s' resolved as '%s'" % (fullID, fullerID),
                 section='resolve_identifier_xref')
-        return None
+        raise LookupError(fullID)
 
 
 class FieldDesc(object):

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -40,7 +40,7 @@ def _find_stdlib_dir():
     return os.path.dirname(os.path.realpath(os_mod_path))
 
 STDLIB_DIR = _find_stdlib_dir()
-STDLIB_URL = 'http://docs.python.org/library/'
+STDLIB_URL = 'https://docs.python.org/3/library/'
 
 
 def link(o):

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -199,7 +199,11 @@ class _EpydocLinker(DocstringLinker):
         if target is not None:
             return self._objLink(target)
 
-        if fullID != fullerID:
+        if fullID == fullerID:
+            self.obj.report(
+                "invalid ref to '%s' not resolved" % (fullID,),
+                section='resolve_identifier_xref')
+        else:
             self.obj.report(
                 "invalid ref to '%s' resolved as '%s'" % (fullID, fullerID),
                 section='resolve_identifier_xref')

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -26,7 +26,20 @@ except ImportError:
     exceptions = builtins
 
 
-STDLIB_DIR = os.path.dirname(os.__file__)
+def _find_stdlib_dir():
+    """Find the standard library location for the currently running
+    Python interpreter.
+    """
+
+    # When running in a virtualenv, when some (but not all) modules
+    # may be symlinked. We want the actual installation location of
+    # the standard library, not the location of the virtualenv.
+    os_mod_path = os.__file__
+    if os_mod_path.endswith('.pyc') or os_mod_path.endswith('.pyo'):
+        os_mod_path = os_mod_path[:-1]
+    return os.path.dirname(os.path.realpath(os_mod_path))
+
+STDLIB_DIR = _find_stdlib_dir()
 STDLIB_URL = 'http://docs.python.org/library/'
 
 

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -114,7 +114,7 @@ def test_EpydocLinker_look_for_intersphinx_hit():
     assert 'http://tm.tld/some.html' == result
 
 
-def test_EpydocLinker_translate_identifier_xref_intersphinx_absolute_id():
+def test_EpydocLinker_resolve_identifier_xref_intersphinx_absolute_id():
     """
     Returns the link from Sphinx inventory based on a cross reference
     ID specified in absolute dotted path and with a custom pretty text for the
@@ -127,16 +127,12 @@ def test_EpydocLinker_translate_identifier_xref_intersphinx_absolute_id():
     target = model.Module(system, 'ignore-name')
     sut = epydoc2stan._EpydocLinker(target)
 
-    result = sut.translate_identifier_xref(
-        'base.module.other', 'base.module.pretty')
+    url = sut.resolve_identifier_xref('base.module.other')
 
-    expected = (
-        '<a href="http://tm.tld/some.html"><code>base.module.pretty</code></a>'
-        )
-    assert expected == flatten(result)
+    assert "http://tm.tld/some.html" == url
 
 
-def test_EpydocLinker_translate_identifier_xref_intersphinx_relative_id():
+def test_EpydocLinker_resolve_identifier_xref_intersphinx_relative_id():
     """
     Return the link from inventory using short names, by resolving them based
     on the imports done in the module.
@@ -155,16 +151,12 @@ def test_EpydocLinker_translate_identifier_xref_intersphinx_relative_id():
     sut = epydoc2stan._EpydocLinker(target)
 
     # This is called for the L{ext_module<Pretty Text>} markup.
-    result = sut.translate_identifier_xref(
-        'ext_module', 'Pretty Text')
+    url = sut.resolve_identifier_xref('ext_module')
 
-    expected = (
-        '<a href="http://tm.tld/some.html"><code>Pretty Text</code></a>'
-        )
-    assert expected == flatten(result)
+    assert "http://tm.tld/some.html" == url
 
 
-def test_EpydocLinker_translate_identifier_xref_intersphinx_link_not_found(capsys):
+def test_EpydocLinker_resolve_identifier_xref_intersphinx_link_not_found(capsys):
     """
     A message is sent to stdout when no link could be found for the reference,
     while returning the reference name without an A link tag.
@@ -182,9 +174,8 @@ def test_EpydocLinker_translate_identifier_xref_intersphinx_link_not_found(capsy
     sut = epydoc2stan._EpydocLinker(target)
 
     # This is called for the L{ext_module} markup.
-    result = sut.translate_identifier_xref(
-        fullID='ext_module', prettyID='ext_module')
-    assert '<code>ext_module</code>' == flatten(result)
+    url = sut.resolve_identifier_xref('ext_module')
+    assert None is url
 
     captured = capsys.readouterr().out
     expected = (

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 
+from pytest import raises
+
 from pydoctor import epydoc2stan, model
 from pydoctor.epydoc.markup import flatten
 from pydoctor.sphinx import SphinxInventory
@@ -174,8 +176,8 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_link_not_found(capsys)
     sut = epydoc2stan._EpydocLinker(target)
 
     # This is called for the L{ext_module} markup.
-    url = sut.resolve_identifier_xref('ext_module')
-    assert None is url
+    with raises(LookupError):
+        sut.resolve_identifier_xref('ext_module')
 
     captured = capsys.readouterr().out
     expected = (

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -183,3 +183,20 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_link_not_found(capsys)
         "resolved as 'ext_package.ext_module'\n"
         )
     assert expected == captured
+
+
+def test_EpydocLinker_resolve_identifier_xref_order(capsys):
+    """
+    Check that the best match is picked when there are multiple candidates.
+    """
+
+    mod = fromText('''
+    class C:
+        socket = None
+    ''')
+    linker = epydoc2stan._EpydocLinker(mod)
+
+    url = linker.resolve_identifier_xref('socket.socket')
+
+    assert epydoc2stan.STDLIB_URL + 'socket.html#socket.socket' == url
+    assert not capsys.readouterr().out


### PR DESCRIPTION
This includes some code cleanups, reduces the chance of false positive matches and adds a warning that is printed when the resolution fails.