### PR TITLE
Fix cross-references to builtin types in standard library

### DIFF
--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -17,11 +17,6 @@ from twisted.web.template import Tag, tags
 from pydoctor.epydoc.markup import DocstringLinker, ParsedDocstring
 import pydoctor.epydoc.markup.plaintext
 
-try:
-    import exceptions
-except ImportError:
-    exceptions = builtins
-
 
 def _find_stdlib_dir():
     """Find the standard library location for the currently running
@@ -82,10 +77,11 @@ def stdlib_doc_link_for_name(name):
     part0 = parts[0]
     if part0 in builtins.__dict__ and not part0.startswith('__'):
         bltin = builtins.__dict__[part0]
-        if part0 in exceptions.__dict__:
-            return STDLIB_URL + 'exceptions.html#exceptions.' + name
-        elif isinstance(bltin, type):
-            return STDLIB_URL + 'stdtypes.html#' + name
+        if isinstance(bltin, type):
+            if issubclass(bltin, BaseException):
+                return STDLIB_URL + 'exceptions.html#' + name
+            else:
+                return STDLIB_URL + 'stdtypes.html#' + name
         elif callable(bltin):
             return STDLIB_URL + 'functions.html#' + name
         else:

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -213,3 +213,18 @@ def test_EpydocLinker_resolve_identifier_xref_order(capsys):
 
     assert epydoc2stan.STDLIB_URL + 'socket.html#socket.socket' == url
     assert not capsys.readouterr().out
+
+
+def test_stdlib_doc_link_for_name():
+    """
+    Check the URLs returned for names from the standard library.
+    """
+
+    base = epydoc2stan.STDLIB_URL
+    link = epydoc2stan.stdlib_doc_link_for_name
+    assert base + 'exceptions.html#KeyError' == link('KeyError')
+    assert base + 'stdtypes.html#str' == link('str')
+    assert base + 'functions.html#len' == link('len')
+    assert base + 'constants.html#None' == link('None')
+    assert base + 'collections.html#collections.defaultdict' == link('collections.defaultdict')
+    assert base + 'logging.handlers.html#logging.handlers.SocketHandler' == link('logging.handlers.SocketHandler')


### PR DESCRIPTION
Builtin types such as `str` were linked to the documentation page for builtin exceptions instead of the page for builtin types.

If we're going to do a 20.7.1 release, this fix should be included.
