### PR TITLE
Add CSS for syntax highlighting and doctest blocks

### DIFF
--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -241,3 +241,36 @@ body.private-hidden #splitTables .private, body.private-hidden #childList .priva
 .deprecationNotice {
     margin: 10px;
 }
+
+/* Syntax highlighting for source code */
+
+.py-string {
+    color: #337ab7;
+}
+.py-comment {
+    color: #309078;
+    font-style: italic;
+}
+.py-keyword {
+    font-weight: bold;
+}
+.py-defname {
+    color: #a947b8;
+    font-weight: bold;
+}
+.py-builtin {
+    color: #fc7844;
+    font-weight: bold;
+}
+
+/* Doctest */
+
+pre.py-doctest {
+    padding: .5em;
+}
+.py-prompt, .py-more {
+    color: #a8a8a8;
+}
+.py-output {
+    color: #c7254e;
+}


### PR DESCRIPTION
The styling for this got lost in [the big makeover of 2015](https://github.com/twisted/pydoctor/commit/620c5070d1ae61d552f6aa542a6b2d9946bd0166).

I tried resurrecting the old CSS that originated from epydoc, but it didn't match very well with the rest of our styling. So I made new rules instead, using some existing colors from our CSS and using GitHub and Kate as inspiration for new styles.