### PR TITLE
Fix issues in HTML rendering of function fields

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -3,7 +3,7 @@
 import ast
 import sys
 from itertools import chain
-from typing import Iterator, Mapping, Optional, Tuple
+from typing import Iterator, Mapping, Tuple
 
 import astor
 from pydoctor import epydoc2stan, model
@@ -507,15 +507,15 @@ class ModuleVistor(ast.NodeVisitor):
             kwargs = base_args.kwarg
             if kwargs:
                 yield kwargs
-        def _get_all_ast_annotations() -> Iterator[Tuple[str, Optional[ast.expr]]]:
+        def _get_all_ast_annotations() -> Iterator[Tuple[str, ast.expr]]:
             for arg in _get_all_args():
-                yield arg.arg, arg.annotation
+                if arg.annotation:
+                    yield arg.arg, arg.annotation
             returns = func.returns
             if returns:
                 yield 'return', returns
-        return {name: value
-                for name, value in _get_all_ast_annotations()
-                if value is not None}
+        return {name: self._unstring_annotation(value)
+                for name, value in _get_all_ast_annotations()}
 
     def _unstring_annotation(self, node: ast.expr) -> ast.expr:
         """Replace all strings in the given expression by parsed versions.

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -517,9 +517,10 @@ class ModuleVistor(ast.NodeVisitor):
                 for name, value in _get_all_ast_annotations()
                 if value is not None}
 
-    def _unstring_annotation(self, node: ast.expr) -> Optional[ast.expr]:
+    def _unstring_annotation(self, node: ast.expr) -> ast.expr:
         """Replace all strings in the given expression by parsed versions.
-        Returns the resulting node, or L{None} if parsing failed.
+        @return: The unstringed node. If parsing fails, an error is logged
+            and the original node is returned.
         """
         try:
             expr = _AnnotationStringParser().visit(node)
@@ -529,7 +530,7 @@ class ModuleVistor(ast.NodeVisitor):
             self.builder.currentMod.report(
                     f'syntax error in annotation: {ex}',
                     lineno_offset=node.lineno)
-            return None
+            return node
 
 
 class _AnnotationStringParser(ast.NodeTransformer):

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -556,6 +556,19 @@ class _AnnotationStringParser(ast.NodeTransformer):
         else:
             raise SyntaxError("expected expression, found statement")
 
+    def visit_Subscript(self, node: ast.Subscript) -> ast.Subscript:
+        value = self.visit(node.value)
+        if isinstance(value, ast.Name) and value.id == 'Literal':
+            # Literal[...] expression; don't unstring the arguments.
+            slice = node.slice
+        elif isinstance(value, ast.Attribute) and value.attr == 'Literal':
+            # typing.Literal[...] expression; don't unstring the arguments.
+            slice = node.slice
+        else:
+            # Other subscript; unstring the slice.
+            slice = self.visit(node.slice)
+        return ast.Subscript(value, slice, node.ctx)
+
     # For Python >= 3.8:
 
     def visit_Constant(self, node: ast.Constant) -> ast.expr:

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -3,7 +3,7 @@
 import ast
 import sys
 from itertools import chain
-from typing import Mapping, Iterable, Tuple, Optional
+from typing import Iterator, Mapping, Optional, Tuple
 
 import astor
 from pydoctor import epydoc2stan, model
@@ -53,7 +53,7 @@ def node2fullname(expr, ctx):
 
 
 def _get_function_signature_annotations(func_ast: ast.FunctionDef) -> Mapping[str, ast.expr]:
-    def _get_all_args() -> Iterable[ast.arg]:
+    def _get_all_args() -> Iterator[ast.arg]:
         base_args = func_ast.args
         # New on Python 3.8 -- handle absence gracefully
         try:
@@ -68,7 +68,7 @@ def _get_function_signature_annotations(func_ast: ast.FunctionDef) -> Mapping[st
         kwargs = base_args.kwarg
         if kwargs:
             yield kwargs
-    def _get_all_ast_annotations() -> Iterable[Tuple[str, Optional[ast.expr]]]:
+    def _get_all_ast_annotations() -> Iterator[Tuple[str, Optional[ast.expr]]]:
         for arg in _get_all_args():
             yield arg.arg, arg.annotation
         returns = func_ast.returns

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -535,7 +535,13 @@ class ModuleVistor(ast.NodeVisitor):
 
 
 class _AnnotationStringParser(ast.NodeTransformer):
-    """Implementation of L{ModuleVistor._unstring_annotation()}."""
+    """Implementation of L{ModuleVistor._unstring_annotation()}.
+
+    When given an expression, the node returned by L{visit()} will also
+    be an expression.
+    If any string literal contained in the original expression is either
+    invalid Python or not a singular expression, L{SyntaxError} is raised.
+    """
 
     def _parse_string(self, value: str) -> ast.expr:
         statements = ast.parse(value).body
@@ -543,6 +549,7 @@ class _AnnotationStringParser(ast.NodeTransformer):
             raise SyntaxError("expected expression, found multiple statements")
         stmt, = statements
         if isinstance(stmt, ast.Expr):
+            # Expression wrapped in an Expr statement.
             expr = self.visit(stmt.value)
             assert isinstance(expr, ast.expr), expr
             return expr

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -538,7 +538,10 @@ class _AnnotationStringParser(ast.NodeTransformer):
     """Implementation of L{ModuleVistor._unstring_annotation()}."""
 
     def _parse_string(self, value: str) -> ast.expr:
-        stmt, = ast.parse(value).body
+        statements = ast.parse(value).body
+        if len(statements) != 1:
+            raise SyntaxError("expected expression, found multiple statements")
+        stmt, = statements
         if isinstance(stmt, ast.Expr):
             expr = self.visit(stmt.value)
             assert isinstance(expr, ast.expr), expr

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -524,13 +524,14 @@ class ModuleVistor(ast.NodeVisitor):
         """
         try:
             expr = _AnnotationStringParser().visit(node)
