### PR TITLE
Perform sanity checks on field arguments

### DIFF
--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -36,9 +36,11 @@ each error.
 """
 __docformat__ = 'epytext en'
 
+from typing import List
 import re
 
-from twisted.web.template import XMLString, flattenString
+from twisted.python.failure import Failure
+from twisted.web.template import Tag, XMLString, flattenString
 
 ##################################################
 ## Contents
@@ -108,7 +110,7 @@ def html2stan(html):
     stan.tagName = ''
     return stan
 
-def flatten(stan):
+def flatten(stan: Tag) -> str:
     """
     Convert a document fragment from a Stan tree to HTML.
 
@@ -116,8 +118,8 @@ def flatten(stan):
     @return: An HTML string representation of the C{stan} tree.
     @rtype: C{str}
     """
-    ret = []
-    err = []
+    ret: List[bytes] = []
+    err: List[Failure] = []
     flattenString(None, stan).addCallback(ret.append).addErrback(err.append)
     if err:
         raise err[0].value

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -364,8 +364,11 @@ class FieldHandler:
             d.type = field.body
             desc_list.append(d)
 
-    def _unstar_param_name(self, field):
+    def _handle_param_name(self, field):
         name = field.arg
+        if name is None:
+            field.report('Parameter name missing')
+            return None
         if name and name.startswith('*'):
             field.report('Parameter name "%s" should not include asterixes' % (name,))
             return name.lstrip('*')
@@ -380,10 +383,14 @@ class FieldHandler:
         desc_list.append(d)
 
     def handle_type(self, field):
-        self.types[self._unstar_param_name(field)] = field.body
+        name = self._handle_param_name(field)
+        if name is not None:
+            self.types[name] = field.body
 
     def handle_param(self, field):
-        self.add_info(self.parameter_descs, self._unstar_param_name(field), field)
+        name = self._handle_param_name(field)
+        if name is not None:
+            self.add_info(self.parameter_descs, name, field)
     handle_arg = handle_param
     handle_keyword = handle_param
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -404,7 +404,10 @@ class FieldHandler:
     handle_var = handled_elsewhere
 
     def handle_raises(self, field):
-        self.add_info(self.raise_descs, field.arg, field)
+        name = field.arg
+        if name is None:
+            field.report('Exception type missing')
+        self.add_info(self.raise_descs, name, field)
     handle_raise = handle_raises
 
     def handle_seealso(self, field):

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -428,7 +428,7 @@ class FieldHandler:
         self.sinces.append(field)
 
     def handleUnknownField(self, field):
-        field.report('unknown field "%s"' % (field.tag,))
+        field.report('Unknown field "%s"' % (field.tag,))
         self.add_info(self.unknowns, field.arg, field)
 
     def handle(self, field):

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -337,6 +337,8 @@ class FieldHandler:
             thresh=-1)
 
     def handle_return(self, field):
+        if field.arg is not None:
+            field.report('Unexpected argument in %s field' % (field.tag,))
         if not self.return_desc:
             self.return_desc = FieldDesc()
         if self.return_desc.body:
@@ -345,6 +347,8 @@ class FieldHandler:
     handle_returns = handle_return
 
     def handle_returntype(self, field):
+        if getattr(field, 'arg', None) is not None:
+            field.report('Unexpected argument in %s field' % (field.tag,))
         if not self.return_desc:
             self.return_desc = FieldDesc()
         if self.return_desc.type:

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -248,7 +248,7 @@ def test_unknown_field_name(capsys):
     ''', modname='test')
     epydoc2stan.format_docstring(mod)
     captured = capsys.readouterr().out
-    assert captured == 'test:5: unknown field "zap"\n'
+    assert captured == 'test:5: Unknown field "zap"\n'
 
 
 def test_EpydocLinker_look_for_intersphinx_no_link():

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -38,6 +38,10 @@ def test_multiple_types():
     epydoc2stan.format_docstring(mod.contents['D'])
     epydoc2stan.format_docstring(mod.contents['E'])
 
+def docstring2html(docstring: model.Documentable) -> str:
+    stan = epydoc2stan.format_docstring(docstring)
+    return flatten(stan).replace('><', '>\n<')
+
 def test_func_arg_and_ret_annotation():
     annotation_mod = fromText('''
     def f(a: List[str]) -> bool:
@@ -55,11 +59,8 @@ def test_func_arg_and_ret_annotation():
         @rtype: bool
         """
     ''')
-    def format(docstring):
-        stan = epydoc2stan.format_docstring(docstring)
-        return flatten(stan).replace('><', '>\n<')
-    annotation_fmt = format(annotation_mod.contents['f'])
-    classic_fmt = format(classic_mod.contents['f'])
+    annotation_fmt = docstring2html(annotation_mod.contents['f'])
+    classic_fmt = docstring2html(classic_mod.contents['f'])
     assert annotation_fmt == classic_fmt
 
 def test_func_arg_and_ret_annotation_with_override():
@@ -83,11 +84,8 @@ def test_func_arg_and_ret_annotation_with_override():
         @rtype: bool
         """
     ''')
