### PR TITLE
Improve reporting of missing docstring fields

### DIFF
--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -609,8 +609,8 @@ def extract_fields(obj):
         if tag in ['ivar', 'cvar', 'var', 'type']:
             arg = field.arg()
             if arg is None:
-                obj.system.msg('epydoc2stan', '%s: Missing field name in @%s'
-                               % (obj.fullName(), tag))
+                obj.report("Missing field name in @%s" % (tag,),
+                           'docstring', field.lineno)
                 continue
             attrobj = obj.contents.get(arg)
             if attrobj is None:

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -71,6 +71,20 @@ def test_summary():
     assert u'No summary' == get_summary('no_summary')
 
 
+def test_missing_field_name(capsys):
+    fromText('''
+    """
+    A test module.
+
+    @ivar: Mystery variable.
+    @type: str
+    """
+    ''', modname='test')
+    captured = capsys.readouterr().out
+    assert captured == "test:5: Missing field name in @ivar\n" \
+                       "test:6: Missing field name in @type\n"
+
+
 def test_EpydocLinker_look_for_intersphinx_no_link():
     """
     Return None if inventory had no link for our markup.


### PR DESCRIPTION
The exact line number is now reported, instead of the name of the object the docstring belongs to.

The priority of these messages was also increased, so they are now no longer silenced by a single `--quiet` option, as is used when extracting Twisted's API docs.