### PR TITLE
Fix parsing of docstrings in restructured text format

### DIFF
--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -36,9 +36,11 @@ each error.
 """
 __docformat__ = 'epytext en'
 
+from typing import List
 import re
 
-from twisted.web.template import XMLString, flattenString
+from twisted.python.failure import Failure
+from twisted.web.template import Tag, XMLString, flattenString
 
 ##################################################
 ## Contents
@@ -108,16 +110,15 @@ def html2stan(html):
     stan.tagName = ''
     return stan
 
-def flatten(stan):
+def flatten(stan: Tag) -> str:
     """
     Convert a document fragment from a Stan tree to HTML.
 
     @param stan: Document fragment to flatten.
     @return: An HTML string representation of the C{stan} tree.
-    @rtype: C{str}
     """
-    ret = []
-    err = []
+    ret: List[bytes] = []
+    err: List[Failure] = []
     flattenString(None, stan).addCallback(ret.append).addErrback(err.append)
     if err:
         raise err[0].value

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -431,7 +431,7 @@ class _EpydocHTMLTranslator(HTMLTranslator):
         # iterate through attributes one at a time because some
         # versions of docutils don't case-normalize attributes.
         for attr_dict in attr_dicts:
-            for (key, val) in attr_dict.items():
+            for key, val in list(attr_dict.items()):
                 # Prefix all CSS classes with "rst-"; and prefix all
                 # names with "rst-" to avoid conflicts.
                 if key.lower() in ('class', 'id', 'name'):

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -165,9 +165,6 @@ class _EpydocReader(StandaloneReader):
         document = new_document(self.source.source_path, self.settings)
         # Capture all warning messages.
         document.reporter.attach_observer(self.report)
-        # These are used so we know how to encode warning messages:
-        self._encoding = document.reporter.encoding
-        self._error_handler = document.reporter.error_handler
         # Return the new document.
         return document
 
@@ -177,8 +174,7 @@ class _EpydocReader(StandaloneReader):
         try: linenum = int(error['line'])
         except: linenum = None
 
-        msg = ''.join(c.astext().encode(self._encoding, self._error_handler)
-                      for c in error)
+        msg = ''.join(c.astext() for c in error)
 
         self._errors.append(ParseError(msg, linenum, is_fatal))
 

--- a/pydoctor/test/epydoc/test_restructuredtext.py
+++ b/pydoctor/test/epydoc/test_restructuredtext.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from pydoctor.epydoc.markup import ParseError
+from pydoctor.epydoc.markup.restructuredtext import parse_docstring
+
+
+def test_rst_anon_link_target_missing() -> None:
+    src = """
+    This link's target is `not defined anywhere`__.
+    """
+    errors: List[ParseError] = []
+    parse_docstring(src, errors)
+    assert len(errors) == 1
+    assert errors[0].descr().startswith("Anonymous hyperlink mismatch:")
+    assert errors[0].is_fatal()

--- a/pydoctor/test/epydoc/test_restructuredtext.py
+++ b/pydoctor/test/epydoc/test_restructuredtext.py
@@ -1,8 +1,14 @@
 from typing import List
 
-from pydoctor.epydoc.markup import ParseError
+from pydoctor.epydoc.markup import ParseError, flatten
 from pydoctor.epydoc.markup.restructuredtext import parse_docstring
 
+
+def rst2html(s: str) -> str:
+    errors: List[ParseError] = []
+    parsed = parse_docstring(s, errors)
+    assert not errors
+    return flatten(parsed.to_stan(None))
 
 def test_rst_anon_link_target_missing() -> None:
     src = """
@@ -13,3 +19,10 @@ def test_rst_anon_link_target_missing() -> None:
     assert len(errors) == 1
     assert errors[0].descr().startswith("Anonymous hyperlink mismatch:")
     assert errors[0].is_fatal()
+
+def test_rst_anon_link_email() -> None:
+    src = "`<postmaster@example.net>`__"
+    html = rst2html(src)
+    assert html.startswith('<a ')
+    assert ' href="mailto:postmaster@example.net"' in html
+    assert html.endswith('>mailto:postmaster@example.net</a>')


### PR DESCRIPTION
Some things were overlooked in the porting to Python 3 and we didn't have enough unit test coverage to detect that. See #223 for details.
