### PR TITLE
Require Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,8 @@ language: python
 
 matrix:
   include:
-    - python: 2.7
+    - python: 3.6
       env: TOX_ENV=pyflakes
-    - python: pypy
-      env: TOX_ENV=test-pypy
-    - python: 2.7
-      env: TOX_ENV=test-py27-codecov-travis
     - python: 3.6
       env: TOX_ENV=test-py36
     - python: 3.7
@@ -45,4 +41,4 @@ deploy:
     # All branches is still required.
     # https://github.com/travis-ci/travis-ci/issues/1675
     all_branches: true
-    condition: "$TOX_ENV = test-py27-codecov-travis"
+    condition: "$TOX_ENV = test-py38-codecov-travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       env: TOX_ENV=test-py38-codecov-travis
     - python: 3.8
       env: TOX_ENV=twisted-apidoc
+    - python: pypy3
+      env: TOX_ENV=test-pypy3
 
   allow_failures:
     # Twisted trunk is broken for now.

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -1,7 +1,5 @@
 """Convert ASTs into L{pydoctor.model.Documentable} instances."""
 
-from __future__ import print_function
-
 import ast
 import sys
 from itertools import chain

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -630,8 +630,8 @@ class ASTBuilder:
         system.addObject(attr)
         return attr
 
-    def warning(self, type, detail):
-        self.system._warning(self.current, type, detail)
+    def warning(self, message, detail):
+        self.system._warning(self.current, message, detail)
 
     def processModuleAST(self, ast, mod):
         findAll(ast, mod)

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -567,7 +567,7 @@ def _annotation_for_elements(sequence):
         return None
 
 
-class ASTBuilder(object):
+class ASTBuilder:
     ModuleVistor = ModuleVistor
 
     def __init__(self, system):

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -8,7 +8,6 @@ from itertools import chain
 
 import astor
 from pydoctor import epydoc2stan, model
-from six import string_types
 
 
 def parseFile(path):
@@ -348,7 +347,7 @@ class ModuleVistor(ast.NodeVisitor):
             warn("Unable to figure out value for __doc__ assignment, "
                  "maybe too complex")
             return
-        if not isinstance(docstring, string_types):
+        if not isinstance(docstring, str):
             warn("Ignoring value assigned to __doc__: not a string")
             return
 
@@ -449,11 +448,11 @@ class ModuleVistor(ast.NodeVisitor):
                 args.append(arg.arg)
 
         varargname = node.args.vararg
-        if varargname and not isinstance(varargname, string_types):
+        if varargname and not isinstance(varargname, str):
             varargname = varargname.arg
 
         kwargname = node.args.kwarg
-        if kwargname and not isinstance(kwargname, string_types):
+        if kwargname and not isinstance(kwargname, str):
             kwargname = kwargname.arg
 
         defaults = []

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -428,8 +428,8 @@ class ModuleVistor(ast.NodeVisitor):
                         isstaticmethod = True
             if isstaticmethod:
                 if isclassmethod:
-                    func.report('%s is both classmethod and staticmethod' % (
-                                func.fullName(),))
+                    func.report(f'{func.fullName()} is both classmethod '
+                                f'and staticmethod')
                 else:
                     func.kind = 'Static Method'
             elif isclassmethod:
@@ -491,7 +491,7 @@ class ModuleVistor(ast.NodeVisitor):
             return _AnnotationStringParser().visit(node)
         except SyntaxError as ex:
             self.builder.currentMod.report(
-                    'syntax error in annotation: %s' % (ex,),
+                    f'syntax error in annotation: {ex}',
                     lineno_offset=node.lineno)
             return None
 
@@ -601,7 +601,7 @@ class ASTBuilder:
             obj.setLineNumber(lineno)
 
     def pop(self, obj):
-        assert self.current is obj, "%r is not %r"%(self.current, obj)
+        assert self.current is obj, f"{self.current!r} is not {obj!r}"
         self.current = self._stack.pop()
         if isinstance(obj, model.Module):
             self.currentMod = None

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -1,7 +1,5 @@
 """The command-line parsing and entry point."""
 
-from __future__ import print_function
-
 import datetime
 import os
 import sys

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -306,7 +306,7 @@ def main(args=sys.argv[1:]):
         system.process()
 
         if system.options.projectname is None:
-            name = '/'.join([ro.name for ro in system.rootobjects])
+            name = '/'.join(ro.name for ro in system.rootobjects)
             system.msg(
                 'warning',
                 'WARNING: guessing '+name+' for project name', thresh=-1)

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -180,7 +180,7 @@ def getparser():
 
 def readConfigFile(options):
     # this is all a bit horrible.  rethink, then rewrite!
-    for i, line in enumerate(open(options.configfile, 'rU')):
+    for i, line in enumerate(open(options.configfile)):
         line = line.strip()
         if not line or line.startswith('#'):
             continue

--- a/pydoctor/epydoc/doctest.py
+++ b/pydoctor/epydoc/doctest.py
@@ -153,8 +153,7 @@ def colorize_doctest_body(s):
         # Pre-example text:
         yield s[idx:match.start()]
         # Example source code:
-        for stan in colorize_codeblock_body(pysrc):
-            yield stan
+        yield from colorize_codeblock_body(pysrc)
         # Example output:
         if want:
             style = 'py-except' if EXCEPT_RE.match(want) else 'py-output'
@@ -171,8 +170,7 @@ def colorize_codeblock_body(s):
         start = match.start()
         if idx < start:
             yield s[idx:start]
-        for stan in subfunc(match):
-            yield stan
+        yield from subfunc(match)
         idx = match.end()
     # DOCTEST_RE matches end-of-string.
     assert idx == len(s)

--- a/pydoctor/epydoc/doctest.py
+++ b/pydoctor/epydoc/doctest.py
@@ -11,9 +11,10 @@ Syntax highlighting for blocks of Python code.
 
 __docformat__ = 'epytext en'
 
+import builtins
 import re
 import sys
-from six.moves import builtins
+
 from twisted.web.template import tags
 
 __all__ = ['colorize_codeblock', 'colorize_doctest']

--- a/pydoctor/epydoc/doctest.py
+++ b/pydoctor/epydoc/doctest.py
@@ -39,11 +39,10 @@ else:
 _BUILTINS = [_BI for _BI in dir(builtins) if not _BI.startswith('__')]
 
 #: A regexp group that matches keywords.
-_KEYWORD_GRP = '|'.join([r'\b%s\b' % _KW for _KW in _KEYWORDS])
+_KEYWORD_GRP = '|'.join(r'\b%s\b' % _KW for _KW in _KEYWORDS)
 
 #: A regexp group that matches Python builtins.
