### PR TITLE
Add type annotations for unit tests

### DIFF
--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -330,7 +330,6 @@ def main(args=sys.argv[1:]):
                 writerclass.__name__))
 
             writer = writerclass(options.htmloutput)
-            writer.system = system
             writer.prepOutputDirectory()
 
             if options.htmlsubjects:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -15,7 +15,7 @@ import platform
 import sys
 import types
 from enum import Enum
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Optional, Type
 
 from pydoctor.sphinx import SphinxInventory
 
@@ -408,7 +408,7 @@ class System:
     # Not assigned here for circularity reasons:
     #defaultBuilder = astbuilder.ASTBuilder
     defaultBuilder: Type[ASTBuilder]
-    sourcebase = None
+    sourcebase: Optional[str] = None
 
     def __init__(self, options=None):
         self.allobjects = {}

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -363,26 +363,6 @@ class IntersphinxCache:
             return None
 
 
-@attr.s(auto_attribs=True)
-class StubCache:
-    """
-    A stub cache.
-    """
-
-    _cache: Dict[str, bytes]
-    """A mapping from URLs to content."""
-
-    def get(self, url: str) -> Optional[bytes]:
-        """
-        Return stored for the given URL.
-
-        @param url: The URL to retrieve.
-        @return: The "body" of the URL - the value from L{_cache} or
-            L{None}.
-        """
-        return self._cache.get(url)
-
-
 def prepareCache(
         clearCache: bool,
         enableCache: bool,

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -8,7 +8,8 @@ import shutil
 import textwrap
 import zlib
 from typing import (
-    TYPE_CHECKING, Callable, Dict, IO, Iterable, Mapping, Optional, Tuple
+    TYPE_CHECKING, Callable, ContextManager, Dict, IO, Iterable, Mapping,
+    Optional, Tuple
 )
 
 import appdirs
@@ -162,7 +163,7 @@ class SphinxInventoryWriter:
             content = self._generateContent(subjects)
             target.write(zlib.compress(content))
 
-    def _openFileForWriting(self, path: str) -> IO[bytes]:
+    def _openFileForWriting(self, path: str) -> ContextManager[IO[bytes]]:
         """
         Helper for testing.
         """

--- a/pydoctor/templatewriter/writer.py
+++ b/pydoctor/templatewriter/writer.py
@@ -81,8 +81,8 @@ class TemplateWriter:
                 break
         else:
             pclass = pages.CommonPage
-        self.system.msg('html', str(ob), thresh=1)
+        ob.system.msg('html', str(ob), thresh=1)
         page = pclass(ob)
         self.written_pages += 1
-        self.system.progress('html', self.written_pages, self.total_pages, 'pages written')
+        ob.system.progress('html', self.written_pages, self.total_pages, 'pages written')
         flattenToFile(fobj, page)

--- a/pydoctor/test/__init__.py
+++ b/pydoctor/test/__init__.py
@@ -1,6 +1,22 @@
 """PyDoctor's test suite."""
 
+from logging import LogRecord
+from typing import NamedTuple, Sequence
 import sys
 import pytest
 
 typecomment = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python 3.8")
+
+
+# Because pytest 6.1 does not yet export types for fixtures, we define
+# approximations that are good enough for our test cases:
+
+class CapLog:
+    records: Sequence[LogRecord]
+
+class CaptureResult(NamedTuple):
+    out: str
+    err: str
+
+class CapSys:
+    def readouterr(self) -> CaptureResult: ...

--- a/pydoctor/test/__init__.py
+++ b/pydoctor/test/__init__.py
@@ -1,7 +1,7 @@
 """PyDoctor's test suite."""
 
 from logging import LogRecord
-from typing import NamedTuple, Sequence
+from typing import TYPE_CHECKING, Sequence
 import sys
 import pytest
 
@@ -11,12 +11,17 @@ typecomment = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires pyt
 # Because pytest 6.1 does not yet export types for fixtures, we define
 # approximations that are good enough for our test cases:
 
-class CapLog:
-    records: Sequence[LogRecord]
+if TYPE_CHECKING:
+    from typing_extensions import Protocol
 
-class CaptureResult(NamedTuple):
-    out: str
-    err: str
+    class CapLog(Protocol):
+        records: Sequence[LogRecord]
 
-class CapSys:
-    def readouterr(self) -> CaptureResult: ...
+    class CaptureResult(Protocol):
+        out: str
+        err: str
+
+    class CapSys(Protocol):
+        def readouterr(self) -> CaptureResult: ...
+else:
+    CapLog = CaptureResult = CapSys = object

--- a/pydoctor/test/epydoc/test_epytext.py
+++ b/pydoctor/test/epydoc/test_epytext.py
@@ -1,20 +1,22 @@
-from pydoctor.epydoc.markup import epytext, flatten
+from typing import List
+
+from pydoctor.epydoc.markup import ParseError, epytext, flatten
 
 
-def epytext2html(s):
-    errs = []
+def epytext2html(s: str) -> str:
+    errs: List[ParseError] = []
     v = flatten(epytext.parse_docstring(s, errs).to_stan(None))
     if errs:
         raise errs[0]
     return (v or '').rstrip()
 
 
-def parse(s):
+def parse(s: str) -> str:
     # this strips off the <epytext>...</epytext>
     return ''.join(str(n) for n in epytext.parse(s).children)
 
 
-def test_basic_list():
+def test_basic_list() -> None:
     P1 = "This is a paragraph."
     P2 = "This is a \nparagraph."
     LI1 = "  - This is a list item."
@@ -58,7 +60,7 @@ def test_basic_list():
     assert parse(f'{P2}\n{LI6}\n{P1}') == PARA+LI6LIST+PARA
 
 
-def test_item_wrap():
+def test_item_wrap() -> None:
     LI = "- This is a list\n  item."
     ONELIST = ('<ulist><li><para inline=True>This is a '
                'list item.</para></li></ulist>')
@@ -72,7 +74,7 @@ def test_item_wrap():
                 assert parse(nl1+indent+LI+nl2+indent+LI) == TWOLIST
 
 
-def test_literal_braces():
+def test_literal_braces() -> None:
     """SF bug #1562530 reported some trouble with literal braces.
     This test makes sure that braces are getting rendered as desired.
     """

--- a/pydoctor/test/epydoc/test_epytext2html.py
+++ b/pydoctor/test/epydoc/test_epytext2html.py
@@ -10,23 +10,25 @@ To work around this, expected output should contain at most
 one attribute per tag.
 """
 
-from pydoctor.epydoc.markup import flatten
+from typing import List
+
+from pydoctor.epydoc.markup import ParseError, flatten
 from pydoctor.epydoc.markup.epytext import parse_docstring
 
 
-def epytext2html(s):
-    errors = []
+def epytext2html(s: str) -> str:
+    errors: List[ParseError] = []
     parsed = parse_docstring(s, errors)
     assert not errors
     return flatten(parsed.to_stan(None))
 
-def squash(s):
+def squash(s: str) -> str:
     return ''.join(
         line.lstrip() for line in s.strip().split('\n')
         ).replace('|', '\n')
 
 
-def test_epytext_paragraph():
+def test_epytext_paragraph() -> None:
     doc = '''
         This is a paragraph.  Paragraphs can
         span multiple lines, and can contain
@@ -42,7 +44,7 @@ def test_epytext_paragraph():
         '''
     assert epytext2html(doc) == squash(expected)
 
-def test_epytext_ordered_list():
+def test_epytext_ordered_list() -> None:
     doc = '''
           1. This is an ordered list item.
 
@@ -70,7 +72,7 @@ def test_epytext_ordered_list():
         '''
     assert epytext2html(doc) == squash(expected)
 
-def test_epytext_nested_list():
+def test_epytext_nested_list() -> None:
     doc = '''
         This is a paragraph.
             1. This is a list item.
@@ -88,7 +90,7 @@ def test_epytext_nested_list():
         '''
     assert epytext2html(doc) == squash(expected)
 
-def test_epytext_complex_list():
+def test_epytext_complex_list() -> None:
     doc = '''
         This is a paragraph.
           1. This is a list item.
@@ -132,7 +134,7 @@ def test_epytext_complex_list():
         '''
     assert epytext2html(doc) == squash(expected)
 
-def test_epytext_sections():
+def test_epytext_sections() -> None:
     doc = '''
         This paragraph is not in any section.
 
@@ -159,7 +161,7 @@ def test_epytext_sections():
         '''
     assert epytext2html(doc) == squash(expected)
 
-def test_epytext_literal_block():
+def test_epytext_literal_block() -> None:
     doc = '''
         The following is a literal block::
 
@@ -179,7 +181,7 @@ def test_epytext_literal_block():
         '''
     assert epytext2html(doc) == squash(expected)
 
-def test_epytext_inline():
+def test_epytext_inline() -> None:
     doc = '''
         I{B{Inline markup} may be nested; and
         it may span} multiple lines.
@@ -205,7 +207,7 @@ def test_epytext_inline():
         '''
     assert epytext2html(doc) == squash(expected)
 
-def test_epytext_url():
+def test_epytext_url() -> None:
     doc = '''
         - U{www.python.org}
         - U{http://www.python.org}
@@ -228,7 +230,7 @@ def test_epytext_url():
     # Drop 'target' attribute so we have one attribute per tag.
     assert epytext2html(doc).replace(' target="_top"', '') == squash(expected)
 
-def test_epytext_symbol():
+def test_epytext_symbol() -> None:
     doc = '''
         Symbols can be used in equations:
           - S{sum}S{alpha}/x S{<=} S{beta}

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -830,34 +830,40 @@ def test_annotated_variables(systemcls: Type[model.System]) -> None:
     m: bytes = b"M"
     """module-level"""
     ''', modname='test', systemcls=systemcls)
+
+    def type2html(obj: model.Documentable) -> str:
+        parsed_type = get_parsed_type(obj)
+        assert parsed_type is not None
+        return to_html(parsed_type)
+
     C = mod.contents['C']
     a = C.contents['a']
     assert unwrap(a.parsed_docstring) == """first"""
-    assert to_html(get_parsed_type(a)) == 'string'
+    assert type2html(a) == 'string'
     b = C.contents['b']
     assert unwrap(b.parsed_docstring) == """second"""
-    assert to_html(get_parsed_type(b)) == 'string'
+    assert type2html(b) == 'string'
     c = C.contents['c']
     assert c.docstring == """third"""
-    assert to_html(get_parsed_type(c)) == '<code>str</code>'
+    assert type2html(c) == '<code>str</code>'
     d = C.contents['d']
     assert d.docstring == """fourth"""
-    assert to_html(get_parsed_type(d)) == '<code>str</code>'
+    assert type2html(d) == '<code>str</code>'
     e = C.contents['e']
     assert e.docstring == """fifth"""
-    assert to_html(get_parsed_type(e)) == '<code>List[C]</code>'
+    assert type2html(e) == '<code>List[C]</code>'
     f = C.contents['f']
     assert f.docstring == """sixth"""
-    assert to_html(get_parsed_type(f)) == '<code>List[C]</code>'
+    assert type2html(f) == '<code>List[C]</code>'
     g = C.contents['g']
     assert g.docstring == """seventh"""
-    assert to_html(get_parsed_type(g)) == '<code>List[C]</code>'
+    assert type2html(g) == '<code>List[C]</code>'
     s = C.contents['s']
     assert s.docstring == """instance"""
-    assert to_html(get_parsed_type(s)) == '<code>List[str]</code>'
+    assert type2html(s) == '<code>List[str]</code>'
     m = mod.contents['m']
     assert m.docstring == """module-level"""
-    assert to_html(get_parsed_type(m)) == '<code>bytes</code>'
+    assert type2html(m) == '<code>bytes</code>'
 
 @typecomment
 @systemcls_param

--- a/pydoctor/test/test_colorize.py
+++ b/pydoctor/test/test_colorize.py
@@ -2,7 +2,7 @@ from pydoctor.epydoc.doctest import colorize_codeblock, colorize_doctest
 from pydoctor.epydoc.markup import flatten
 
 
-def test_colorize_codeblock():
+def test_colorize_codeblock() -> None:
     src = '''
 def foo():
     """A multi-line docstring.
@@ -35,7 +35,7 @@ class Foo:
 '''.strip()
     assert flatten(colorize_codeblock(src)) == expected
 
-def test_colorize_doctest_more_string():
+def test_colorize_doctest_more_string() -> None:
     src = '''
 Test multi-line string:
 
@@ -56,7 +56,7 @@ Test multi-line string:
 '''.strip()
     assert flatten(colorize_doctest(src)) == expected
 
-def test_colorize_doctest_more_input():
+def test_colorize_doctest_more_input() -> None:
     src = '''
 Test multi-line expression:
 
@@ -77,7 +77,7 @@ Test multi-line expression:
 '''.strip()
     assert flatten(colorize_doctest(src)) == expected
 
-def test_colorize_doctest_exception():
+def test_colorize_doctest_exception() -> None:
     src = '''
 Test division by zero:
 
@@ -96,7 +96,7 @@ Test division by zero:
 '''.strip()
     assert flatten(colorize_doctest(src)) == expected
 
-def test_colorize_doctest_no_output():
+def test_colorize_doctest_no_output() -> None:
     src = '''
 Test expecting no output:
 

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -1,13 +1,13 @@
+from io import StringIO
 import sys
 
 from pydoctor import driver
-from twisted.python.compat import NativeStringIO
 
 
 def geterrtext(*options):
     options = list(options)
     se = sys.stderr
-    f = NativeStringIO()
+    f = StringIO()
     print(options)
     sys.stderr = f
     try:

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -4,15 +4,14 @@ import sys
 from pydoctor import driver
 
 
-def geterrtext(*options):
-    options = list(options)
+def geterrtext(*options: str) -> str:
     se = sys.stderr
     f = StringIO()
     print(options)
     sys.stderr = f
     try:
         try:
-            driver.main(options)
+            driver.main(list(options))
         except SystemExit:
             pass
         else:
@@ -21,19 +20,19 @@ def geterrtext(*options):
         sys.stderr = se
     return f.getvalue()
 
-def test_invalid_option():
+def test_invalid_option() -> None:
     err = geterrtext('--no-such-option')
     assert 'no such option' in err
 
-def test_cannot_advance_blank_system():
+def test_cannot_advance_blank_system() -> None:
     err = geterrtext('--make-html')
     assert 'forget an --add-package?' in err
 
-def test_no_systemclasses_py3():
+def test_no_systemclasses_py3() -> None:
     err = geterrtext('--system-class')
     assert 'requires 1 argument' in err
 
-def test_invalid_systemclasses():
+def test_invalid_systemclasses() -> None:
     err = geterrtext('--system-class=notdotted')
     assert 'dotted name' in err
     err = geterrtext('--system-class=no-such-module.System')
@@ -42,7 +41,7 @@ def test_invalid_systemclasses():
     assert 'is not a subclass' in err
 
 
-def test_projectbasedir():
+def test_projectbasedir() -> None:
     """
     The --project-base-dir option should set the projectbasedirectory attribute
     on the options object.
@@ -53,7 +52,7 @@ def test_projectbasedir():
     assert options.projectbasedirectory == value
 
 
-def test_cache_disabled_by_default():
+def test_cache_disabled_by_default() -> None:
     """
     Intersphinx object caching is disabled by default.
     """

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -7,8 +7,10 @@ from pydoctor.epydoc.markup import flatten
 from pydoctor.sphinx import SphinxInventory
 from pydoctor.test.test_astbuilder import fromText
 
+from . import CapSys
 
-def test_multiple_types():
+
+def test_multiple_types() -> None:
     mod = fromText('''
     def f(a):
         """
@@ -55,7 +57,7 @@ def test_html_empty_module() -> None:
     """).strip()
     assert docstring2html(mod) == expected_html
 
-def test_func_arg_and_ret_annotation():
+def test_func_arg_and_ret_annotation() -> None:
     annotation_mod = fromText('''
     def f(a: List[str], b: "List[str]") -> bool:
         """
@@ -79,7 +81,7 @@ def test_func_arg_and_ret_annotation():
     classic_fmt = docstring2html(classic_mod.contents['f'])
     assert annotation_fmt == classic_fmt
 
-def test_func_arg_and_ret_annotation_with_override():
+def test_func_arg_and_ret_annotation_with_override() -> None:
     annotation_mod = fromText('''
     def f(a: List[str], b: List[str]) -> bool:
         """
@@ -104,7 +106,7 @@ def test_func_arg_and_ret_annotation_with_override():
     classic_fmt = docstring2html(classic_mod.contents['f'])
     assert annotation_fmt == classic_fmt
 
-def test_func_arg_when_doc_missing():
+def test_func_arg_when_doc_missing() -> None:
     annotation_mod = fromText('''
     def f(a: List[str], b: int) -> bool:
         """
@@ -125,7 +127,7 @@ def test_func_arg_when_doc_missing():
     assert annotation_fmt == classic_fmt
 
 
-def test_func_missing_param_name(capsys):
+def test_func_missing_param_name(capsys: CapSys) -> None:
     """Param and type fields must include the name of the parameter."""
     mod = fromText('''
     def f(a, b):
@@ -143,7 +145,7 @@ def test_func_missing_param_name(capsys):
         )
 
 
-def test_func_missing_exception_type(capsys):
+def test_func_missing_exception_type(capsys: CapSys) -> None:
     """Raise fields must include the exception type."""
     mod = fromText('''
     def f(x):
@@ -157,7 +159,7 @@ def test_func_missing_exception_type(capsys):
     assert captured == '<test>:5: Exception type missing\n'
 
 
-def test_unexpected_field_args(capsys):
+def test_unexpected_field_args(capsys: CapSys) -> None:
     """Warn when field arguments that should be empty aren't."""
     mod = fromText('''
     def get_it():
@@ -172,7 +174,7 @@ def test_unexpected_field_args(capsys):
                        "<test>:5: Unexpected argument in rtype field\n"
 
 
-def test_func_starargs(capsys):
+def test_func_starargs(capsys: CapSys) -> None:
     """Var-args must be named in fields without asterixes.
     But for compatibility, we warn and strip off the asterixes.
     """
@@ -207,7 +209,7 @@ def test_func_starargs(capsys):
         )
 
 
-def test_summary():
+def test_summary() -> None:
     mod = fromText('''
     def single_line_summary():
         """
@@ -231,7 +233,7 @@ def test_summary():
         Lorem Ipsum
         """
     ''')
-    def get_summary(func):
+    def get_summary(func: str) -> str:
         stan = epydoc2stan.format_summary(mod.contents[func])
         assert stan.tagName == 'span', stan
         return flatten(stan.children)
@@ -240,7 +242,7 @@ def test_summary():
     assert 'No summary' == get_summary('no_summary')
 
 
-def test_missing_field_name(capsys):
+def test_missing_field_name(capsys: CapSys) -> None:
     fromText('''
     """
     A test module.
@@ -254,7 +256,7 @@ def test_missing_field_name(capsys):
                        "test:6: Missing field name in @type\n"
 
 
-def test_unknown_field_name(capsys):
+def test_unknown_field_name(capsys: CapSys) -> None:
     mod = fromText('''
     """
     A test module.
@@ -267,7 +269,7 @@ def test_unknown_field_name(capsys):
     assert captured == 'test:5: Unknown field "zap"\n'
 
 
-def test_EpydocLinker_look_for_intersphinx_no_link():
+def test_EpydocLinker_look_for_intersphinx_no_link() -> None:
     """
     Return None if inventory had no link for our markup.
     """
@@ -280,7 +282,7 @@ def test_EpydocLinker_look_for_intersphinx_no_link():
     assert None is result
 
 
-def test_EpydocLinker_look_for_intersphinx_hit():
+def test_EpydocLinker_look_for_intersphinx_hit() -> None:
     """
     Return the link from inventory based on first package name.
     """
@@ -296,7 +298,7 @@ def test_EpydocLinker_look_for_intersphinx_hit():
     assert 'http://tm.tld/some.html' == result
 
 
-def test_EpydocLinker_resolve_identifier_xref_intersphinx_absolute_id():
+def test_EpydocLinker_resolve_identifier_xref_intersphinx_absolute_id() -> None:
     """
     Returns the link from Sphinx inventory based on a cross reference
     ID specified in absolute dotted path and with a custom pretty text for the
@@ -314,7 +316,7 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_absolute_id():
     assert "http://tm.tld/some.html" == url
 
 
-def test_EpydocLinker_resolve_identifier_xref_intersphinx_relative_id():
+def test_EpydocLinker_resolve_identifier_xref_intersphinx_relative_id() -> None:
     """
     Return the link from inventory using short names, by resolving them based
     on the imports done in the module.
@@ -338,7 +340,7 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_relative_id():
     assert "http://tm.tld/some.html" == url
 
 
-def test_EpydocLinker_resolve_identifier_xref_intersphinx_link_not_found(capsys):
+def test_EpydocLinker_resolve_identifier_xref_intersphinx_link_not_found(capsys: CapSys) -> None:
     """
     A message is sent to stdout when no link could be found for the reference,
     while returning the reference name without an A link tag.
@@ -367,7 +369,7 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_link_not_found(capsys)
     assert expected == captured
 
 
-def test_EpydocLinker_resolve_identifier_xref_order(capsys):
+def test_EpydocLinker_resolve_identifier_xref_order(capsys: CapSys) -> None:
     """
     Check that the best match is picked when there are multiple candidates.
     """
@@ -384,7 +386,7 @@ def test_EpydocLinker_resolve_identifier_xref_order(capsys):
     assert not capsys.readouterr().out
 
 
-def test_stdlib_doc_link_for_name():
+def test_stdlib_doc_link_for_name() -> None:
     """
     Check the URLs returned for names from the standard library.
     """

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -5,7 +5,7 @@ Unit tests for model.
 import sys
 import zlib
 
-from pydoctor import model, sphinx
+from pydoctor import model
 from pydoctor.driver import parse_args
 from pydoctor.test.test_astbuilder import fromText
 
@@ -83,7 +83,7 @@ def test_fetchIntersphinxInventories_empty():
     options.intersphinx = []
     sut = model.System(options=options)
 
-    sut.fetchIntersphinxInventories(sphinx.StubCache({}))
+    sut.fetchIntersphinxInventories({})
 
     # Use internal state since I don't know how else to
     # check for SphinxInventory state.
@@ -112,7 +112,7 @@ def test_fetchIntersphinxInventories_content():
     # Patch url getter to avoid touching the network.
     sut.intersphinx._getURL = lambda url: url_content[url]
 
-    sut.fetchIntersphinxInventories(sphinx.StubCache(url_content))
+    sut.fetchIntersphinxInventories(url_content)
 
     assert [] == log
     assert (

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -15,6 +15,7 @@ class FakeOptions:
     A fake options object as if it came from that stupid optparse thing.
     """
     sourcehref = None
+    projectbasedirectory: str
 
 
 
@@ -23,12 +24,13 @@ class FakeDocumentable:
     A fake of pydoctor.model.Documentable that provides a system and
     sourceHref attribute.
     """
-    system = None
+    system: model.System
     sourceHref = None
+    filepath: str
 
 
 
-def test_setSourceHrefOption():
+def test_setSourceHrefOption() -> None:
     """
     Test that the projectbasedirectory option sets the model.sourceHref
     properly.
@@ -53,7 +55,7 @@ def test_setSourceHrefOption():
     assert mod.sourceHref == expected
 
 
-def test_initialization_default():
+def test_initialization_default() -> None:
     """
     When initialized without options, will use default options and default
     verbosity.
@@ -64,7 +66,7 @@ def test_initialization_default():
     assert 3 == sut.options.verbosity
 
 
-def test_initialization_options():
+def test_initialization_options() -> None:
     """
     Can be initialized with options.
     """
@@ -75,7 +77,7 @@ def test_initialization_options():
     assert options is sut.options
 
 
-def test_fetchIntersphinxInventories_empty():
+def test_fetchIntersphinxInventories_empty() -> None:
     """
     Convert option to empty dict.
     """
@@ -90,7 +92,7 @@ def test_fetchIntersphinxInventories_empty():
     assert {} == sut.intersphinx._links
 
 
-def test_fetchIntersphinxInventories_content():
+def test_fetchIntersphinxInventories_content() -> None:
     """
     Download and parse intersphinx inventories for each configured
     intersphix.
@@ -108,7 +110,9 @@ def test_fetchIntersphinxInventories_content():
         }
     sut = model.System(options=options)
     log = []
-    sut.msg = lambda part, msg: log.append((part, msg))
+    def log_msg(part: str, msg: str) -> None:
+        log.append((part, msg))
+    sut.msg = log_msg # type: ignore[assignment]
     # Patch url getter to avoid touching the network.
     sut.intersphinx._getURL = lambda url: url_content[url]
 
@@ -125,7 +129,7 @@ def test_fetchIntersphinxInventories_content():
         )
 
 
-def test_docsources_class_attribute():
+def test_docsources_class_attribute() -> None:
     src = '''
     class Base:
         attr = False
@@ -139,7 +143,7 @@ def test_docsources_class_attribute():
     assert base_attr in list(sub_attr.docsources())
 
 
-def test_docstring_lineno():
+def test_docstring_lineno() -> None:
     src = '''
     def f():
         """
@@ -156,10 +160,10 @@ def test_docstring_lineno():
 
 
 class Dummy:
-    def crash(self):
+    def crash(self) -> None:
         """Mmm"""
 
-def test_introspection():
+def test_introspection() -> None:
     """Find docstrings from this test using introspection."""
     system = model.System()
     py_mod = sys.modules[__name__]

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -1,10 +1,11 @@
+from typing import Type
 import os
 
 from pydoctor import model
 
 testpackages = os.path.join(os.path.dirname(__file__), 'testpackages')
 
-def processPackage(packname, systemcls=model.System):
+def processPackage(packname: str, systemcls: Type[model.System] = model.System) -> model.System:
     testpackage = os.path.join(testpackages, packname)
     system = systemcls()
     system.packages.append(testpackage)
@@ -12,36 +13,36 @@ def processPackage(packname, systemcls=model.System):
     system.process()
     return system
 
-def test_relative_import():
+def test_relative_import() -> None:
     system = processPackage("relativeimporttest")
     cls = system.allobjects['relativeimporttest.mod1.C']
     assert cls.bases == ['relativeimporttest.mod2.B']
 
-def test_package_docstring():
+def test_package_docstring() -> None:
     system = processPackage("relativeimporttest")
     assert (system.allobjects['relativeimporttest.__init__'].docstring ==
             "DOCSTRING")
 
-def test_modnamedafterbuiltin():
+def test_modnamedafterbuiltin() -> None:
     # well, basically the test is that this doesn't explode:
     system = processPackage("modnamedafterbuiltin")
     # but let's test _something_
     assert system.allobjects['modnamedafterbuiltin.mod.Dict'].baseobjects == [None], \
       system.allobjects['modnamedafterbuiltin.mod.Dict'].baseobjects
 
-def test_nestedconfusion():
+def test_nestedconfusion() -> None:
     system = processPackage("nestedconfusion")
     A = system.allobjects['nestedconfusion.mod.nestedconfusion.A']
     C = system.allobjects['nestedconfusion.mod.C']
     assert A.baseobjects[0] is C
 
-def test_importingfrompackage():
+def test_importingfrompackage() -> None:
     system = processPackage("importingfrompackage")
     system.getProcessedModule('importingfrompackage.mod')
     submod = system.allobjects['importingfrompackage.subpack.submod']
     assert submod.state is model.ProcessingState.PROCESSED
 
-def test_allgames():
+def test_allgames() -> None:
     system = processPackage("allgames")
     # InSourceAll is not moved into mod2, but NotInSourceAll is.
     assert 'InSourceAll' in system.allobjects['allgames.mod1'].contents

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -74,6 +74,10 @@ def inv_writer_nolog() -> sphinx.SphinxInventoryWriter:
     return sphinx.SphinxInventoryWriter(logger=PydoctorNoLogger(), project_name='project_name')
 
 
+IGNORE_SYSTEM = cast(model.System, 'ignore-system')
+"""Passed as a System when we don't want the system to be accessed."""
+
+
 def test_generate_empty_functional(inv_writer: InvWriter) -> None:
     """
     Functional test for index generation of empty API.
@@ -133,7 +137,7 @@ def test_generateLine_package(inv_writer_nolog: sphinx.SphinxInventoryWriter) ->
     """
 
     result = inv_writer_nolog._generateLine(
-        model.Package('ignore-system', 'package1'))
+        model.Package(IGNORE_SYSTEM, 'package1'))
 
     assert 'package1 py:module -1 package1.html -\n' == result
 
