### PR TITLE
Add type annotations to pydoctor.sphinx module

### DIFF
--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -283,7 +283,16 @@ class InvalidMaxAge(Exception):
     """
 
 
-def parseMaxAge(maxAge):
+def parseMaxAge(maxAge: str) -> Dict[str, int]:
+    """
+    Parse a string into a maximum age dictionary.
+
+    @param maxAge: A string consisting of an integer number
+        followed by a single character unit.
+    @return: A dictionary whose keys match L{datetime.timedelta}'s
+        arguments.
+    @raises: L{InvalidMaxAge} when a string cannot be parsed.
+    """
     try:
         amount = int(maxAge[:-1])
     except (ValueError, TypeError):
@@ -302,22 +311,6 @@ def parseMaxAge(maxAge):
             f"and less than {unit.maximum}")
 
     return {unit.name: amount}
-
-
-parseMaxAge.__doc__ = (
-    """
-    Parse a string into a maximum age dictionary.
-
-    @param maxAge: {}
-    @type maxAge: L{str}
-
-    @raises: L{InvalidMaxAge} when a string cannot be parsed.
-
-    @return: A dictionary whose keys match L{datetime.timedelta}'s
-        arguments.
-    @rtype: L{dict}
-    """
-)
 
 
 @attr.s(auto_attribs=True)
@@ -379,46 +372,34 @@ class StubCache:
     _cache: Dict[str, bytes]
     """A mapping from URLs to content."""
 
-    def get(self, url):
+    def get(self, url: str) -> Optional[bytes]:
         """
         Return stored for the given URL.
 
         @param url: The URL to retrieve.
-        @type url: L{str}
-
         @return: The "body" of the URL - the value from L{_cache} or
             L{None}.
-        @rtype: L{bytes}.
         """
         return self._cache.get(url)
 
 
 def prepareCache(
-        clearCache,
-        enableCache,
-        cachePath,
-        maxAge,
-        sessionFactory=requests.Session,
-):
+        clearCache: bool,
+        enableCache: bool,
+        cachePath: str,
+        maxAge: str,
+        sessionFactory: Callable[[], requests.Session] = requests.Session,
+        ) -> IntersphinxCache:
     """
     Prepare an Intersphinx cache.
 
     @param clearCache: Remove the cache?
-    @type clearCache: L{bool}
-
     @param enableCache: Enable the cache?
-    @type enableCache: L{bool}
-
     @param cachePath: Path of the cache directory.
-    @type cachePath: L{str}
-
     @param maxAge: The maximum age in seconds of cached Intersphinx
         C{objects.inv} files.
-    @type maxAge: L{float}
-
     @param sessionFactory: (optional) A zero-argument L{callable} that
         returns a L{requests.Session}.
-
     @return: A L{IntersphinxCache} instance.
     """
     if clearCache:

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import textwrap
 import zlib
+from typing import Dict
 
 import appdirs
 import attr
@@ -209,25 +210,22 @@ class SphinxInventoryWriter:
 USER_INTERSPHINX_CACHE = appdirs.user_cache_dir("pydoctor")
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class _Unit:
     """
     A unit of time for maximum age parsing.
 
-    @ivar name: The name of the unit.
-    @type name: L{str}
-
-    @ivar minimum: The minimum value, inclusive.
-    @ivar minimum: L{int}
-
-    @ivar maximum: The maximum value, exclusive.
-    @ivar maxium: L{int}
-
     @see: L{parseMaxAge}
     """
-    name = attr.ib()
-    minimum = attr.ib()
-    maximum = attr.ib()
+
+    name: str
+    """The name of the unit."""
+
+    minimum: int
+    """The minimum value, inclusive."""
+
+    maximum: int
+    """The maximum value, exclusive."""
 
 
 # timedelta stores seconds and minutes internally as ints.  Limit them
@@ -298,16 +296,16 @@ parseMaxAge.__doc__ = (
 )
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class IntersphinxCache:
     """
     An Intersphinx cache.
-
-    @param session: A session that may or may not cache requests.
-    @type session: L{requests.Session}
     """
-    _session = attr.ib()
-    _logger = attr.ib(default=logger)
+
+    _session: requests.Session
+    """A session that may or may not cache requests."""
+
+    _logger: logging.Logger = logger
 
     @classmethod
     def fromParameters(cls, sessionFactory, cachePath, maxAgeDictionary):
@@ -351,15 +349,14 @@ class IntersphinxCache:
             return None
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class StubCache:
     """
     A stub cache.
-
-    @param cache: A L{dict} mapping URLs to content.
-    @type cache: L{dict} of L{str} to L{bytes}
     """
-    _cache = attr.ib()
+
+    _cache: Dict[str, bytes]
+    """A mapping from URLs to content."""
 
     def get(self, url):
         """

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -332,20 +332,20 @@ class IntersphinxCache:
     _logger: logging.Logger = logger
 
     @classmethod
-    def fromParameters(cls, sessionFactory, cachePath, maxAgeDictionary):
+    def fromParameters(
+            cls,
+            sessionFactory: Callable[[], requests.Session],
+            cachePath: str,
+            maxAgeDictionary: Mapping[str, int]
+            ) -> 'IntersphinxCache':
         """
         Construct an instance with the given parameters.
 
         @param sessionFactory: A zero-argument L{callable} that
             returns a L{requests.Session}.
-
         @param cachePath: Path of the cache directory.
-        @type cachePath: L{str}
-
-        @param maxAgeDictionary: A dictionary describing the maximum
+        @param maxAgeDictionary: A mapping describing the maximum
             age of any cache entry.
-        @type maxAgeDictionary: L{dict}
-
         @see: L{parseMaxAge}
         """
         session = CacheControl(sessionFactory(),
@@ -353,15 +353,12 @@ class IntersphinxCache:
                                heuristic=ExpiresAfter(**maxAgeDictionary))
         return cls(session)
 
-    def get(self, url):
+    def get(self, url: str) -> Optional[bytes]:
         """
         Retrieve a URL using the cache.
 
         @param url: The URL to retrieve.
-        @type url: L{str}
-
-        @return: The body of the URL.
-        @rtype: L{bytes} on success and L{None} on failure.
+        @return: The body of the URL, or L{None} on failure.
         """
         try:
             return self._session.get(url).content

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -45,19 +45,6 @@ def make_SphinxInventoryWithLog(factory=sphinx.SphinxInventory):
     return (inventory, log)
 
 
-def test_writer_initialization():
-    """
-    Is initialized with logger and project name.
-    """
-    logger = object()
-    name = object()
-
-    sut = sphinx.SphinxInventoryWriter(logger=logger, project_name=name)
-
-    assert logger is sut.info
-    assert name is sut.project_name
-
-
 def test_generate_empty_functional():
     """
     Functional test for index generation of empty API.


### PR DESCRIPTION
I picked `pydoctor.sphinx` as a first module to annotate since it's relatively self-contained, so I could go through the process without complications.