-    def format(docstring):
-        stan = epydoc2stan.format_docstring(docstring)
-        return flatten(stan).replace('><', '>\n<')
-    annotation_fmt = format(annotation_mod.contents['f'])
-    classic_fmt = format(classic_mod.contents['f'])
+    annotation_fmt = docstring2html(annotation_mod.contents['f'])
+    classic_fmt = docstring2html(classic_mod.contents['f'])
     assert annotation_fmt == classic_fmt
 
 def test_func_arg_when_doc_missing():
@@ -106,11 +104,8 @@ def test_func_arg_when_doc_missing():
         @rtype: bool
         """
     ''')
-    def format(docstring):
-        stan = epydoc2stan.format_docstring(docstring)
-        return flatten(stan).replace('><', '>\n<')
-    annotation_fmt = format(annotation_mod.contents['f'])
-    classic_fmt = format(classic_mod.contents['f'])
+    annotation_fmt = docstring2html(annotation_mod.contents['f'])
+    classic_fmt = docstring2html(classic_mod.contents['f'])
     assert annotation_fmt == classic_fmt
 
 

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -109,6 +109,24 @@ def test_func_arg_when_doc_missing():
     assert annotation_fmt == classic_fmt
 
 
+def test_func_missing_param_name(capsys):
+    """Param and type fields must include the name of the parameter."""
+    mod = fromText('''
+    def f(a, b):
+        """
+        @param a: The first parameter.
+        @param: The other one.
+        @type: L{str}
+        """
+    ''')
+    epydoc2stan.format_docstring(mod.contents['f'])
+    captured = capsys.readouterr().out
+    assert captured == (
+        '<test>:5: Parameter name missing\n'
+        '<test>:6: Parameter name missing\n'
+        )
+
+
 def test_func_starargs(capsys):
     """Var-args must be named in fields without asterixes.
     But for compatibility, we warn and strip off the asterixes.

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -141,6 +141,21 @@ def test_func_missing_exception_type(capsys):
     assert captured == '<test>:5: Exception type missing\n'
 
 
+def test_unexpected_field_args(capsys):
+    """Warn when field arguments that should be empty aren't."""
+    mod = fromText('''
+    def get_it():
+        """
+        @return value: The thing you asked for, probably.
+        @rtype value: Not a clue.
+        """
+    ''')
+    epydoc2stan.format_docstring(mod.contents['get_it'])
+    captured = capsys.readouterr().out
+    assert captured == "<test>:4: Unexpected argument in return field\n" \
+                       "<test>:5: Unexpected argument in rtype field\n"
+
+
 def test_func_starargs(capsys):
     """Var-args must be named in fields without asterixes.
     But for compatibility, we warn and strip off the asterixes.

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -109,6 +109,40 @@ def test_func_arg_when_doc_missing():
     assert annotation_fmt == classic_fmt
 
 
+def test_func_starargs(capsys):
+    """Var-args must be named in fields without asterixes.
+    But for compatibility, we warn and strip off the asterixes.
+    """
+    bad_mod = fromText('''
+    def f(*args: int, **kwargs) -> None:
+        """
+        Do something with var-positional and var-keyword arguments.
+
+        @param *args: var-positional arguments
+        @param **kwargs: var-keyword arguments
+        @type **kwargs: L{str}
+        """
+    ''', modname='<bad>')
+    good_mod = fromText('''
+    def f(*args: int, **kwargs) -> None:
+        """
+        Do something with var-positional and var-keyword arguments.
+
+        @param args: var-positional arguments
+        @param kwargs: var-keyword arguments
+        @type kwargs: L{str}
+        """
+    ''', modname='<good>')
+    bad_fmt = docstring2html(bad_mod.contents['f'])
+    good_fmt = docstring2html(good_mod.contents['f'])
+    assert bad_fmt == good_fmt
+    captured = capsys.readouterr().out
+    assert captured == (
+        '<bad>:6: Parameter name "*args" should not include asterixes\n'
+        '<bad>:7: Parameter name "**kwargs" should not include asterixes\n'
+        '<bad>:8: Parameter name "**kwargs" should not include asterixes\n'
+        )
+
 
 def test_summary():
     mod = fromText('''

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -127,6 +127,20 @@ def test_func_missing_param_name(capsys):
         )
 
 
+def test_func_missing_exception_type(capsys):
+    """Raise fields must include the exception type."""
+    mod = fromText('''
+    def f(x):
+        """
+        @raise ValueError: If C{x} is rejected.
+        @raise: On a blue moon.
+        """
+    ''')
+    epydoc2stan.format_docstring(mod.contents['f'])
+    captured = capsys.readouterr().out
+    assert captured == '<test>:5: Exception type missing\n'
+
+
 def test_func_starargs(capsys):
     """Var-args must be named in fields without asterixes.
     But for compatibility, we warn and strip off the asterixes.


### PR DESCRIPTION
The following sanity checks are added:
- Warn about missing parameter name in `@param` and `@type` fields
- When parameter names in `@param` and `@type` fields include asterixes, warn and strip them
- Warn about missing exception type in `@raise` fields
- Warn on non-empty `@return` and `@rtype` arguments

These checks can spot mistakes in docstrings that can lead to inferior HTML output. In the case of parameters, inconsistencies between documented names and actual names can cause problems when merging the information extracted from annotations with the information from the docstring.