@@ -144,7 +148,7 @@ def test_generateLine_module(inv_writer_nolog: sphinx.SphinxInventoryWriter) -> 
     """
 
     result = inv_writer_nolog._generateLine(
-        model.Module('ignore-system', 'module1'))
+        model.Module(IGNORE_SYSTEM, 'module1'))
 
     assert 'module1 py:module -1 module1.html -\n' == result
 
@@ -155,7 +159,7 @@ def test_generateLine_class(inv_writer_nolog: sphinx.SphinxInventoryWriter) -> N
     """
 
     result = inv_writer_nolog._generateLine(
-        model.Class('ignore-system', 'class1'))
+        model.Class(IGNORE_SYSTEM, 'class1'))
 
     assert 'class1 py:class -1 class1.html -\n' == result
 
@@ -167,10 +171,10 @@ def test_generateLine_function(inv_writer_nolog: sphinx.SphinxInventoryWriter) -
     Functions are inside a module.
     """
 
-    parent = model.Module('ignore-system', 'module1')
+    parent = model.Module(IGNORE_SYSTEM, 'module1')
 
     result = inv_writer_nolog._generateLine(
-        model.Function('ignore-system', 'func1', parent))
+        model.Function(IGNORE_SYSTEM, 'func1', parent))
 
     assert 'module1.func1 py:function -1 module1.html#func1 -\n' == result
 
@@ -182,10 +186,10 @@ def test_generateLine_method(inv_writer_nolog: sphinx.SphinxInventoryWriter) -> 
     Methods are functions inside a class.
     """
 
