### PR TITLE
Add return type information only for functions

### DIFF
--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -36,9 +36,11 @@ each error.
 """
 __docformat__ = 'epytext en'
 
+from typing import List
 import re
 
-from twisted.web.template import XMLString, flattenString
+from twisted.python.failure import Failure
+from twisted.web.template import Tag, XMLString, flattenString
 
 ##################################################
 ## Contents
@@ -108,7 +110,7 @@ def html2stan(html):
     stan.tagName = ''
     return stan
 
-def flatten(stan):
+def flatten(stan: Tag) -> str:
     """
     Convert a document fragment from a Stan tree to HTML.
 
@@ -116,8 +118,8 @@ def flatten(stan):
     @return: An HTML string representation of the C{stan} tree.
     @rtype: C{str}
     """
-    ret = []
-    err = []
+    ret: List[bytes] = []
+    err: List[Failure] = []
     flattenString(None, stan).addCallback(ret.append).addErrback(err.append)
     if err:
         raise err[0].value

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -319,12 +319,12 @@ class FieldHandler:
             for name, value in annotations.items()
             }
         ret_type = formatted_annotations.pop('return', None)
-        ret_value = cls(obj, formatted_annotations)
+        handler = cls(obj, formatted_annotations)
         if ret_type is not None:
             return_type = FieldDesc()
             return_type.body = ret_type
-            ret_value.handle_returntype(return_type)
-        return ret_value
+            handler.handle_returntype(return_type)
+        return handler
 
     def redef(self, field):
         self.obj.system.msg(

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -314,15 +314,16 @@ class FieldHandler:
     @classmethod
     def from_ast_annotations(cls, obj: model.Documentable, annotations: Mapping[str, ast.expr]) -> "FieldHandler":
         linker = _EpydocLinker(obj)
-        annotations = {name: AnnotationDocstring(value).to_stan(linker)
-                       for name, value in annotations.items()}
-        return_type = FieldDesc()
-        try:
-            return_type.body = annotations.pop("return")
-        except KeyError:
-            pass
-        ret_value = cls(obj, annotations)
-        ret_value.handle_returntype(return_type)
+        formatted_annotations = {
+            name: AnnotationDocstring(value).to_stan(linker)
+            for name, value in annotations.items()
+            }
+        ret_type = formatted_annotations.pop('return', None)
+        ret_value = cls(obj, formatted_annotations)
+        if ret_type is not None:
+            return_type = FieldDesc()
+            return_type.body = ret_type
+            ret_value.handle_returntype(return_type)
         return ret_value
 
     def redef(self, field):

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -438,7 +438,10 @@ class FieldHandler:
             label = f"Unknown Field: {kind}"
             r.append(format_desc_list(label, fieldlist, label))
 
-        return tags.table(class_='fieldTable')(r)
+        if any(r):
+            return tags.table(class_='fieldTable')(r)
+        else:
+            return tags.transparent
 
 
 def reportErrors(obj, errs):

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -38,6 +38,10 @@ def test_multiple_types():
     epydoc2stan.format_docstring(mod.contents['D'])
     epydoc2stan.format_docstring(mod.contents['E'])
 
+def docstring2html(docstring: model.Documentable) -> str:
+    stan = epydoc2stan.format_docstring(docstring)
+    return flatten(stan).replace('><', '>\n<')
+
 def test_func_arg_and_ret_annotation():
     annotation_mod = fromText('''
     def f(a: List[str]) -> bool:
@@ -55,11 +59,8 @@ def test_func_arg_and_ret_annotation():
         @rtype: bool
         """
     ''')
-    def format(docstring):
-        stan = epydoc2stan.format_docstring(docstring)
-        return flatten(stan).replace('><', '>\n<')
-    annotation_fmt = format(annotation_mod.contents['f'])
-    classic_fmt = format(classic_mod.contents['f'])
+    annotation_fmt = docstring2html(annotation_mod.contents['f'])
+    classic_fmt = docstring2html(classic_mod.contents['f'])
     assert annotation_fmt == classic_fmt
 
 def test_func_arg_and_ret_annotation_with_override():
@@ -83,11 +84,8 @@ def test_func_arg_and_ret_annotation_with_override():
         @rtype: bool
         """
     ''')
-    def format(docstring):
-        stan = epydoc2stan.format_docstring(docstring)
-        return flatten(stan).replace('><', '>\n<')
-    annotation_fmt = format(annotation_mod.contents['f'])
-    classic_fmt = format(classic_mod.contents['f'])
+    annotation_fmt = docstring2html(annotation_mod.contents['f'])
+    classic_fmt = docstring2html(classic_mod.contents['f'])
     assert annotation_fmt == classic_fmt
 
 def test_func_arg_when_doc_missing():
@@ -106,11 +104,8 @@ def test_func_arg_when_doc_missing():
         @rtype: bool
         """
     ''')
-    def format(docstring):
-        stan = epydoc2stan.format_docstring(docstring)
-        return flatten(stan).replace('><', '>\n<')
-    annotation_fmt = format(annotation_mod.contents['f'])
-    classic_fmt = format(classic_mod.contents['f'])
+    annotation_fmt = docstring2html(annotation_mod.contents['f'])
+    classic_fmt = docstring2html(classic_mod.contents['f'])
     assert annotation_fmt == classic_fmt
 
 

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from pytest import raises
 
 from pydoctor import epydoc2stan, model
@@ -41,6 +43,17 @@ def test_multiple_types():
 def docstring2html(docstring: model.Documentable) -> str:
     stan = epydoc2stan.format_docstring(docstring)
     return flatten(stan).replace('><', '>\n<')
+
+def test_html_empty_module() -> None:
+    mod = fromText('''
+    """Empty module."""
+    ''')
+    expected_html = textwrap.dedent("""
+    <div>
+    <p>Empty module.</p>
+    </div>
+    """).strip()
+    assert docstring2html(mod) == expected_html
 
 def test_func_arg_and_ret_annotation():
     annotation_mod = fromText('''


### PR DESCRIPTION
I noticed a stray "Returns" at the end of module descriptions when using pydoctor's `master` branch, but not with the 20.7.1 release. So this is a regression, probably introduced as part of #209.

The problem is that an empty `FieldDesc` is assigned to `return_desc`, which ends up in the HTML output as a return value because it evaluates to `True` even when empty. Rather than trying to define exactly how empty a `FieldDesc` must be to be considered `False`, I decided it was clearer to leave `return_desc` on its default value of `None` for `Documentables` other than functions.
