### PR TITLE
Fix reported source location in error messages

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -324,8 +324,7 @@ class ModuleVistor(ast.NodeVisitor):
     def _handleDocstringUpdate(self, targetNode, expr, lineno):
         def warn(msg):
             self.system.msg('ast', "%s:%d: %s" % (
-                    getattr(self.builder.currentMod, 'filepath', '<unknown>'),
-                    lineno, msg))
+                    self.builder.currentMod.description, lineno, msg))
 
         # Figure out target object.
         full_name = node2fullname(targetNode, self.builder.current)

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -184,15 +184,15 @@ class DocstringLinker:
     target URL for crossreference links.
     """
 
-    def resolve_identifier_xref(self, identifier):
+    def resolve_identifier_xref(self, identifier: str, lineno: int) -> str:
         """
         Resolve a crossreference link to a Python identifier.
 
-        @type identifier: C{string}
         @param identifier: The name of the Python identifier that
             should be linked to.
-        @rtype: C{string}
-        @return: The URL of the target
+        @param lineno: The line number within the docstring at which the
+            crossreference is located.
+        @return: The URL of the target.
         @raise LookupError: If C{identifier} could not be resolved.
         """
         raise NotImplementedError()

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -1142,7 +1142,7 @@ def _colorize_link(doc, link, token, end, errors):
             return
 
     # Construct the target element.
-    target_elt = Element('target', target)
+    target_elt = Element('target', target, lineno=str(token.startline))
 
     # Add them to the link element.
     link.children = [name_elt, target_elt]
@@ -1332,8 +1332,9 @@ class ParsedEpytextDocstring(ParsedDocstring):
             return tags.a(variables[0], href=variables[1], target='_top')
         elif tree.tag == 'link':
             label = tags.code(variables[0])
+            lineno = int(tree.children[1].attribs['lineno'])
             try:
-                url = linker.resolve_identifier_xref(variables[1])
+                url = linker.resolve_identifier_xref(variables[1], lineno)
             except LookupError:
                 return label
             else:

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -393,8 +393,10 @@ class _EpydocHTMLTranslator(HTMLTranslator):
         if m: text, target = m.groups()
         else: target = text = node.astext()
         label = tags.code(text)
+        # TODO: 'node.line' is None for some reason.
+        lineno = 0
         try:
-            url = self._linker.resolve_identifier_xref(target)
+            url = self._linker.resolve_identifier_xref(target, lineno)
         except LookupError:
             xref = label
         else:

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -394,6 +394,7 @@ class _EpydocHTMLTranslator(HTMLTranslator):
         else: target = text = node.astext()
         label = tags.code(text)
         # TODO: 'node.line' is None for some reason.
+        #       https://github.com/twisted/pydoctor/issues/237
         lineno = 0
         try:
             url = self._linker.resolve_identifier_xref(target, lineno)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -421,6 +421,7 @@ def format_docstring(obj: model.Documentable) -> Tag:
     elif source is None:
         # A split field is documented by its parent.
         source = obj.parent
+        assert source is not None
 
     try:
         stan = pdoc.to_stan(_EpydocLinker(source))

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -284,7 +284,7 @@ class Documentable:
     def report(self, descr, section='parsing', lineno_offset=0):
         """Log an error or warning about this documentable object."""
 
-        if section == 'docstring':
+        if section in ('docstring', 'resolve_identifier_xref'):
             linenumber = self.docstring_lineno
         else:
             linenumber = self.linenumber

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -206,11 +206,7 @@ class SphinxInventoryWriter:
         from pydoctor import model
 
         full_name = obj.fullName()
-
-        if obj.documentation_location is model.DocLocation.OWN_PAGE:
-            url = obj.fullName() + '.html'
-        else:
-            url = obj.parent.fullName() + '.html#' + obj.name
+        url = obj.url
 
         display = '-'
         if isinstance(obj, (model.Package, model.Module)):

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -1,16 +1,16 @@
 """Miscellaneous utilities."""
 
-from urllib.parse import quote
+from typing import Optional
 import os
 
 from pydoctor import model
 from twisted.python.filepath import FilePath
-from twisted.web.template import tags
+from twisted.web.template import Tag, tags
 
-def link(o):
+def link(o: model.Documentable) -> str:
     if not o.isVisible:
         o.system.msg("html", "don't link to %s"%o.fullName())
-    return quote(o.fullName()+'.html')
+    return o.url
 
 def srclink(o):
     return o.sourceHref
@@ -23,22 +23,13 @@ def templatefile(filename):
 def templatefilepath(filename):
     return FilePath(templatefile(filename))
 
-def taglink(o, label=None):
+def taglink(o: model.Documentable, label: Optional[str] = None) -> Tag:
     if not o.isVisible:
         o.system.msg("html", "don't link to %s"%o.fullName())
     if label is None:
         label = o.fullName()
-    if o.documentation_location is model.DocLocation.PARENT_PAGE:
-        p = o.parent
-        if isinstance(p, model.Module) and p.name == '__init__':
-            p = p.parent
-        linktext = link(p) + '#' + quote(o.name)
-    elif o.documentation_location is model.DocLocation.OWN_PAGE:
-        linktext = link(o)
-    else:
-        raise AssertionError(
-            f"Unknown documentation_location: {o.documentation_location}")
     # Create a link to the object, with a "data-type" attribute which says what
     # kind of object it is (class, etc). This helps doc2dash figure out what it
     # is.
-    return tags.a(href=linktext, class_="code", **{"data-type":o.kind})(label)
+    ret: Tag = tags.a(href=o.url, class_="code", **{"data-type": o.kind})(label)
+    return ret

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -654,15 +654,15 @@ def test_docstring_assignment(systemcls: Type[model.System], capsys: CapSys) -> 
     captured = capsys.readouterr()
     lines = captured.out.split('\n')
     assert len(lines) > 0 and lines[0] == \
-        "<unknown>:20: Unable to figure out target for __doc__ assignment"
+        "<test>:20: Unable to figure out target for __doc__ assignment"
     assert len(lines) > 1 and lines[1] == \
-        "<unknown>:21: Unable to figure out target for __doc__ assignment: " \
+        "<test>:21: Unable to figure out target for __doc__ assignment: " \
         "computed full name not found: real"
     assert len(lines) > 2 and lines[2] == \
-        "<unknown>:22: Unable to figure out value for __doc__ assignment, " \
+        "<test>:22: Unable to figure out value for __doc__ assignment, " \
         "maybe too complex"
     assert len(lines) > 3 and lines[3] == \
-        "<unknown>:23: Ignoring value assigned to __doc__: not a string"
+        "<test>:23: Ignoring value assigned to __doc__: not a string"
     assert len(lines) == 5 and lines[-1] == ''
 
 @systemcls_param

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -402,6 +402,11 @@ def test_EpydocLinker_resolve_identifier_xref_order(capsys: CapSys) -> None:
 
 
 def test_xref_not_found_epytext(capsys: CapSys) -> None:
+    """
+    When a link in an epytext docstring cannot be resolved, the reference
+    and the line number of the link should be reported.
+    """
+
     mod = fromText('''
     """
     A test module.
