### PR TITLE
Use mypy-zope plugin

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,8 @@ warn_unreachable=True
 warn_unused_configs=True
 warn_unused_ignores=True
 
+plugins=mypy_zope:plugin
+
 [mypy-appdirs.*]
 ignore_missing_imports=True
 

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ description = run mypy (static type checker)
 
 deps =
     mypy>=0.770
+    mypy-zope
     ; Libraries which include type annotations:
     hypothesis
 


### PR DESCRIPTION
We extend classes from twisted.web.template that use Zope interfaces and mypy will report errors if we check without the plugin.

Note that these errors will only show up in our CI after twisted/twisted#1354 is merged, but I'd rather be prepared for that.