-_BUILTIN_GRP = (r'(?<!\.)(?:%s)' % '|'.join([r'\b%s\b' % _BI
-                                             for _BI in _BUILTINS]))
+_BUILTIN_GRP = r'(?<!\.)(?:%s)' % '|'.join(r'\b%s\b' % _BI for _BI in _BUILTINS)
 
 #: A regexp group that matches Python strings.
 _STRING_GRP = '|'.join(

--- a/pydoctor/epydoc/doctest.py
+++ b/pydoctor/epydoc/doctest.py
@@ -13,7 +13,6 @@ __docformat__ = 'epytext en'
 
 import builtins
 import re
-import sys
 
 from twisted.web.template import tags
 
@@ -21,19 +20,13 @@ __all__ = ['colorize_codeblock', 'colorize_doctest']
 
 #: A list of the names of all Python keywords.
 _KEYWORDS = [
-    'and', 'as', 'assert', 'break', 'class', 'continue', 'def', 'del',
-    'elif', 'else', 'except', 'finally', 'for', 'from', 'global',
-    'if', 'import', 'in', 'is', 'lambda', 'not', 'or', 'pass',
+    'and', 'as', 'assert', 'async', 'await', 'break', 'class', 'continue',
+    'def', 'del', 'elif', 'else', 'except', 'finally', 'for', 'from', 'global',
+    'if', 'import', 'in', 'is', 'lambda', 'nonlocal', 'not', 'or', 'pass',
     'raise', 'return', 'try', 'while', 'with', 'yield'
     ]
-if sys.version_info.major == 2:
-    # These became builtins in Python 3.
-    _KEYWORDS += ['exec', 'print']
-else:
-    _KEYWORDS += ['async', 'await', 'nonlocal']
-    # These are technically keywords since Python 3,
-    # but we don't want to colorize them as such:
-    #_KEYWORDS += ['None', 'True', 'False']
+# The following are technically keywords since Python 3,
+# but we don't want to colorize them as such: 'None', 'True', 'False'.
 
 #: A list of all Python builtins.
 _BUILTINS = [_BI for _BI in dir(builtins) if not _BI.startswith('__')]

--- a/pydoctor/epydoc/doctest.py
+++ b/pydoctor/epydoc/doctest.py
@@ -39,10 +39,10 @@ else:
 _BUILTINS = [_BI for _BI in dir(builtins) if not _BI.startswith('__')]
 
 #: A regexp group that matches keywords.
-_KEYWORD_GRP = '|'.join(r'\b%s\b' % _KW for _KW in _KEYWORDS)
+_KEYWORD_GRP = '|'.join(rf'\b{_KW}\b' for _KW in _KEYWORDS)
 
 #: A regexp group that matches Python builtins.
-_BUILTIN_GRP = r'(?<!\.)(?:%s)' % '|'.join(r'\b%s\b' % _BI for _BI in _BUILTINS)
+_BUILTIN_GRP = r'(?<!\.)(?:%s)' % '|'.join(rf'\b{_BI}\b' for _BI in _BUILTINS)
 
 #: A regexp group that matches Python strings.
 _STRING_GRP = '|'.join(
@@ -65,11 +65,11 @@ _DEFINE_GRP = r'\b(?:def|class)[ \t]+\w+'
 DEFINE_FUNC_RE = re.compile(r'(?P<def>\w+)(?P<space>\s+)(?P<name>\w+)')
 
 #: A regexp that matches Python prompts
-PROMPT_RE = re.compile('(%s|%s)' % (_PROMPT1_GRP, _PROMPT2_GRP),
+PROMPT_RE = re.compile(f'({_PROMPT1_GRP}|{_PROMPT2_GRP})',
                        re.MULTILINE | re.DOTALL)
 
 #: A regexp that matches Python "..." prompts.
-PROMPT2_RE = re.compile('(%s)' % _PROMPT2_GRP,
+PROMPT2_RE = re.compile(f'({_PROMPT2_GRP})',
                         re.MULTILINE | re.DOTALL)
 
 #: A regexp that matches doctest exception blocks.
@@ -83,13 +83,11 @@ DOCTEST_DIRECTIVE_RE = re.compile(r'#[ \t]*doctest:.*')
 #: that should be colored.
 DOCTEST_RE = re.compile(
     '('
-        r'(?P<STRING>%s)|(?P<COMMENT>%s)|(?P<DEFINE>%s)|'
-        r'(?P<KEYWORD>%s)|(?P<BUILTIN>%s)|'
-        r'(?P<PROMPT1>%s)|(?P<PROMPT2>%s)|(?P<EOS>\Z)'
-    ')' % (
-        _STRING_GRP, _COMMENT_GRP, _DEFINE_GRP, _KEYWORD_GRP, _BUILTIN_GRP,
-        _PROMPT1_GRP, _PROMPT2_GRP
-        ),
+        rf'(?P<STRING>{_STRING_GRP})|(?P<COMMENT>{_COMMENT_GRP})|'
+        rf'(?P<DEFINE>{_DEFINE_GRP})|'
+        rf'(?P<KEYWORD>{_KEYWORD_GRP})|(?P<BUILTIN>{_BUILTIN_GRP})|'
+        rf'(?P<PROMPT1>{_PROMPT1_GRP})|(?P<PROMPT2>{_PROMPT2_GRP})|(?P<EOS>\Z)'
+    ')',
     re.MULTILINE | re.DOTALL)
 
 #: This regular expression is used to find doctest examples in a

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -173,9 +173,9 @@ class Field:
 
     def __repr__(self):
         if self._arg is None:
-            return '<Field @%s: ...>' % self._tag
+            return f'<Field @{self._tag}: ...>'
         else:
-            return '<Field @%s %s: ...>' % (self._tag, self._arg)
+            return f'<Field @{self._tag} {self._arg}: ...>'
 
 ##################################################
 ## Docstring Linker (resolves crossreferences)
@@ -263,7 +263,7 @@ class ParseError(Exception):
         @rtype: C{string}
         """
         if self._linenum is not None:
-            return 'Line %d: %s' % (self._linenum + 1, self.descr())
+            return f'Line {self._linenum + 1:d}: {self.descr()}'
         else:
             return self.descr()
 
@@ -279,4 +279,4 @@ class ParseError(Exception):
         if self._linenum is None:
             return '<ParseError on unknown line>'
         else:
-            return '<ParseError on line %d>' % (self._linenum + 1)
+            return f'<ParseError on line {self._linenum + 1:d}>'

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -38,7 +38,6 @@ __docformat__ = 'epytext en'
 
 import re
 
-from six import text_type
 from twisted.web.template import XMLString, flattenString
 
 ##################################################
@@ -100,7 +99,7 @@ def html2stan(html):
     @type html: C{string}
     @return: The fragment as a tree with a transparent root node.
     """
-    if isinstance(html, text_type):
+    if isinstance(html, str):
         html = html.encode('utf8')
 
     html = _RE_CONTROL.sub(lambda m:b'\\x%02x' % ord(m.group()), html)

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -224,13 +224,13 @@ _LINK_COLORIZING_TAGS = ['link', 'uri']
 ## Structuring (Top Level)
 ##################################################
 
-def parse(str, errors = None):
+def parse(text, errors = None):
     """
     Return a DOM tree encoding the contents of an epytext string.  Any
     errors generated during parsing will be stored in C{errors}.
 
-    @param str: The epytext string to parse.
-    @type str: C{string}
+    @param text: The epytext string to parse.
+    @type text: C{str}
     @param errors: A list where any errors generated during parsing
         will be stored.  If no list is specified, then fatal errors
         will generate exceptions, and non-fatal errors will be
@@ -249,11 +249,11 @@ def parse(str, errors = None):
         raise_on_error = False
 
     # Preprocess the string.
-    str = re.sub('\015\012', '\012', str)
-    str = str.expandtabs()
+    text = re.sub('\015\012', '\012', text)
+    text = text.expandtabs()
 
     # Tokenize the input string.
-    tokens = _tokenize(str, errors)
+    tokens = _tokenize(text, errors)
 
     # Have we encountered a field yet?
     encountered_field = False
@@ -903,13 +903,13 @@ def _tokenize_para(lines, start, para_indent, tokens, errors):
     tokens.append(Token(Token.PARA, start, contents, para_indent))
     return linenum
 
-def _tokenize(str, errors):
+def _tokenize(text, errors):
     """
     Split a given formatted docstring into an ordered list of
     C{Token}s, according to the epytext markup rules.
 
-    @param str: The epytext string
-    @type str: C{string}
+    @param text: The epytext string
+    @type text: C{str}
     @param errors: A list where any errors generated during parsing
         will be stored.  If no list is specified, then errors will
         generate exceptions.
@@ -918,7 +918,7 @@ def _tokenize(str, errors):
     @rtype: C{list} of L{Token}
     """
     tokens = []
-    lines = str.split('\n')
+    lines = text.split('\n')
 
     # Scan through the lines, determining what @type of token we're
     # dealing with, and tokenizing it, as appropriate.
@@ -986,7 +986,7 @@ def _colorize(doc, token, errors, tagName='para'):
     @return: a DOM C{Element} encoding the given paragraph.
     @returntype: C{Element}
     """
-    str = token.contents
+    text = token.contents
 
     # Maintain a stack of DOM elements, containing the ancestors of
     # the text currently being analyzed.  New elements are pushed when
@@ -1005,7 +1005,7 @@ def _colorize(doc, token, errors, tagName='para'):
     # to the next open or close brace.
     start = 0
     while 1:
-        match = _BRACE_RE.search(str, start)
+        match = _BRACE_RE.search(text, start)
         if match is None: break
         end = match.start()
 
@@ -1016,19 +1016,19 @@ def _colorize(doc, token, errors, tagName='para'):
         # and convert them to literal braces once we find the matching
         # close-brace.
         if match.group() == '{':
-            if (end>0) and 'A' <= str[end-1] <= 'Z':
+            if (end>0) and 'A' <= text[end-1] <= 'Z':
                 if (end-1) > start:
-                    stack[-1].children.append(str[start:end-1])
-                if str[end-1] not in _COLORIZING_TAGS:
+                    stack[-1].children.append(text[start:end-1])
+                if text[end-1] not in _COLORIZING_TAGS:
                     estr = "Unknown inline markup tag."
                     errors.append(ColorizingError(estr, token, end-1))
                     stack.append(Element('unknown'))
                 else:
-                    tag = _COLORIZING_TAGS[str[end-1]]
+                    tag = _COLORIZING_TAGS[text[end-1]]
                     stack.append(Element(tag))
             else:
                 if end > start:
-                    stack[-1].children.append(str[start:end])
+                    stack[-1].children.append(text[start:end])
                 stack.append(Element('litbrace'))
             openbrace_stack.append(end)
             stack[-2].children.append(stack[-1])
@@ -1044,7 +1044,7 @@ def _colorize(doc, token, errors, tagName='para'):
 
             # Add any remaining text.
             if end > start:
-                stack[-1].children.append(str[start:end])
+                stack[-1].children.append(text[start:end])
 
             # Special handling for symbols:
             if stack[-1].tag == 'symbol':
@@ -1094,8 +1094,8 @@ def _colorize(doc, token, errors, tagName='para'):
         start = end+1
 
     # Add any final text.
-    if start < len(str):
-        stack[-1].children.append(str[start:])
+    if start < len(text):
+        stack[-1].children.append(text[start:])
 
     if len(stack) != 1:
         estr = "Unbalanced '{'."

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -108,7 +108,6 @@ __docformat__ = 'epytext en'
 #   5. testing
 
 import re
-import six
 from twisted.web.template import CharRef, Tag, tags
 from pydoctor.epydoc.doctest import colorize_doctest
 from pydoctor.epydoc.markup import Field, ParseError, ParsedDocstring
@@ -1049,7 +1048,7 @@ def _colorize(doc, token, errors, tagName='para'):
             # Special handling for symbols:
             if stack[-1].tag == 'symbol':
                 if (len(stack[-1].children) != 1 or
-                    not isinstance(stack[-1].children[0], six.string_types)):
+                    not isinstance(stack[-1].children[0], str)):
                     estr = "Invalid symbol code."
                     errors.append(ColorizingError(estr, token, end))
                 else:
@@ -1064,7 +1063,7 @@ def _colorize(doc, token, errors, tagName='para'):
             # Special handling for escape elements:
             if stack[-1].tag == 'escape':
                 if (len(stack[-1].children) != 1 or
-                    not isinstance(stack[-1].children[0], six.string_types)):
+                    not isinstance(stack[-1].children[0], str)):
                     estr = "Invalid escape code."
                     errors.append(ColorizingError(estr, token, end))
                 else:
@@ -1107,7 +1106,7 @@ def _colorize_link(doc, link, token, end, errors):
     variables = link.children[:]
 
     # If the last child isn't text, we know it's bad.
-    if len(variables)==0 or not isinstance(variables[-1], six.string_types):
+    if len(variables)==0 or not isinstance(variables[-1], str):
         estr = "Bad %s target." % link.tag
         errors.append(ColorizingError(estr, token, end))
         return
@@ -1315,7 +1314,7 @@ class ParsedEpytextDocstring(ParsedDocstring):
         return self._stan
 
     def _to_stan(self, tree, linker, seclevel=0):
-        if isinstance(tree, six.string_types):
+        if isinstance(tree, str):
             return tree
 
         if tree.tag == 'section':

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -142,14 +142,14 @@ class Element:
         notation.
         @bug: Doesn't escape '<' or '&' or '>'.
         """
-        attribs = ''.join([' %s=%r' % t for t in self.attribs.items()])
+        attribs = ''.join(' %s=%r' % t for t in self.attribs.items())
         return ('<%s%s>' % (self.tag, attribs) +
-                ''.join([str(child) for child in self.children]) +
+                ''.join(str(child) for child in self.children) +
                 '</%s>' % self.tag)
 
     def __repr__(self):
-        attribs = ''.join([', %s=%r' % t for t in self.attribs.items()])
-        args = ''.join([', %r' % c for c in self.children])
+        attribs = ''.join(', %s=%r' % t for t in self.attribs.items())
+        args = ''.join(', %r' % c for c in self.children)
         return 'Element(%s%s%s)' % (self.tag, args, attribs)
 
 ##################################################
@@ -274,8 +274,8 @@ def parse(text, errors = None):
     for token in tokens:
         # Uncomment this for debugging:
         #print('%s: %s\n%s: %s\n' %
-        #       (''.join(['%-11s' % (t and t.tag) for t in stack]),
-        #        token.tag, ''.join(['%-11s' % i for i in indent_stack]),
+        #       (''.join('%-11s' % (t and t.tag) for t in stack),
+        #        token.tag, ''.join('%-11s' % i for i in indent_stack),
         #        token.indent))
 
         # Pop any completed blocks off the stack.

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -96,8 +96,6 @@ Description::
 # Note: the symbol list is appended to the docstring automatically,
 # below.
 
-from __future__ import print_function
-
 __docformat__ = 'epytext en'
 
 # Code organization..

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -245,7 +245,7 @@ class _SplitFieldsTranslator(NodeVisitor):
                         return
                     except ValueError as e:
                         estr = 'Unable to split consolidated field '
-                        estr += '"%s" - %s' % (tagname, e)
+                        estr += f'"{tagname}" - {e}'
                         self._errors.append(ParseError(estr, node.line,
                                                        is_fatal=False))
 
@@ -439,12 +439,12 @@ class _EpydocHTMLTranslator(HTMLTranslator):
                 # Prefix all CSS classes with "rst-"; and prefix all
                 # names with "rst-" to avoid conflicts.
                 if key.lower() in ('class', 'id', 'name'):
-                    attr_dict[key] = 'rst-%s' % val
+                    attr_dict[key] = f'rst-{val}'
                 elif key.lower() in ('classes', 'ids', 'names'):
-                    attr_dict[key] = ['rst-%s' % cls for cls in val]
+                    attr_dict[key] = [f'rst-{cls}' for cls in val]
                 elif key.lower() == 'href':
                     if attr_dict[key][:1]=='#':
-                        attr_dict[key] = '#rst-%s' % attr_dict[key][1:]
+                        attr_dict[key] = f'#rst-{attr_dict[key][1:]}'
                     else:
                         # If it's an external link, open it in a new
                         # page.

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -177,8 +177,8 @@ class _EpydocReader(StandaloneReader):
         try: linenum = int(error['line'])
         except: linenum = None
 
-        msg = ''.join([c.astext().encode(self._encoding, self._error_handler)
-                       for c in error])
+        msg = ''.join(c.astext().encode(self._encoding, self._error_handler)
+                      for c in error)
 
         self._errors.append(ParseError(msg, linenum, is_fatal))
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -13,7 +13,6 @@ import sys
 
 from pydoctor import model
 from pydoctor.epydoc.markup import ParseError
-from six import string_types
 from six.moves import builtins
 from six.moves.urllib.parse import quote
 from twisted.web.template import Tag, tags
@@ -439,7 +438,7 @@ def reportErrors(obj, errs):
 
         for err in errs:
             lineno_offset = 0
-            if isinstance(err, string_types):
+            if isinstance(err, str):
                 descr = err
             elif isinstance(err, ParseError):
                 descr = err.descr()

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -7,14 +7,14 @@ from __future__ import print_function
 import astor
 
 from importlib import import_module
+from urllib.parse import quote
+import builtins
 import itertools
 import os
 import sys
 
 from pydoctor import model
 from pydoctor.epydoc.markup import ParseError
-from six.moves import builtins
-from six.moves.urllib.parse import quote
 from twisted.web.template import Tag, tags
 from pydoctor.epydoc.markup import DocstringLinker, ParsedDocstring
 import pydoctor.epydoc.markup.plaintext

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -210,7 +210,7 @@ class _EpydocLinker(DocstringLinker):
         raise LookupError(fullID)
 
 
-class FieldDesc(object):
+class FieldDesc:
     def __init__(self):
         self.kind = None
         self.name = None
@@ -281,7 +281,7 @@ def format_field_list(obj, singular, fields, plural=None):
     return rows
 
 
-class Field(object):
+class Field:
     """Like pydoctor.epydoc.markup.Field, but without the gross accessor
     methods and with a formatted body."""
     def __init__(self, field, obj):
@@ -297,7 +297,7 @@ class Field(object):
         return "<%s %r %r %s %d>"%(self.__class__.__name__,
                              self.tag, self.arg, self.lineno, r)
 
-class FieldHandler(object):
+class FieldHandler:
     def __init__(self, obj):
         self.obj = obj
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -108,7 +108,7 @@ class _EpydocLinker(DocstringLinker):
             return link(obj)
         else:
             raise AssertionError(
-                "Unknown documentation_location: %s" % obj.documentation_location)
+                f"Unknown documentation_location: {obj.documentation_location}")
 
     def look_for_name(self, name, candidates):
         part0 = name.split('.')[0]
@@ -222,10 +222,11 @@ class FieldDesc:
             body = body, ' (type: ', self.type, ')'
         return body
     def __repr__(self):
-        contents = []
-        for k, v in self.__dict__.items():
-            contents.append("%s=%r"%(k, v))
-        return "<%s(%s)>"%(self.__class__.__name__, ', '.join(contents))
+        contents = ', '.join(
+            f"{k}={v!r}"
+            for k, v in self.__dict__.items()
+            )
+        return f"<{self.__class__.__name__}({contents})>"
 
 
 def format_desc_list(singular, descs, plural=None):
@@ -461,7 +462,7 @@ def parse_docstring(obj, doc, source):
     try:
         pdoc = parser(doc, errs)
     except Exception as e:
-        errs.append('%s: %s' % (e.__class__.__name__, e))
+        errs.append(f'{e.__class__.__name__}: {e}')
         pdoc = None
     if pdoc is None:
         pdoc = pydoctor.epydoc.markup.plaintext.parse_docstring(doc, errs)
@@ -490,7 +491,7 @@ def format_docstring(obj):
     try:
         stan = pdoc.to_stan(_EpydocLinker(source))
     except Exception as e:
-        errs = ['%s: %s' % (e.__class__.__name__, e)]
+        errs = [f'{e.__class__.__name__}: {e}']
         if doc is None:
             stan = tags.p(class_="undocumented")('Broken description')
         else:
@@ -559,13 +560,14 @@ def format_undocumented(obj):
         subcounts['module'] -= 1
     if subdocstrings:
         plurals = {'class': 'classes'}
-        text = "No %s docstring; %s documented" % (
-            obj.kind.lower(),
+        text = (
+            "No ", obj.kind.lower(), " docstring; "
             ', '.join(
-                "%s/%s %s" % (subdocstrings.get(k, 0), subcounts[k],
-                              plurals.get(k, k + 's'))
+                f"{subdocstrings.get(k, 0)}/{subcounts[k]} "
+                f"{plurals.get(k, k + 's')}"
                 for k in sorted(subcounts)
-                )
+                ),
+            " documented"
             )
     else:
         text = "Undocumented"

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -2,8 +2,6 @@
 Convert epydoc markup into renderable content.
 """
 
-from __future__ import print_function
-
 import astor
 
 from importlib import import_module

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -416,16 +416,10 @@ class FieldHandler:
                         ('Note', 'Notes', self.notes)):
             r.append(format_field_list(self.obj, s, l, p))
         unknowns = {}
-        unknownsinorder = []
         for fieldinfo in self.unknowns:
-            tag = fieldinfo.kind
-            if tag in unknowns:
-                unknowns[tag].append(fieldinfo)
-            else:
-                unknowns[tag] = [fieldinfo]
-                unknownsinorder.append(unknowns[tag])
-        for fieldlist in unknownsinorder:
-            label = "Unknown Field: " + fieldlist[0].kind
+            unknowns.setdefault(fieldinfo.kind, []).append(fieldinfo)
+        for kind, fieldlist in unknowns.items():
+            label = f"Unknown Field: {kind}"
             r.append(format_desc_list(label, fieldlist, label))
 
         return tags.table(class_='fieldTable')(r)

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -14,7 +14,6 @@ import os
 import platform
 import sys
 import types
-from collections import OrderedDict
 from enum import Enum
 
 from pydoctor.sphinx import SphinxInventory
@@ -85,7 +84,7 @@ class Documentable:
             self.doctarget = self
 
     def setup(self):
-        self.contents = OrderedDict()
+        self.contents = {}
 
     def setDocstring(self, node):
         doc = node.s
@@ -404,7 +403,7 @@ class System:
     sourcebase = None
 
     def __init__(self, options=None):
-        self.allobjects = OrderedDict()
+        self.allobjects = {}
         self.rootobjects = []
         self.warnings = {}
         self.packages = []

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -285,7 +285,7 @@ class ProcessingState(Enum):
 
 class CanContainImportsDocumentable(Documentable):
     def setup(self):
-        super(CanContainImportsDocumentable, self).setup()
+        super().setup()
         self._localNameToFullName_map = {}
 
 
@@ -294,7 +294,7 @@ class Module(CanContainImportsDocumentable):
     state = ProcessingState.UNPROCESSED
 
     def setup(self):
-        super(Module, self).setup()
+        super().setup()
         self.all = None
 
     def _localNameToFullName(self, name):
@@ -327,7 +327,7 @@ class Module(CanContainImportsDocumentable):
 class Class(CanContainImportsDocumentable):
     kind = "Class"
     def setup(self):
-        super(Class, self).setup()
+        super().setup()
         self.rawbases = []
         self.subclasses = []
 
@@ -365,7 +365,7 @@ class Function(Inheritable):
     kind = "Function"
 
     def setup(self):
-        super(Function, self).setup()
+        super().setup()
         if isinstance(self.parent, Class):
             self.kind = "Method"
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -115,7 +115,7 @@ class Documentable:
             if parentMod is not None:
                 parentSourceHref = parentMod.sourceHref
                 if parentSourceHref:
-                    self.sourceHref = '%s#L%d' % (parentSourceHref, lineno)
+                    self.sourceHref = f'{parentSourceHref}#L{lineno:d}'
 
     def fullName(self):
         parent = self.parent
@@ -131,7 +131,7 @@ class Documentable:
         return prefix + self.name
 
     def __repr__(self):
-        return "%s %r"%(self.__class__.__name__, self.fullName())
+        return f"{self.__class__.__name__} {self.fullName()!r}"
 
     def docsources(self):
         """Objects that can be considered as a source of documentation.
@@ -251,7 +251,7 @@ class Documentable:
 
         self.system.msg(
             section,
-            '%s:%s: %s' % (self.module.description, linenumber, descr),
+            f'{self.module.description}:{linenumber}: {descr}',
             thresh=-1)
 
 
@@ -442,7 +442,7 @@ class System:
         if n is None:
             i = str(i)
         else:
-            i = '%s/%s'%(i,n)
+            i = f'{i}/{n}'
         if self.verbosity(section) == 0 and sys.stdout.isatty():
             print('\r'+i, msg, end='')
             sys.stdout.flush()
@@ -600,8 +600,7 @@ class System:
 
     def addPackage(self, dirpath, parentPackage=None):
         if not os.path.exists(dirpath):
-            raise Exception("package path %r does not exist!"
-                            %(dirpath,))
+            raise Exception(f"package path {dirpath!r} does not exist!")
         if not os.path.exists(os.path.join(dirpath, '__init__.py')):
             raise Exception("you must pass a package directory to "
                             "addPackage")
@@ -632,8 +631,7 @@ class System:
                 if not self.options.introspect_c_modules:
                     continue
                 if package is not None:
-                    module_full_name = "%s.%s" % (
-                        package.fullName(), module_name)
+                    module_full_name = f'{package.fullName()}.{module_name}'
                 else:
                     module_full_name = module_name
                 py_mod = imp.load_module(
@@ -709,12 +707,12 @@ class System:
             head = self.processing_modules.pop()
             assert head == mod.fullName()
         self.unprocessed_modules.remove(mod)
+        num_warnings = sum(len(v) for v in self.warnings.values())
         self.progress(
             'process',
             self.module_count - len(self.unprocessed_modules),
             self.module_count,
-            "modules processed %s warnings"%(
-            sum(len(v) for v in self.warnings.values()),))
+            f"modules processed {num_warnings} warnings")
 
 
     def process(self):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -8,6 +8,7 @@ being documented -- a System is a bad of Documentables, in some sense.
 
 from __future__ import print_function, unicode_literals
 
+import builtins
 import datetime
 import imp
 import inspect
@@ -19,7 +20,6 @@ from collections import OrderedDict
 from enum import Enum
 
 from pydoctor.sphinx import SphinxInventory
-from six.moves import builtins
 
 # originally when I started to write pydoctor I had this idea of a big
 # tree of Documentables arranged in an almost arbitrary tree.

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -475,14 +475,14 @@ class System:
     def objForFullName(self, fullName):
         return self.allobjects.get(fullName)
 
-    def _warning(self, current, type, detail):
+    def _warning(self, current, message, detail):
         if current is not None:
             fn = current.fullName()
         else:
             fn = '<None>'
         if self.options.verbosity > 0:
-            print(fn, type, detail)
-        self.warnings.setdefault(type, []).append((fn, detail))
+            print(fn, message, detail)
+        self.warnings.setdefault(message, []).append((fn, detail))
 
     def objectsOfType(self, cls):
         """Iterate over all instances of C{cls} present in the system. """
@@ -627,11 +627,11 @@ class System:
                 self.addModuleFromPath(package, fullname)
 
     def addModuleFromPath(self, package, path):
-        for (suffix, mode, type) in imp.get_suffixes():
+        for (suffix, mode, impl) in imp.get_suffixes():
             if not path.endswith(suffix):
                 continue
             module_name = os.path.basename(path[:-len(suffix)])
-            if type == imp.C_EXTENSION:
+            if impl == imp.C_EXTENSION:
                 if not self.options.introspect_c_modules:
                     continue
                 if package is not None:
@@ -641,9 +641,9 @@ class System:
                     module_full_name = module_name
                 py_mod = imp.load_module(
                     module_full_name, open(path, 'rb'), path,
-                    (suffix, mode, type))
+                    (suffix, mode, impl))
                 self.introspectModule(py_mod, module_full_name)
-            elif type == imp.PY_SOURCE:
+            elif impl == imp.PY_SOURCE:
                 self.addModule(path, module_name, package)
             break
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -6,8 +6,6 @@ system being documented.  An instance of L{System} represents the whole system
 being documented -- a System is a bad of Documentables, in some sense.
 """
 
-from __future__ import print_function, unicode_literals
-
 import builtins
 import datetime
 import imp

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -434,7 +434,8 @@ class System:
     def verbosity(self, section=None):
         if isinstance(section, str):
             section = (section,)
-        delta = max([self.options.verbosity_details.get(sect, 0) for sect in section])
+        delta = max(self.options.verbosity_details.get(sect, 0)
+                    for sect in section)
         return self.options.verbosity + delta
 
     def progress(self, section, i, n, msg):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -335,10 +335,8 @@ class Class(CanContainImportsDocumentable):
         if include_self:
             yield self
         for b in self.baseobjects:
-            if b is None:
-                continue
-            for b2 in b.allbases(True):
-                yield b2
+            if b is not None:
+                yield from b.allbases(True)
     def _localNameToFullName(self, name):
         if name in self.contents:
             o = self.contents[name]

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -49,7 +49,7 @@ class DocLocation(Enum):
     #UNDER_PARENT_DOCSTRING = 3
 
 
-class Documentable(object):
+class Documentable:
     """An object that can be documented.
 
     The interface is a bit ridiculously wide.
@@ -182,7 +182,7 @@ class Documentable(object):
         mod1.py::
 
             from external_location import External
-            class Local(object):
+            class Local:
                 pass
 
         mod2.py::
@@ -391,7 +391,7 @@ class PrivacyClass(Enum):
 
 
 
-class System(object):
+class System:
     """A collection of related documentable objects.
 
     PyDoctor documents collections of objects, often the contents of a

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -1,7 +1,6 @@
 """
 Support for Sphinx compatibility.
 """
-from __future__ import absolute_import, print_function
 
 import logging
 import os

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -110,7 +110,7 @@ class SphinxInventory:
         if relative_link.endswith('$'):
             relative_link = relative_link[:-1] + name
 
-        return '%s/%s' % (base_url, relative_link)
+        return f'{base_url}/{relative_link}'
 
 
 class SphinxInventoryWriter:
@@ -147,12 +147,11 @@ class SphinxInventoryWriter:
         """
         Return header for project  with name.
         """
-        version = [str(part) for part in self.version]
-        return ("""# Sphinx inventory version 2
-# Project: %s
-# Version: %s
+        return f"""# Sphinx inventory version 2
+# Project: {self.project_name}
+# Version: {'.'.join(str(part) for part in self.version)}
 # The rest of this file is compressed with zlib.
-""" % (self.project_name, '.'.join(version))).encode('utf-8')
+""".encode('utf-8')
 
     def _generateContent(self, subjects):
         """
@@ -204,7 +203,7 @@ class SphinxInventoryWriter:
             self.error(
                 'sphinx', "Unknown type %r for %s." % (type(obj), full_name,))
 
-        return '%s py:%s -1 %s %s\n' % (full_name, domainname, url, display)
+        return f'{full_name} py:{domainname} -1 {url} {display}\n'
 
 
 USER_INTERSPHINX_CACHE = appdirs.user_cache_dir("pydoctor")
@@ -242,16 +241,16 @@ _maxAgeUnits = {
     "w": _Unit("weeks", minimum=1, maximum=(999999999 + 1) // 7),
 }
 _maxAgeUnitNames = ", ".join(
-    "{} ({})".format(indicator, unit.name)
+    f"{indicator} ({unit.name})"
     for indicator, unit in _maxAgeUnits.items()
 )
 
 
 MAX_AGE_HELP = textwrap.dedent(
-    """
+    f"""
     The maximum age of any entry in the cache.  Of the format
-    <int><unit> where <unit> is one of {}.
-    """.format(_maxAgeUnitNames)
+    <int><unit> where <unit> is one of {_maxAgeUnitNames}.
+    """
 )
 MAX_AGE_DEFAULT = '1w'
 
@@ -272,13 +271,13 @@ def parseMaxAge(maxAge):
         unit = _maxAgeUnits[maxAge[-1]]
     except (IndexError, KeyError):
         raise InvalidMaxAge(
-            "Maximum age's units must be one of {}".format(_maxAgeUnitNames))
+            f"Maximum age's units must be one of {_maxAgeUnitNames}")
 
     if not (unit.minimum <= amount < unit.maximum):
         raise InvalidMaxAge(
-            "Maximum age in {} must be "
-            "greater than or equal to {} "
-            "and less than {}".format(unit.name, unit.minimum, unit.maximum))
+            f"Maximum age in {unit.name} must be "
+            f"greater than or equal to {unit.minimum} "
+            f"and less than {unit.maximum}")
 
     return {unit.name: amount}
 

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -19,7 +19,7 @@ from cachecontrol.heuristics import ExpiresAfter
 logger = logging.getLogger(__name__)
 
 
-class SphinxInventory(object):
+class SphinxInventory:
     """
     Sphinx inventory handler.
     """
@@ -114,7 +114,7 @@ class SphinxInventory(object):
         return '%s/%s' % (base_url, relative_link)
 
 
-class SphinxInventoryWriter(object):
+class SphinxInventoryWriter:
     """
     Sphinx inventory handler.
     """
@@ -212,7 +212,7 @@ USER_INTERSPHINX_CACHE = appdirs.user_cache_dir("pydoctor")
 
 
 @attr.s
-class _Unit(object):
+class _Unit:
     """
     A unit of time for maximum age parsing.
 
@@ -301,7 +301,7 @@ parseMaxAge.__doc__ = (
 
 
 @attr.s
-class IntersphinxCache(object):
+class IntersphinxCache:
     """
     An Intersphinx cache.
 
@@ -354,7 +354,7 @@ class IntersphinxCache(object):
 
 
 @attr.s
-class StubCache(object):
+class StubCache:
     """
     A stub cache.
 

--- a/pydoctor/templatewriter/__init__.py
+++ b/pydoctor/templatewriter/__init__.py
@@ -1,7 +1,5 @@
 """Render pydoctor data as HTML."""
 
-from __future__ import print_function
-
 DOCTYPE = b'''\
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -187,8 +187,8 @@ class CommonPage(Element):
 
 class PackagePage(CommonPage):
     def children(self):
-        return sorted([o for o in self.ob.contents.values()
-                       if o.name != '__init__' and o.isVisible],
+        return sorted((o for o in self.ob.contents.values()
+                       if o.name != '__init__' and o.isVisible),
                       key=lambda o2:(-o2.privacyClass.value, o2.fullName()))
 
     def packageInitTable(self):
@@ -229,9 +229,11 @@ def nested_bases(b):
     return r
 
 def unmasked_attrs(baselist):
-    maybe_masking = set()
-    for b in baselist[1:]:
-        maybe_masking.update(set([o.name for o in b.contents.values()]))
+    maybe_masking = {
+        o.name
+        for b in baselist[1:]
+        for o in b.contents.values()
+        }
     return [o for o in baselist[0].contents.values()
             if o.isVisible and o.name not in maybe_masking]
 
@@ -352,7 +354,9 @@ class ZopeInterfaceClassPage(ClassPage):
     def extras(self):
         r = [super().extras()]
         if self.ob.isinterface:
-            namelist = sorted([o.fullName() for o in self.ob.implementedby_directly], key=lambda x:x.lower())
+            namelist = sorted(
+                    (o.fullName() for o in self.ob.implementedby_directly),
+                    key=lambda x:x.lower())
             label = 'Known implementations: '
         else:
             namelist = sorted(self.ob.implements_directly, key=lambda x:x.lower())

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -40,11 +40,12 @@ def signature(argspec):
         else:
             things.append(regarg)
     if varargname:
-        things.append('*%s' % varargname)
+        things.append(f'*{varargname}')
 
-    things += ['%s=%s' % kwarg for kwarg in kwargs]
+    for k, v in kwargs:
+        things.append(f'{k}={v}')
     if varkwname:
-        things.append('**%s' % varkwname)
+        things.append(f'**{varkwname}')
     return ', '.join(things)
 
 class DocGetter:

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -217,8 +217,7 @@ def overriding_subclasses(c, name, firstcall=True):
     else:
         for sc in c.subclasses:
             if sc.isVisible:
-                for sc2 in overriding_subclasses(sc, name, False):
-                    yield sc2
+                yield from overriding_subclasses(sc, name, False)
 
 def nested_bases(b):
     r = [(b,)]

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -273,7 +273,7 @@ class ClassPage(CommonPage):
         self.overridenInCount = 0
 
     def extras(self):
-        r = super(ClassPage, self).extras()
+        r = super().extras()
         scs = sorted(self.ob.subclasses, key=lambda o:o.fullName().lower())
         if not scs:
             return r
@@ -284,7 +284,7 @@ class ClassPage(CommonPage):
         return r
 
     def mediumName(self, ob):
-        r = [super(ClassPage, self).mediumName(ob)]
+        r = [super().mediumName(ob)]
         zipped = list(zip(self.ob.rawbases, self.ob.bases, self.ob.baseobjects))
         if zipped:
             r.append('(')
@@ -350,7 +350,7 @@ class ClassPage(CommonPage):
 
 class ZopeInterfaceClassPage(ClassPage):
     def extras(self):
-        r = [super(ZopeInterfaceClassPage, self).extras()]
+        r = [super().extras()]
         if self.ob.isinterface:
             namelist = sorted([o.fullName() for o in self.ob.implementedby_directly], key=lambda x:x.lower())
             label = 'Known implementations: '
@@ -378,11 +378,9 @@ class ZopeInterfaceClassPage(ClassPage):
         r = []
         if imeth:
             r.append(tags.div(class_="interfaceinfo")('from ', util.taglink(imeth, imeth.parent.fullName())))
-        r.extend(super(ZopeInterfaceClassPage, self).functionExtras(data))
+        r.extend(super().functionExtras(data))
         return r
 
 class FunctionPage(CommonPage):
     def mediumName(self, ob):
-        return [
-            super(FunctionPage, self).mediumName(ob), '(',
-            signature(self.ob.argspec), ')']
+        return [super().mediumName(ob), '(', signature(self.ob.argspec), ')']

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -49,7 +49,7 @@ def signature(argspec):
         things.append('**%s' % varkwname)
     return ', '.join(things)
 
-class DocGetter(object):
+class DocGetter:
     def get(self, ob, summary=False):
         if summary:
             return epydoc2stan.format_summary(ob)

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -1,7 +1,5 @@
 """The classes that turn  L{Documentable} instances into objects we can render."""
 
-from __future__ import print_function
-
 from twisted.web.template import tags, Element, renderer, XMLFile
 
 from pydoctor import epydoc2stan, model

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from pydoctor.templatewriter import util
 from twisted.web.template import Element, XMLFile, renderer
 

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import ast
 
 import astor

--- a/pydoctor/templatewriter/pages/table.py
+++ b/pydoctor/templatewriter/pages/table.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from pydoctor.templatewriter import util
 from twisted.web.template import Element, TagLoader, XMLFile, renderer
 

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -1,7 +1,5 @@
 """Classes that generate the summary pages."""
 
-from __future__ import print_function
-
 from pydoctor import epydoc2stan, model
 from pydoctor.templatewriter import util
 from twisted.web.template import Element, TagLoader, XMLFile, renderer, tags

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -1,7 +1,5 @@
 """Miscellaneous utilities."""
 
-from __future__ import print_function
-
 from urllib.parse import quote
 import os
 

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -2,13 +2,12 @@
 
 from __future__ import print_function
 
+from urllib.parse import quote
 import os
 
 from pydoctor import model
 from twisted.python.filepath import FilePath
 from twisted.web.template import tags
-
-from six.moves.urllib.parse import quote
 
 def link(o):
     if not o.isVisible:

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -37,7 +37,7 @@ def taglink(o, label=None):
         linktext = link(o)
     else:
         raise AssertionError(
-            "Unknown documentation_location: %s" % o.documentation_location)
+            f"Unknown documentation_location: {o.documentation_location}")
     # Create a link to the object, with a "data-type" attribute which says what
     # kind of object it is (class, etc). This helps doc2dash figure out what it
     # is.

--- a/pydoctor/templatewriter/writer.py
+++ b/pydoctor/templatewriter/writer.py
@@ -1,7 +1,5 @@
 """Badly named module that contains the driving code for the rendering."""
 
-from __future__ import print_function
-
 import os
 import shutil
 

--- a/pydoctor/test/__init__.py
+++ b/pydoctor/test/__init__.py
@@ -5,5 +5,4 @@ import sys
 import pytest
 
 py3only = pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python 3")
-py2only = pytest.mark.skipif(sys.version_info >= (3, 0), reason="requires python 2")
 typecomment = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python 3.8")

--- a/pydoctor/test/__init__.py
+++ b/pydoctor/test/__init__.py
@@ -1,6 +1,5 @@
 """PyDoctor's test suite."""
 
-from __future__ import print_function
 import sys
 import pytest
 

--- a/pydoctor/test/__init__.py
+++ b/pydoctor/test/__init__.py
@@ -4,5 +4,4 @@ from __future__ import print_function
 import sys
 import pytest
 
-py3only = pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python 3")
 typecomment = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python 3.8")

--- a/pydoctor/test/epydoc/restructuredtext.doctest
+++ b/pydoctor/test/epydoc/restructuredtext.doctest
@@ -7,7 +7,7 @@ Regression Testing for restructuredtext
 ...     errors = []
 ...     parsed = restructuredtext.parse_docstring(s, errors)
 ...     for error in errors:
-...         print('ERROR: %s' % error)
+...         print(f'ERROR: {error}')
 ...     if parsed is None:
 ...         print('EMPTY BODY')
 ...     else:
@@ -16,9 +16,9 @@ Regression Testing for restructuredtext
 ...         body = flatten(field.body().to_stan(None))
 ...         arg = field.arg()
 ...         if arg is None:
-...             print('%s: %s' % (field.tag(), body))
+...             print(f'{field.tag()}: {body}')
 ...         else:
-...             print('%s "%s": %s' % (field.tag(), arg, body))
+...             print(f'{field.tag()} "{arg}": {body}')
 
 Fields
 ======

--- a/pydoctor/test/epydoc/test_epytext.py
+++ b/pydoctor/test/epydoc/test_epytext.py
@@ -31,22 +31,22 @@ def test_basic_list():
     for p in (P1, P2):
         for li1 in (LI1, LI2, LI3, LI4):
             assert parse(li1) == ONELIST
-            assert parse('%s\n%s' % (p, li1)) == PARA+ONELIST
-            assert parse('%s\n%s' % (li1, p)) == ONELIST+PARA
-            assert parse('%s\n%s\n%s' % (p, li1, p)) == PARA+ONELIST+PARA
+            assert parse(f'{p}\n{li1}') == PARA+ONELIST
+            assert parse(f'{li1}\n{p}') == ONELIST+PARA
+            assert parse(f'{p}\n{li1}\n{p}') == PARA+ONELIST+PARA
 
             for li2 in (LI1, LI2, LI3, LI4):
-                assert parse('%s\n%s' % (li1, li2)) == TWOLIST
-                assert parse('%s\n%s\n%s' % (p, li1, li2)) == PARA+TWOLIST
-                assert parse('%s\n%s\n%s' % (li1, li2, p)) == TWOLIST+PARA
-                assert parse('%s\n%s\n%s\n%s' % (p, li1, li2, p)) == PARA+TWOLIST+PARA
+                assert parse(f'{li1}\n{li2}') == TWOLIST
+                assert parse(f'{p}\n{li1}\n{li2}') == PARA+TWOLIST
+                assert parse(f'{li1}\n{li2}\n{p}') == TWOLIST+PARA
+                assert parse(f'{p}\n{li1}\n{li2}\n{p}') == PARA+TWOLIST+PARA
 
     LI5 = "  - This is a list item.\n\n    It contains two paragraphs."
     LI5LIST = ('<ulist><li><para inline=True>This is a list item.</para>'
                '<para>It contains two paragraphs.</para></li></ulist>')
     assert parse(LI5) == LI5LIST
-    assert parse('%s\n%s' % (P1, LI5)) == PARA+LI5LIST
-    assert parse('%s\n%s\n%s' % (P2, LI5, P1)) == PARA+LI5LIST+PARA
+    assert parse(f'{P1}\n{LI5}') == PARA+LI5LIST
+    assert parse(f'{P2}\n{LI5}\n{P1}') == PARA+LI5LIST+PARA
 
     LI6 = ("  - This is a list item with a literal block::\n"
            "    hello\n      there")
@@ -54,8 +54,8 @@ def test_basic_list():
                'block:</para><literalblock>  hello\n    there'
                '</literalblock></li></ulist>')
     assert parse(LI6) == LI6LIST
-    assert parse('%s\n%s' % (P1, LI6)) == PARA+LI6LIST
-    assert parse('%s\n%s\n%s' % (P2, LI6, P1)) == PARA+LI6LIST+PARA
+    assert parse(f'{P1}\n{LI6}') == PARA+LI6LIST
+    assert parse(f'{P2}\n{LI6}\n{P1}') == PARA+LI6LIST+PARA
 
 
 def test_item_wrap():

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import textwrap
 
 import astor

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -11,7 +11,7 @@ from pydoctor.epydoc.markup import flatten
 from pydoctor.epydoc2stan import get_parsed_type
 from pydoctor.zopeinterface import ZopeInterfaceSystem
 
-from . import py3only, typecomment
+from . import typecomment
 import pytest
 
 
@@ -489,7 +489,6 @@ def test_inline_docstring_classvar(systemcls):
     assert b.docstring == """inline doc for _b"""
     assert b.privacyClass is model.PrivacyClass.PRIVATE
 
-@py3only
 @systemcls_param
 def test_inline_docstring_annotated_classvar(systemcls):
     mod = fromText('''
@@ -573,7 +572,6 @@ def test_inline_docstring_instancevar(systemcls):
     assert f.privacyClass is model.PrivacyClass.VISIBLE
     assert f.kind == 'Instance Variable'
 
-@py3only
 @systemcls_param
 def test_inline_docstring_annotated_instancevar(systemcls):
     mod = fromText('''
@@ -774,7 +772,6 @@ def test_variable_types(systemcls):
     assert str(unwrap(g.parsed_type)) == 'string'
     assert g.kind == 'Instance Variable'
 
-@py3only
 @systemcls_param
 def test_annotated_variables(systemcls):
     mod = fromText('''
@@ -856,7 +853,6 @@ def test_type_comment(systemcls, capsys):
     assert type2str(mod.contents['i'].annotation) == 'List'
     assert not capsys.readouterr().out
 
-@py3only
 @systemcls_param
 def test_bad_string_annotation(systemcls, capsys):
     mod = fromText('''

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -11,7 +11,7 @@ from pydoctor.epydoc.markup import flatten
 from pydoctor.epydoc2stan import get_parsed_type
 from pydoctor.zopeinterface import ZopeInterfaceSystem
 
-from . import py2only, py3only, typecomment
+from . import py3only, typecomment
 import pytest
 
 
@@ -96,17 +96,6 @@ def test_function_argspec(systemcls):
     docfunc, = mod.contents.values()
     assert docfunc.argspec == (['a', 'b'], 'c', 'kw', ('3',))
 
-
-@py2only
-@systemcls_param
-def test_function_argspec_with_tuple(systemcls):
-    src = textwrap.dedent('''
-    def f((a,z), b=3, *c, **kw):
-        pass
-    ''')
-    mod = fromText(src, systemcls=systemcls)
-    docfunc, = mod.contents.values()
-    assert docfunc.argspec ==  ([['a', 'z'], 'b'], 'c', 'kw', ('3',))
 
 @systemcls_param
 def test_class(systemcls):

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -5,7 +5,6 @@ import sys
 from pydoctor import driver
 from twisted.python.compat import NativeStringIO
 
-from . import py3only
 
 def geterrtext(*options):
     options = list(options)
@@ -32,7 +31,6 @@ def test_cannot_advance_blank_system():
     err = geterrtext('--make-html')
     assert 'forget an --add-package?' in err
 
-@py3only
 def test_no_systemclasses_py3():
     err = geterrtext('--system-class')
     assert 'requires 1 argument' in err

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -5,7 +5,7 @@ import sys
 from pydoctor import driver
 from twisted.python.compat import NativeStringIO
 
-from . import py2only, py3only
+from . import py3only
 
 def geterrtext(*options):
     options = list(options)
@@ -31,11 +31,6 @@ def test_invalid_option():
 def test_cannot_advance_blank_system():
     err = geterrtext('--make-html')
     assert 'forget an --add-package?' in err
-
-@py2only
-def test_no_systemclasses_py2():
-    err = geterrtext('--system-class')
-    assert 'requires an argument' in err
 
 @py3only
 def test_no_systemclasses_py3():

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 
 from pydoctor import driver

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from pytest import raises
 
 from pydoctor import epydoc2stan, model

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -66,9 +66,9 @@ def test_summary():
         stan = epydoc2stan.format_summary(mod.contents[func])
         assert stan.tagName == 'span', stan
         return flatten(stan.children)
-    assert u'Lorem Ipsum' == get_summary('single_line_summary')
-    assert u'Foo Bar Baz' == get_summary('three_lines_summary')
-    assert u'No summary' == get_summary('no_summary')
+    assert 'Lorem Ipsum' == get_summary('single_line_summary')
+    assert 'Foo Bar Baz' == get_summary('three_lines_summary')
+    assert 'No summary' == get_summary('no_summary')
 
 
 def test_missing_field_name(capsys):

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -16,19 +16,19 @@ def test_multiple_types():
         @type a: a pink thing!
         @type a: no, blue! aaaargh!
         """
-    class C(object):
+    class C:
         """
         @ivar a: it\'s an instance var
         @type a: a pink thing!
         @type a: no, blue! aaaargh!
         """
-    class D(object):
+    class D:
         """
         @cvar a: it\'s an instance var
         @type a: a pink thing!
         @type a: no, blue! aaaargh!
         """
-    class E(object):
+    class E:
         """
         @cvar: missing name
         @type: name still missing

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -1,7 +1,6 @@
 """
 Unit tests for model.
 """
-from __future__ import print_function
 
 import sys
 import zlib

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -11,7 +11,7 @@ from pydoctor.driver import parse_args
 from pydoctor.test.test_astbuilder import fromText
 
 
-class FakeOptions(object):
+class FakeOptions:
     """
     A fake options object as if it came from that stupid optparse thing.
     """
@@ -19,7 +19,7 @@ class FakeOptions(object):
 
 
 
-class FakeDocumentable(object):
+class FakeDocumentable:
     """
     A fake of pydoctor.model.Documentable that provides a system and
     sourceHref attribute.
@@ -156,7 +156,7 @@ def test_docstring_lineno():
     assert func.docstring_lineno == 4 # first non-blank line
 
 
-class Dummy(object):
+class Dummy:
     def crash(self):
         """Mmm"""
 

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 
 from pydoctor import model

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -435,7 +435,7 @@ maxAgeAmounts = st.integers() | st.just("\x00")
 maxAgeUnits = st.sampled_from(tuple(sphinx._maxAgeUnits)) | st.just("\x00")
 
 
-class TestParseMaxAge(object):
+class TestParseMaxAge:
     """
     Tests for L{sphinx.parseMaxAge}
     """
@@ -500,7 +500,7 @@ def test_ClosingBytesIO():
     assert b''.join(buffer) == data
 
 
-class TestIntersphinxCache(object):
+class TestIntersphinxCache:
     """
     Tests for L{sphinx.IntersphinxCache}
     """
@@ -584,13 +584,13 @@ class TestIntersphinxCache(object):
         """
         loggedExceptions = []
 
-        class _Logger(object):
+        class _Logger:
 
             @staticmethod
             def exception(*args, **kwargs):
                 loggedExceptions.append((args, kwargs))
 
-        class _RaisesOnGet(object):
+        class _RaisesOnGet:
 
             @staticmethod
             def get(url):
@@ -603,7 +603,7 @@ class TestIntersphinxCache(object):
         assert len(loggedExceptions)
 
 
-class TestStubCache(object):
+class TestStubCache:
     """
     Tests for L{sphinx.StubCache}.
     """

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -241,7 +241,7 @@ def test_getPayload_content():
     """
     Return content as string.
     """
-    payload = u"first_line\nsecond line\nit's a snake: \U0001F40D"
+    payload = "first_line\nsecond line\nit's a snake: \U0001F40D"
     sut = sphinx.SphinxInventory(logger=object())
     content = b"""# Ignored line
 # Project: some-name
@@ -528,7 +528,7 @@ class TestIntersphinxCache:
         """
         L{IntersphinxCache.get} caches responses to the file system.
         """
-        url = u"https://cache.example/objects.inv"
+        url = "https://cache.example/objects.inv"
         content = b'content'
 
         send_returns(
@@ -597,7 +597,7 @@ class TestIntersphinxCache:
 
         cache = sphinx.IntersphinxCache(session=_RaisesOnGet, logger=_Logger)
 
-        assert cache.get(u"some url") is None
+        assert cache.get("some url") is None
 
         assert len(loggedExceptions)
 
@@ -611,7 +611,7 @@ class TestStubCache:
         """
         L{sphinx.StubCache.get} returns its cached content for a URL.
         """
-        url = u"url"
+        url = "url"
         content = b"content"
 
         cache = sphinx.StubCache({url: content})

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -1,7 +1,6 @@
 """
 Tests for Sphinx integration.
 """
-from __future__ import print_function
 
 import datetime
 import io

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -475,7 +475,7 @@ class ClosingBytesIO(io.BytesIO):
     """
 
     def read(self, *args, **kwargs):
-        data = super(ClosingBytesIO, self).read(*args, **kwargs)
+        data = super().read(*args, **kwargs)
         if self.tell() >= len(self.getvalue()):
             self.close()
         return data

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -247,7 +247,7 @@ def test_getPayload_content():
 # Project: some-name
 # Version: 2.0
 # commented line.
-%s""" % (zlib.compress(payload.encode('utf-8')),)
+""" + zlib.compress(payload.encode('utf-8'))
 
     result = sut._getPayload('http://base.ignore', content)
 
@@ -281,7 +281,7 @@ def test_getPayload_invalid_decode():
     base_url = 'http://tm.tld'
     content = b"""# Project: some-name
 # Version: 2.0
-%s""" % (zlib.compress(payload),)
+""" + zlib.compress(payload)
 
     result = sut._getPayload(base_url, content)
 
@@ -334,7 +334,7 @@ def test_update_functional():
 # Project: some-name
 # Version: 2.0
 # The rest of this file is compressed with zlib.
-%s""" % (zlib.compress(payload),)
+""" + zlib.compress(payload)
 
     url = 'http://some.url/api/objects.inv'
 
@@ -449,7 +449,7 @@ class TestParseMaxAge:
         L{datetime.timedelta}, and the constructed L{datetime.timedelta}
         matches the specification.
         """
-        maxAge = "{}{}".format(amount, unit)
+        maxAge = f"{amount}{unit}"
         try:
             parsedMaxAge = sphinx.parseMaxAge(maxAge)
         except sphinx.InvalidMaxAge:
@@ -663,7 +663,7 @@ def test_prepareCache(
             clearCache=clearCache,
             enableCache=enableCache,
             cachePath=str(cacheDirectory),
-            maxAge="{}{}".format(maxAgeAmount, maxAgeUnit)
+            maxAge=f"{maxAgeAmount}{maxAgeUnit}"
         )
     except sphinx.InvalidMaxAge:
         pass

--- a/pydoctor/test/test_templatewriter.py
+++ b/pydoctor/test/test_templatewriter.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import shutil
 import tempfile

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -261,7 +261,7 @@ def test_implementer_decoration():
         def method(self):
             """documentation"""
     @implementer(IMyInterface)
-    class Implementation(object):
+    class Implementation:
         def method(self):
             pass
     '''
@@ -275,7 +275,7 @@ def test_implementer_decoration_nonclass():
     from zope.interface import implementer
     var = 0
     @implementer(var)
-    class Implementation(object):
+    class Implementation:
         pass
     '''
     mod = fromText(src, systemcls=ZopeInterfaceSystem)
@@ -317,7 +317,7 @@ def test_implementer_with_none():
         def method(self):
             """documentation"""
     @implementer(IMyInterface, *extra_interfaces)
-    class Implementation(object):
+    class Implementation:
         def method(self):
             pass
     '''
@@ -334,7 +334,7 @@ def test_implementer_nonclass(capsys):
     from zope.interface import Interface, implementer
     var = 'not a class'
     @implementer(var)
-    class Implementation(object):
+    class Implementation:
         pass
     '''
     mod = fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
@@ -349,10 +349,10 @@ def test_implementer_plainclass(capsys):
     """
     src = '''
     from zope.interface import Interface, implementer
-    class C(object):
+    class C:
         pass
     @implementer(C)
-    class Implementation(object):
+    class Implementation:
         pass
     '''
     mod = fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from pydoctor.test.test_astbuilder import fromText
 from pydoctor.test.test_packages import processPackage
 from pydoctor.zopeinterface import ZopeInterfaceSystem

--- a/pydoctor/test/testpackages/multipleinheritance/mod.py
+++ b/pydoctor/test/testpackages/multipleinheritance/mod.py
@@ -1,11 +1,11 @@
-class NewBaseClassA(object):
+class NewBaseClassA:
     def methodA(self):
         """
         This is method A.
         """
 
 
-class NewBaseClassB(object):
+class NewBaseClassB:
     def methodB(self):
         """
         This is method B.

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -74,17 +74,13 @@ def _inheritedDocsources(obj):
 
 class ZopeInterfaceFunction(model.Function):
     def docsources(self):
-        for source in super(ZopeInterfaceFunction, self).docsources():
-            yield source
-        for source in _inheritedDocsources(self):
-            yield source
+        yield from super(ZopeInterfaceFunction, self).docsources()
+        yield from _inheritedDocsources(self)
 
 class ZopeInterfaceAttribute(model.Attribute):
     def docsources(self):
-        for source in super(ZopeInterfaceAttribute, self).docsources():
-            yield source
-        for source in _inheritedDocsources(self):
-            yield source
+        yield from super(ZopeInterfaceAttribute, self).docsources()
+        yield from _inheritedDocsources(self)
 
 def addInterfaceInfoToScope(scope, interfaceargs):
     for arg in interfaceargs:

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -7,7 +7,6 @@ import re
 
 import astor
 from pydoctor import astbuilder, model
-from six import text_type
 
 
 class ZopeInterfaceModule(model.Module):
@@ -256,7 +255,7 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
         for base in cls.bases:
             if isinstance(base, ast.Name):
                 bases.append(self.builder.current.expandName(base.id))
-            elif isinstance(base, text_type):
+            elif isinstance(base, str):
                 bases.append(self.builder.current.expandName(base))
             else:
                 raise Exception(base)

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -1,7 +1,5 @@
 """Support for Zope interfaces."""
 
-from __future__ import print_function
-
 import ast
 import re
 

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -9,7 +9,7 @@ from pydoctor import astbuilder, model
 
 class ZopeInterfaceModule(model.Module):
     def setup(self):
-        super(ZopeInterfaceModule, self).setup()
+        super().setup()
         self.implements_directly = [] # [name of interface]
 
     @property
@@ -26,7 +26,7 @@ class ZopeInterfaceClass(model.Class):
     implementsOnly = False
     implementedby_directly = None # [objects], when isinterface == True
     def setup(self):
-        super(ZopeInterfaceClass, self).setup()
+        super().setup()
         self.implements_directly = [] # [name of interface]
 
     @property
@@ -74,12 +74,12 @@ def _inheritedDocsources(obj):
 
 class ZopeInterfaceFunction(model.Function):
     def docsources(self):
-        yield from super(ZopeInterfaceFunction, self).docsources()
+        yield from super().docsources()
         yield from _inheritedDocsources(self)
 
 class ZopeInterfaceAttribute(model.Attribute):
     def docsources(self):
-        yield from super(ZopeInterfaceAttribute, self).docsources()
+        yield from super().docsources()
         yield from _inheritedDocsources(self)
 
 def addInterfaceInfoToScope(scope, interfaceargs):
@@ -146,7 +146,7 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
         return self.builder.current.expandName(name)
 
     def _handleAssignmentInModule(self, target, annotation, expr, lineno):
-        super(ZopeInterfaceModuleVisitor, self)._handleAssignmentInModule(
+        super()._handleAssignmentInModule(
                 target, annotation, expr, lineno)
 
         if not isinstance(expr, ast.Call):
@@ -164,7 +164,7 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             self.newAttr = interface
 
     def _handleAssignmentInClass(self, target, annotation, expr, lineno):
-        super(ZopeInterfaceModuleVisitor, self)._handleAssignmentInClass(
+        super()._handleAssignmentInClass(
                 target, annotation, expr, lineno)
 
         def handleSchemaField():
@@ -239,7 +239,7 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
     visit_Call_zope_interface_classImplementsOnly = visit_Call_zope_interface_classImplements
 
     def visit_ClassDef(self, node):
-        super(ZopeInterfaceModuleVisitor, self).visit_ClassDef(node)
+        super().visit_ClassDef(node)
         cls = self.builder.current.contents.get(node.name)
         if cls is None:
             return

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [install]
 optimize=1
 
-[bdist_wheel]
-universal = 1
-
 [bdist_rpm]
 release = 1
 doc_files = README.txt

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -54,6 +52,7 @@ setup(
     ],
     use_incremental=True,
     setup_requires=["incremental"],
+    python_requires='>=3.6',
     install_requires=[
         "incremental",
         "appdirs",
@@ -62,6 +61,5 @@ setup(
         "requests",
         "six",
         "astor",
-        "enum34;python_version<'3.4'",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
         "CacheControl[filecache]",
         "Twisted",
         "requests",
-        "six",
         "astor",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,7 @@
 ;
 [tox]
 envlist =
-    test-{py27,py36,py37,py38,pypy,pypy3},pyflakes,twisted-apidoc
-
-[testenv:pyflakes]
-basepython = /usr/bin/python
+    test-{py36,py37,py38,pypy3},pyflakes,twisted-apidoc
 
 
 [testenv]
@@ -19,8 +16,7 @@ passenv = *
 
 
 deps =
-    test-{py35,py36,py37,py38,pypy3},twisted-apidoc: git+https://github.com/twisted/twisted.git
-    test-{py27,pypy}: Twisted
+    test-{py36,py37,py38,pypy3},twisted-apidoc: git+https://github.com/twisted/twisted.git
 
     test: coverage
     test: pytest

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 ;
 [tox]
 envlist =
-    test-{py27,py36,py37,py38,pypy},pyflakes,twisted-apidoc
+    test-{py27,py36,py37,py38,pypy,pypy3},pyflakes,twisted-apidoc
 
 [testenv:pyflakes]
 basepython = /usr/bin/python
@@ -19,7 +19,7 @@ passenv = *
 
 
 deps =
-    test-{py35,py36,py37,py38},twisted-apidoc: git+https://github.com/twisted/twisted.git
+    test-{py35,py36,py37,py38,pypy3},twisted-apidoc: git+https://github.com/twisted/twisted.git
     test-{py27,pypy}: Twisted
 
     test: coverage


### PR DESCRIPTION
This PR drops support for Python 2.7 and 3.5.

The main motivations for picking 3.6 as the new requirement are f-strings and support for variable annotations. The use of f-strings is already introduced in this PR; type annotations will be a separate PR.

The tools [pyupgrade](https://github.com/asottile/pyupgrade) and [flynt](https://github.com/ikamensh/flynt) were very useful in finding and applying modernizations. I didn't commit their output as-is though: I separated it by category and applied additional cleanups to the changed code.

One category of strings that I did not convert to f-strings are the ones used for logging messages, since I expect that we'll move to a proper logging system one day.
