### PR TITLE
Update use of 3rd party type annotations

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -25,9 +25,6 @@ ignore_missing_imports=True
 [mypy-incremental.*]
 ignore_missing_imports=True
 
-[mypy-pytest.*]
-ignore_missing_imports=True
-
 [mypy-twisted.*]
 ignore_missing_imports=True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,8 +25,5 @@ ignore_missing_imports=True
 [mypy-incremental.*]
 ignore_missing_imports=True
 
-[mypy-twisted.*]
-ignore_missing_imports=True
-
 [mypy-urllib3.*]
 ignore_missing_imports=True

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ doc_files = README.txt
 
 
 [tool:pytest]
+testpaths=pydoctor/test
 python_files=test_*.py
 addopts=--doctest-glob='*.doctest'
 doctest_optionflags=ELLIPSIS IGNORE_EXCEPTION_DETAIL

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ deps =
     mypy-zope
     ; Libraries which include type annotations:
     hypothesis
+    pytest>=6.0.0
 
 commands =
     mypy                                       \

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv = *
 
 
 deps =
-    test-{py36,py37,py38,pypy3},twisted-apidoc: git+https://github.com/twisted/twisted.git
+    test,test-{py36,py37,py38,pypy3},twisted-apidoc: git+https://github.com/twisted/twisted.git
 
     test: coverage
     test: pytest
@@ -32,8 +32,6 @@ deps =
 
 
 commands =
-    test: {envpython} --version
-    test: trial --version
     test: coverage erase
     test: coverage run --source pydoctor --omit pydoctor/test/* --branch -m pytest {posargs:pydoctor}
     test: coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ deps =
     ; Libraries which include type annotations:
     hypothesis
     pytest>=6.0.0
+    git+https://github.com/twisted/twisted.git
 
 commands =
     mypy                                       \


### PR DESCRIPTION
Both Twisted and pytest ship with type annotations now, so we should use those in our mypy runs.