-            assert isinstance(expr, ast.expr), expr
-            return expr
         except SyntaxError as ex:
             self.builder.currentMod.report(
                     f'syntax error in annotation: {ex}',
                     lineno_offset=node.lineno)
             return node
+        else:
+            assert isinstance(expr, ast.expr), expr
+            return expr
 
 
 class _AnnotationStringParser(ast.NodeTransformer):

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -284,7 +284,7 @@ class Field:
         self.tag = field.tag()
         self.arg = field.arg()
         self.lineno = field.lineno
-        self.body = tags.code(field.body().to_stan(_EpydocLinker(obj)))
+        self.body = field.body().to_stan(_EpydocLinker(obj))
 
     def __repr__(self):
         r = repr(self.body)

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -1,3 +1,4 @@
+import ast
 import textwrap
 
 import astor
@@ -857,7 +858,7 @@ def test_bad_string_annotation(annotation, systemcls, capsys):
     mod = fromText(f'''
     x: "{annotation}"
     ''', modname='test', systemcls=systemcls)
-    assert mod.contents['x'].annotation is None
+    assert isinstance(mod.contents['x'].annotation, ast.expr)
     assert "syntax error in annotation" in capsys.readouterr().out
 
 @systemcls_param

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -851,10 +851,11 @@ def test_type_comment(systemcls, capsys):
     assert type2str(mod.contents['i'].annotation) == 'List'
     assert not capsys.readouterr().out
 
+@pytest.mark.parametrize('annotation', ("[", "pass"))
 @systemcls_param