@@ -417,6 +422,13 @@ def test_xref_not_found_epytext(capsys: CapSys) -> None:
 
 
 def test_xref_not_found_restructured(capsys: CapSys) -> None:
+    """
+    When a link in an reStructedText docstring cannot be resolved, the reference
+    and the line number of the link should be reported.
+    However, currently the best we can do is report the starting line of the
+    docstring instead.
+    """
+
     system = model.System()
     system.options.docformat = 'restructuredtext'
     mod = fromText('''

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -444,4 +444,5 @@ def test_xref_not_found_restructured(capsys: CapSys) -> None:
     captured = capsys.readouterr().out
     # TODO: Should actually be line 5, but I can't get docutils to fill in
     #       the line number when it calls visit_title_reference().
+    #       https://github.com/twisted/pydoctor/issues/237
     assert captured == "test:3: invalid ref to 'NoSuchName' not resolved\n"

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -40,7 +40,6 @@ def test_setSourceHrefOption() -> None:
     moduleRelativePart = "/package/module.py"
 
     mod = FakeDocumentable()
-    mod.filepath = projectBaseDir + moduleRelativePart
 
     options = FakeOptions()
     options.projectbasedirectory = projectBaseDir
@@ -49,7 +48,7 @@ def test_setSourceHrefOption() -> None:
     system.sourcebase = viewSourceBase
     system.options = options
     mod.system = system
-    system.setSourceHref(mod)
+    system.setSourceHref(mod, projectBaseDir + moduleRelativePart)
 
     expected = viewSourceBase + moduleRelativePart
     assert mod.sourceHref == expected

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -170,10 +170,12 @@ def test_introspection() -> None:
     system.introspectModule(py_mod, __name__)
 
     module = system.objForFullName(__name__)
+    assert module is not None
     assert module.docstring == __doc__
 
     func = module.contents['test_introspection']
     assert func.docstring == "Find docstrings from this test using introspection."
 
     method = system.objForFullName(__name__ + '.Dummy.crash')
+    assert method is not None
     assert method.docstring == "Mmm"

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -43,10 +43,18 @@ def test_importingfrompackage() -> None:
     assert submod.state is model.ProcessingState.PROCESSED
 
 def test_allgames() -> None:
+    """
+    Test reparenting of documentables.
+    A name which is defined in module 1, but included in __all__ of module 2
+    that it is imported into, should end up in the documentation of module 2.
+    """
+
     system = processPackage("allgames")
     # InSourceAll is not moved into mod2, but NotInSourceAll is.
     assert 'InSourceAll' in system.allobjects['allgames.mod1'].contents
     assert 'NotInSourceAll' in system.allobjects['allgames.mod2'].contents
+    # Source paths must be unaffected by the move, so that error messages
+    # point to the right source code.
     moved = system.allobjects['allgames.mod2'].contents['NotInSourceAll']
     assert moved.source_path.endswith('/allgames/mod1.py')
     assert moved.parentMod.source_path.endswith('/allgames/mod2.py')

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -47,3 +47,6 @@ def test_allgames() -> None:
     # InSourceAll is not moved into mod2, but NotInSourceAll is.
     assert 'InSourceAll' in system.allobjects['allgames.mod1'].contents
     assert 'NotInSourceAll' in system.allobjects['allgames.mod2'].contents
+    moved = system.allobjects['allgames.mod2'].contents['NotInSourceAll']
+    assert moved.source_path.endswith('/allgames/mod1.py')
+    assert moved.parentMod.source_path.endswith('/allgames/mod2.py')

--- a/pydoctor/test/test_templatewriter.py
+++ b/pydoctor/test/test_templatewriter.py
@@ -69,8 +69,10 @@ def test_basic_package(tmp_path: Path) -> None:
     w.writeDocsFor(root, False)
     w.writeModuleIndex(system)
     for ob in system.allobjects.values():
-        if ob.documentation_location is model.DocLocation.OWN_PAGE:
-            assert (tmp_path / f'{ob.fullName()}.html').is_file()
+        url = ob.url
+        if '#' in url:
+            url = url[:url.find('#')]
+        assert (tmp_path / url).is_file()
     with open(tmp_path / 'basic.html') as f:
         assert 'Package docstring' in f.read()
 


### PR DESCRIPTION
This fixes two issues with error reporting:
- when a function or class is reparented, we now report the original source file (where the docstring resides) instead of the new parent's source file
- the reported line number for cross-reference errors is now the line number of the cross-reference itself, rather than the line number of the documented object

I only managed to get the second item to work for epytext: for restructured text I did figure out how it should work in theory, but in practice the line number reported by docutils is always `None`. Instead of the exact line we now report the start of the docstring, which shouldn't be too far off in most cases.

What triggered me to make these fixes was this error reported on Twisted:
```
src/twisted/logger/__init__.py:22: invalid ref to 'twisted.python.log.ILegacyLogObserver' resolved as 'ILegacyLogObserver'
```
which should actually read:
```
src/twisted/logger/_legacy.py:25: invalid ref to 'twisted.python.log.ILegacyLogObserver' resolved as 'ILegacyLogObserver'
```