-    parent = model.Class('ignore-system', 'class1')
+    parent = model.Class(IGNORE_SYSTEM, 'class1')
 
     result = inv_writer_nolog._generateLine(
-        model.Function('ignore-system', 'meth1', parent))
+        model.Function(IGNORE_SYSTEM, 'meth1', parent))
 
     assert 'class1.meth1 py:method -1 class1.html#meth1 -\n' == result
 
@@ -195,10 +199,10 @@ def test_generateLine_attribute(inv_writer_nolog: sphinx.SphinxInventoryWriter) 
     Check inventory for attributes.
     """
 
-    parent = model.Class('ignore-system', 'class1')
+    parent = model.Class(IGNORE_SYSTEM, 'class1')
 
     result = inv_writer_nolog._generateLine(
-        model.Attribute('ignore-system', 'attr1', parent))
+        model.Attribute(IGNORE_SYSTEM, 'attr1', parent))
 
     assert 'class1.attr1 py:attribute -1 class1.html#attr1 -\n' == result
 
@@ -216,7 +220,7 @@ def test_generateLine_unknown(inv_writer: InvWriter) -> None:
     """
 
     result = inv_writer._generateLine(
-        UnknownType('ignore-system', 'unknown1'))
+        UnknownType(IGNORE_SYSTEM, 'unknown1'))
 
     assert 'unknown1 py:obj -1 unknown1.html -\n' == result
     assert [(

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -325,7 +325,7 @@ def test_update_functional():
 
     url = 'http://some.url/api/objects.inv'
 
-    sut.update(sphinx.StubCache({url: content}), url)
+    sut.update({url: content}, url)
 
     assert 'http://some.url/api/module1.html' == sut.getLink('some.module1')
     assert 'http://some.url/api/module2.html' == sut.getLink('other.module2')
@@ -337,7 +337,7 @@ def test_update_bad_url():
     """
     sut, log = make_SphinxInventoryWithLog()
 
-    sut.update(sphinx.StubCache({}), 'really.bad.url')
+    sut.update({}, 'really.bad.url')
 
     assert sut._links == {}
     expected_log = [(
@@ -352,7 +352,7 @@ def test_update_fail():
     """
     sut, log = make_SphinxInventoryWithLog()
 
-    sut.update(sphinx.StubCache({}), 'http://some.tld/o.inv')
+    sut.update({}, 'http://some.tld/o.inv')
 
     assert sut._links == {}
     expected_log = [(
@@ -586,32 +586,6 @@ class TestIntersphinxCache:
         assert caplog.records[0].levelname == "ERROR"
         assert caplog.records[0].exc_info is not None
         assert caplog.records[0].exc_info[0] is _TestException
-
-
-class TestStubCache:
-    """
-    Tests for L{sphinx.StubCache}.
-    """
-
-    def test_getFromCache(self):
-        """
-        L{sphinx.StubCache.get} returns its cached content for a URL.
-        """
-        url = "url"
-        content = b"content"
-
-        cache = sphinx.StubCache({url: content})
-
-        assert cache.get(url) is content
-
-    def test_not_in_cache(self):
-        """
-        L{sphinx.StubCache.get} returns L{None} if it has no cached
-        content for a URL.
-        """
-        cache = sphinx.StubCache({})
-
-        assert cache.get(b"url") is None
 
 
 @given(

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -197,7 +197,11 @@ def test_generateLine_unknown():
         UnknownType('ignore-system', 'unknown1'))
 
     assert 'unknown1 py:obj -1 unknown1.html -\n' == result
-
+    assert [(
+        'sphinx',
+        "Unknown type <class 'pydoctor.test.test_sphinx.UnknownType'> for unknown1.",
+        -1
+        )] == log
 
 
 def test_getPayload_empty():

--- a/pydoctor/test/test_templatewriter.py
+++ b/pydoctor/test/test_templatewriter.py
@@ -1,6 +1,3 @@
-import os
-import shutil
-import tempfile
 from io import BytesIO
 
 import pytest
@@ -60,24 +57,20 @@ def test_document_code_in_init_module():
     html = getHTMLOf(system.allobjects['codeininit'])
     assert 'functionInInit' in html
 
-def test_basic_package():
+def test_basic_package(tmp_path):
     system = processPackage("basic")
-    targetdir = tempfile.mkdtemp()
-    try:
-        w = writer.TemplateWriter(targetdir)
-        system.options.htmlusesplitlinks = True
-        system.options.htmlusesorttable = True
-        w.prepOutputDirectory()
-        root, = system.rootobjects
-        w.writeDocsFor(root, False)
-        w.writeModuleIndex(system)
-        for ob in system.allobjects.values():
-            if ob.documentation_location is model.DocLocation.OWN_PAGE:
-                assert os.path.isfile(os.path.join(targetdir, ob.fullName() + '.html'))
-        with open(os.path.join(targetdir, 'basic.html')) as f:
-            assert 'Package docstring' in f.read()
-    finally:
-        shutil.rmtree(targetdir)
+    w = writer.TemplateWriter(str(tmp_path))
+    system.options.htmlusesplitlinks = True
+    system.options.htmlusesorttable = True
+    w.prepOutputDirectory()
+    root, = system.rootobjects
+    w.writeDocsFor(root, False)
+    w.writeModuleIndex(system)
+    for ob in system.allobjects.values():
+        if ob.documentation_location is model.DocLocation.OWN_PAGE:
+            assert (tmp_path / f'{ob.fullName()}.html').is_file()
+    with open(tmp_path / 'basic.html') as f:
+        assert 'Package docstring' in f.read()
 
 def test_hasdocstring():
     system = processPackage("basic")

--- a/pydoctor/test/test_templatewriter.py
+++ b/pydoctor/test/test_templatewriter.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 from pydoctor import model, templatewriter
@@ -7,19 +8,20 @@ from pydoctor.test.test_astbuilder import fromText
 from pydoctor.test.test_packages import processPackage
 
 
-def flatten(t):
+def flatten(t: pages.ChildTable) -> str:
     io = BytesIO()
     writer.flattenToFile(io, t)
     return io.getvalue().decode()
 
 
-def getHTMLOf(ob):
+def getHTMLOf(ob: model.Documentable) -> str:
     wr = templatewriter.TemplateWriter('')
     f = BytesIO()
     wr.writeDocsForOne(ob, f)
     return f.getvalue().decode()
 
-def test_simple():
+
+def test_simple() -> None:
     src = '''
     def f():
         """This is a docstring."""
@@ -28,19 +30,19 @@ def test_simple():
     v = getHTMLOf(mod.contents['f'])
     assert 'This is a docstring' in v
 
-def test_empty_table():
+def test_empty_table() -> None:
     mod = fromText('')
     t = pages.ChildTable(pages.DocGetter(), mod, [])
     flattened = flatten(t)
     assert 'The renderer named' not in flattened
 
-def test_nonempty_table():
+def test_nonempty_table() -> None:
     mod = fromText('def f(): pass')
     t = pages.ChildTable(pages.DocGetter(), mod, mod.contents.values())
     flattened = flatten(t)
     assert 'The renderer named' not in flattened
 
-def test_rest_support():
+def test_rest_support() -> None:
     system = model.System()
     system.options.docformat = 'restructuredtext'
     system.options.verbosity = 4
@@ -52,12 +54,12 @@ def test_rest_support():
     html = getHTMLOf(mod.contents['f'])
     assert "<pre>" not in html
 
-def test_document_code_in_init_module():
+def test_document_code_in_init_module() -> None:
     system = processPackage("codeininit")
     html = getHTMLOf(system.allobjects['codeininit'])
     assert 'functionInInit' in html
 
-def test_basic_package(tmp_path):
+def test_basic_package(tmp_path: Path) -> None:
     system = processPackage("basic")
     w = writer.TemplateWriter(str(tmp_path))
     system.options.htmlusesplitlinks = True
@@ -72,7 +74,7 @@ def test_basic_package(tmp_path):
     with open(tmp_path / 'basic.html') as f:
         assert 'Package docstring' in f.read()
 
-def test_hasdocstring():
+def test_hasdocstring() -> None:
     system = processPackage("basic")
     from pydoctor.templatewriter.summary import hasdocstring
     assert not hasdocstring(system.allobjects['basic._private_mod'])
@@ -80,7 +82,7 @@ def test_hasdocstring():
     sub_f = system.allobjects['basic.mod.D.f']
     assert hasdocstring(sub_f) and not sub_f.docstring
 
-def test_missing_variable():
+def test_missing_variable() -> None:
     mod = fromText('''
     """Module docstring.
 
@@ -95,7 +97,7 @@ def test_missing_variable():
     'className',
     ['NewClassThatMultiplyInherits', 'OldClassThatMultiplyInherits'],
 )
-def test_multipleInheritanceNewClass(className):
+def test_multipleInheritanceNewClass(className: str) -> None:
     """
     A class that has multiple bases has all methods in its MRO
     rendered.

--- a/pydoctor/test/test_templatewriter.py
+++ b/pydoctor/test/test_templatewriter.py
@@ -18,7 +18,6 @@ def flatten(t):
 
 def getHTMLOf(ob):
     wr = templatewriter.TemplateWriter('')
-    wr.system = ob.system
     f = BytesIO()
     wr.writeDocsForOne(ob, f)
     return f.getvalue().decode()
@@ -66,7 +65,6 @@ def test_basic_package():
     targetdir = tempfile.mkdtemp()
     try:
         w = writer.TemplateWriter(targetdir)
-        w.system = system
         system.options.htmlusesplitlinks = True
         system.options.htmlusesorttable = True
         w.prepOutputDirectory()

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -2,10 +2,13 @@ from pydoctor.test.test_astbuilder import fromText
 from pydoctor.test.test_packages import processPackage
 from pydoctor.zopeinterface import ZopeInterfaceSystem
 
+from . import CapSys
+
+
 # we set up the same situation using both implements and
 # classImplements and run the same tests.
 
-def test_implements():
+def test_implements() -> None:
     src = '''
     import zope.interface
 
@@ -23,7 +26,7 @@ def test_implements():
     '''
     implements_test(src)
 
-def test_classImplements():
+def test_classImplements() -> None:
     src = '''
     import zope.interface
     class IFoo(zope.interface.Interface):
@@ -42,7 +45,7 @@ def test_classImplements():
     '''
     implements_test(src)
 
-def test_implementer():
+def test_implementer() -> None:
     src = '''
     import zope.interface
 
@@ -62,7 +65,7 @@ def test_implementer():
     '''
     implements_test(src)
 
-def implements_test(src):
+def implements_test(src: str) -> None:
     mod = fromText(src, 'zi', systemcls=ZopeInterfaceSystem)
     ifoo = mod.contents['IFoo']
     ibar = mod.contents['IBar']
@@ -89,7 +92,7 @@ def implements_test(src):
     assert ibar.allImplementations == [foobar, onlybar]
 
 
-def test_subclass_with_same_name():
+def test_subclass_with_same_name() -> None:
     src = '''
     class A:
         pass
@@ -98,7 +101,7 @@ def test_subclass_with_same_name():
     '''
     fromText(src, 'zi', systemcls=ZopeInterfaceSystem)
 
-def test_multiply_inheriting_interfaces():
+def test_multiply_inheriting_interfaces() -> None:
     src = '''
     from zope.interface import Interface, implements
 
@@ -111,7 +114,7 @@ def test_multiply_inheriting_interfaces():
     mod = fromText(src, 'zi', systemcls=ZopeInterfaceSystem)
     assert len(mod.contents['Both'].allImplementedInterfaces) == 2
 
-def test_attribute(capsys):
+def test_attribute(capsys: CapSys) -> None:
     src = '''
     import zope.interface as zi
     class C(zi.Interface):
@@ -131,14 +134,14 @@ def test_attribute(capsys):
     captured = capsys.readouterr().out
     assert captured == 'mod:5: definition of attribute "bad_attr" should have docstring as its sole argument\n'
 
-def test_interfaceclass():
+def test_interfaceclass() -> None:
     system = processPackage('interfaceclass', systemcls=ZopeInterfaceSystem)
     mod = system.allobjects['interfaceclass.mod']
     assert mod.contents['MyInterface'].isinterface
     assert mod.contents['MyInterface'].docstring == "This is my interface."
     assert mod.contents['AnInterface'].isinterface
 
-def test_warnerproofing():
+def test_warnerproofing() -> None:
     src = '''
     from zope import interface
     Interface = interface.Interface
@@ -148,7 +151,7 @@ def test_warnerproofing():
     mod = fromText(src, systemcls=ZopeInterfaceSystem)
     assert mod.contents['IMyInterface'].isinterface
 
-def test_zopeschema(capsys):
+def test_zopeschema(capsys: CapSys) -> None:
     src = '''
     from zope import schema, interface
     class IMyInterface(interface.Interface):
@@ -169,7 +172,7 @@ def test_zopeschema(capsys):
     captured = capsys.readouterr().out
     assert captured == 'mod:6: description of field "bad" is not a string literal\n'
 
-def test_aliasing_in_class():
+def test_aliasing_in_class() -> None:
     src = '''
     from zope import interface
     class IMyInterface(interface.Interface):
@@ -181,7 +184,7 @@ def test_aliasing_in_class():
     assert attr.docstring == 'fun in a bun'
     assert attr.kind == "Attribute"
 
-def test_zopeschema_inheritance():
+def test_zopeschema_inheritance() -> None:
     src = '''
     from zope import schema, interface
     from zope.schema import Int as INTEGERSCHMEMAFIELD
@@ -204,7 +207,7 @@ def test_zopeschema_inheritance():
     myint = mod.contents['IMyInterface'].contents['myint']
     assert myint.kind == "Int"
 
-def test_docsources_includes_interface():
+def test_docsources_includes_interface() -> None:
     src = '''
     from zope import interface
     class IInterface(interface.Interface):
@@ -220,7 +223,7 @@ def test_docsources_includes_interface():
     method = mod.contents['Implementation'].contents['method']
     assert imethod in method.docsources(), list(method.docsources())
 
-def test_docsources_includes_baseinterface():
+def test_docsources_includes_baseinterface() -> None:
     src = '''
     from zope import interface
     class IBase(interface.Interface):
@@ -238,7 +241,7 @@ def test_docsources_includes_baseinterface():
     method = mod.contents['Implementation'].contents['method']
     assert imethod in method.docsources(), list(method.docsources())
 
-def test_docsources_interface_attribute():
+def test_docsources_interface_attribute() -> None:
     src = '''
     from zope import interface
     class IInterface(interface.Interface):
@@ -252,7 +255,7 @@ def test_docsources_interface_attribute():
     attr = mod.contents['Implementation'].contents['attr']
     assert iattr in list(attr.docsources())
 
-def test_implementer_decoration():
+def test_implementer_decoration() -> None:
     src = '''
     from zope.interface import Interface, implementer
     class IMyInterface(Interface):
@@ -268,7 +271,7 @@ def test_implementer_decoration():
     impl = mod.contents['Implementation']
     assert impl.implements_directly == [iface.fullName()]
 
-def test_implementer_decoration_nonclass():
+def test_implementer_decoration_nonclass() -> None:
     src = '''
     from zope.interface import implementer
     var = 0
@@ -280,7 +283,7 @@ def test_implementer_decoration_nonclass():
     impl = mod.contents['Implementation']
     assert impl.implements_directly == []
 
-def test_docsources_from_moduleprovides():
+def test_docsources_from_moduleprovides() -> None:
     src = '''
     from zope import interface
 
@@ -298,12 +301,12 @@ def test_docsources_from_moduleprovides():
     function = mod.contents['bar']
     assert imethod in function.docsources(), list(function.docsources())
 
-def test_interfaceallgames():
+def test_interfaceallgames() -> None:
     system = processPackage('interfaceallgames', systemcls=ZopeInterfaceSystem)
     mod = system.allobjects['interfaceallgames.interface']
     assert [o.fullName() for o in mod.contents['IAnInterface'].allImplementations] == ['interfaceallgames.implementation.Implementation']
 
-def test_implementer_with_none():
+def test_implementer_with_none() -> None:
     """
     If the implementer call contains a split out empty list, don't fail on
     attempting to process it.
@@ -324,7 +327,7 @@ def test_implementer_with_none():
     impl = mod.contents['Implementation']
     assert impl.implements_directly == [iface.fullName()]
 
-def test_implementer_nonclass(capsys):
+def test_implementer_nonclass(capsys: CapSys) -> None:
     """
     Check rejection of non-class arguments passed to @implementer.
     """
@@ -341,7 +344,7 @@ def test_implementer_nonclass(capsys):
     captured = capsys.readouterr().out
     assert captured == "mod:4: probable interface mod.var not detected as a class\n"
 
-def test_implementer_plainclass(capsys):
+def test_implementer_plainclass(capsys: CapSys) -> None:
     """
     Check patching of non-interface classes passed to @implementer.
     """

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ description = run mypy (static type checker)
 deps =
     mypy>=0.770
     mypy-zope
+    typing-extensions
     ; Libraries which include type annotations:
     hypothesis
 


### PR DESCRIPTION
My hope is that the calls made by the test cases to the code under test will act as a sanity check when adding type annotations to that code.

In any case, the process of adding the annotations to the unit tests led to several code and test cleanups already. I put these in separate commits, for easier reviewing.