-def test_bad_string_annotation(systemcls, capsys):
-    mod = fromText('''
-    x: "["
+def test_bad_string_annotation(annotation, systemcls, capsys):
+    mod = fromText(f'''
+    x: "{annotation}"
     ''', modname='test', systemcls=systemcls)
     assert mod.contents['x'].annotation is None
     assert "syntax error in annotation" in capsys.readouterr().out

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -855,11 +855,26 @@ def test_type_comment(systemcls, capsys):
 @pytest.mark.parametrize('annotation', ("[", "pass", "1 ; 2"))
 @systemcls_param
 def test_bad_string_annotation(annotation, systemcls, capsys):
+    """Invalid string annotations must be reported as syntax errors."""
     mod = fromText(f'''
     x: "{annotation}"
     ''', modname='test', systemcls=systemcls)
     assert isinstance(mod.contents['x'].annotation, ast.expr)
     assert "syntax error in annotation" in capsys.readouterr().out
+
+@pytest.mark.parametrize('annotation,expected', (
+    ("Literal['[', ']']", "Literal['[', ']']"),
+    ("typing.Literal['pass', 'raise']", "typing.Literal['pass', 'raise']"),
+    ("Optional[Literal['1 ; 2']]", "Optional[Literal['1 ; 2']]"),
+    ("'Literal'['!']", "Literal['!']"),
+    (r"'Literal[\'if\', \'while\']'", "Literal['if', 'while']"),
+    ))
+def test_literal_string_annotation(annotation: str, expected: str) -> None:
+    """Strings inside Literal annotations must not be recursively parsed."""
+    stmt, = ast.parse(annotation).body
+    assert isinstance(stmt, ast.Expr)
+    unstringed = astbuilder._AnnotationStringParser().visit(stmt.value)
+    assert astor.to_source(unstringed).strip() == expected
 
 @systemcls_param
 def test_inferred_variable_types(systemcls):

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -852,7 +852,7 @@ def test_type_comment(systemcls, capsys):
     assert type2str(mod.contents['i'].annotation) == 'List'
     assert not capsys.readouterr().out
 
-@pytest.mark.parametrize('annotation', ("[", "pass"))
+@pytest.mark.parametrize('annotation', ("[", "pass", "1 ; 2"))
 @systemcls_param
 def test_bad_string_annotation(annotation, systemcls, capsys):
     mod = fromText(f'''

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -40,17 +40,20 @@ def test_multiple_types():
 
 def test_func_arg_and_ret_annotation():
     annotation_mod = fromText('''
-    def f(a: List[str]) -> bool:
+    def f(a: List[str], b: "List[str]") -> bool:
         """
         @param a: an arg, a the best of args
+        @param b: a param to follow a
         @return: the best that we can do
         """
     ''')
     classic_mod = fromText('''
-    def f(a):
+    def f(a, b):
         """
         @param a: an arg, a the best of args
         @type a: C{List[str]}
+        @param b: a param to follow a
+        @type b: C{List[str]}
         @return: the best that we can do
         @rtype: C{bool}
         """

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -50,9 +50,9 @@ def test_func_arg_and_ret_annotation():
     def f(a):
         """
         @param a: an arg, a the best of args
-        @type a: List[str]
+        @type a: C{List[str]}
         @return: the best that we can do
-        @rtype: bool
+        @rtype: C{bool}
         """
     ''')
     def format(docstring):
@@ -68,7 +68,7 @@ def test_func_arg_and_ret_annotation_with_override():
         """
         @param a: an arg, a the best of args
         @param b: a param to follow a
-        @type b: List[awesome]
+        @type b: C{List[awesome]}
         @return: the best that we can do
         """
     ''')
@@ -76,11 +76,11 @@ def test_func_arg_and_ret_annotation_with_override():
     def f(a):
         """
         @param a: an arg, a the best of args
-        @type a: List[str]
+        @type a: C{List[str]}
         @param b: a param to follow a
-        @type b: List[awesome]
+        @type b: C{List[awesome]}
         @return: the best that we can do
-        @rtype: bool
+        @rtype: C{bool}
         """
     ''')
     def format(docstring):
@@ -101,9 +101,9 @@ def test_func_arg_when_doc_missing():
     def f(a):
         """
         Today I will not document details
-        @type a: List[str]
-        @type b: int
-        @rtype: bool
+        @type a: C{List[str]}
+        @type b: C{int}
+        @rtype: C{bool}
         """
     ''')
     def format(docstring):


### PR DESCRIPTION
This fixes two noticeable rendering issues for functions:
- parameter descriptions should not be formatted as code (regression from #209)
- string literal annotations should be parsed ("unstringed") instead of output as strings

It also improves the way errors in annotations are handled:
- avoid a crash when a string literal annotation contains a statement rather than an expression
- if a string literal annotation fails to parse, render it as a string instead of discarding it
