### PR TITLE
The great epydoc2stan cleanup of 2020

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -515,8 +515,13 @@ class ModuleVistor(ast.NodeVisitor):
             returns = func.returns
             if returns:
                 yield 'return', returns
-        return {name: None if value is None else self._unstring_annotation(value)
-                for name, value in _get_all_ast_annotations()}
+        return {
+            # Include parameter names even if they're not annotated, so that
+            # we can use the key set to know which parameters exist and warn
+            # when non-existing parameters are documented.
+            name: None if value is None else self._unstring_annotation(value)
+            for name, value in _get_all_ast_annotations()
+            }
 
     def _unstring_annotation(self, node: ast.expr) -> ast.expr:
         """Replace all strings in the given expression by parsed versions.

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -3,7 +3,7 @@
 import ast
 import sys
 from itertools import chain
-from typing import Iterator, Mapping, Tuple
+from typing import Iterator, Mapping, Optional, Tuple
 
 import astor
 from pydoctor import epydoc2stan, model
@@ -485,7 +485,9 @@ class ModuleVistor(ast.NodeVisitor):
                 return _infer_type(default)
         return None
 
-    def _annotations_from_function(self, func: ast.FunctionDef) -> Mapping[str, ast.expr]:
+    def _annotations_from_function(
+            self, func: ast.FunctionDef
+            ) -> Mapping[str, Optional[ast.expr]]:
         """Get annotations from a function definition.
         @param func: The function definition's AST.
         @return: Mapping from argument name to annotation.
@@ -507,14 +509,13 @@ class ModuleVistor(ast.NodeVisitor):
             kwargs = base_args.kwarg
             if kwargs:
                 yield kwargs
-        def _get_all_ast_annotations() -> Iterator[Tuple[str, ast.expr]]:
+        def _get_all_ast_annotations() -> Iterator[Tuple[str, Optional[ast.expr]]]:
             for arg in _get_all_args():
-                if arg.annotation:
-                    yield arg.arg, arg.annotation
+                yield arg.arg, arg.annotation
             returns = func.returns
             if returns:
                 yield 'return', returns
-        return {name: self._unstring_annotation(value)
+        return {name: None if value is None else self._unstring_annotation(value)
                 for name, value in _get_all_ast_annotations()}
 
     def _unstring_annotation(self, node: ast.expr) -> ast.expr:

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -36,7 +36,7 @@ each error.
 """
 __docformat__ = 'epytext en'
 
-from typing import List
+from typing import List, Optional
 import re
 
 from twisted.python.failure import Failure
@@ -143,36 +143,32 @@ class Field:
     Tags are automatically downcased and stripped; and arguments are
     automatically stripped.
     """
-    def __init__(self, tag, arg, body, lineno):
+
+    def __init__(self, tag: str, arg: Optional[str], body: ParsedDocstring, lineno: int):
         self._tag = tag.lower().strip()
-        if arg is None: self._arg = None
-        else: self._arg = arg.strip()
+        self._arg = None if arg is None else arg.strip()
         self._body = body
         self.lineno = lineno
 
-    def tag(self):
+    def tag(self) -> str:
         """
         @return: This field's tag.
-        @rtype: C{string}
         """
         return self._tag
 
-    def arg(self):
+    def arg(self) -> Optional[str]:
         """
-        @return: This field's argument, or C{None} if this field has
-            no argument.
-        @rtype: C{string} or C{None}
+        @return: This field's argument, or C{None} if this field has no argument.
         """
         return self._arg
 
-    def body(self):
+    def body(self) -> ParsedDocstring:
         """
         @return: This field's body.
-        @rtype: L{ParsedDocstring}
         """
         return self._body
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self._arg is None:
             return f'<Field @{self._tag}: ...>'
         else:

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -314,7 +314,6 @@ class FieldHandler:
         self.authors = []
         self.sinces = []
         self.unknowns = []
-        self.unattached_types = {}
 
     @classmethod
     def from_ast_annotations(cls, obj: model.Documentable, annotations: Mapping[str, ast.expr]) -> "FieldHandler":
@@ -330,12 +329,6 @@ class FieldHandler:
             return_type.body = ret_type
             handler.handle_returntype(return_type)
         return handler
-
-    def redef(self, field):
-        self.obj.system.msg(
-            "epytext",
-            "on %r: redefinition of @type %s"%(self.obj.fullName(), field.arg),
-            thresh=-1)
 
     def handle_return(self, field):
         if field.arg is not None:
@@ -356,18 +349,6 @@ class FieldHandler:
             self.obj.system.msg('epydoc2stan', 'XXX')
         self.return_desc.type = field.body
     handle_rtype = handle_returntype
-
-    def add_type_info(self, desc_list, field):
-        if desc_list and desc_list[-1].name == field.arg:
-            if desc_list[-1].type is not None:
-                self.redef(field)
-            desc_list[-1].type = field.body
-        else:
-            d = FieldDesc()
-            d.kind = field.tag
-            d.name = field.arg
-            d.type = field.body
-            desc_list.append(d)
 
     def _handle_param_name(self, field):
         name = field.arg

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -232,17 +232,9 @@ class FieldDesc:
         return tags.transparent(body)
 
 
-def format_desc_list(
-        singular: str, descs: Sequence[FieldDesc], plural: Optional[str] = None
-        ) -> List[Tag]:
-    if plural is None:
-        plural = singular + 's'
+def format_desc_list(label: str, descs: Sequence[FieldDesc]) -> List[Tag]:
     if not descs:
         return []
-    if len(descs) > 1:
-        label = plural
-    else:
-        label = singular
     r: List[Tag] = []
     first = True
     for d in descs:
@@ -434,11 +426,11 @@ class FieldHandler:
     def format(self) -> Tag:
         r = []
 
-        r.append(format_desc_list('Parameters', self.parameter_descs, 'Parameters'))
+        r.append(format_desc_list('Parameters', self.parameter_descs))
         if self.return_desc:
             r.append(tags.tr(class_="fieldStart")(tags.td(class_="fieldName")('Returns'),
                                tags.td(colspan="2")(self.return_desc.format())))
-        r.append(format_desc_list("Raises", self.raise_descs, "Raises"))
+        r.append(format_desc_list("Raises", self.raise_descs))
         for s, p, l in (('Author', 'Authors', self.authors),
                         ('See Also', 'See Also', self.seealsos),
                         ('Present Since', 'Present Since', self.sinces),
@@ -448,8 +440,7 @@ class FieldHandler:
         for fieldinfo in self.unknowns:
             unknowns.setdefault(fieldinfo.kind, []).append(fieldinfo)
         for kind, fieldlist in unknowns.items():
-            label = f"Unknown Field: {kind}"
-            r.append(format_desc_list(label, fieldlist, label))
+            r.append(format_desc_list(f"Unknown Field: {kind}", fieldlist))
 
         if any(r):
             return tags.table(class_='fieldTable')(r)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -365,7 +365,15 @@ class FieldHandler:
         desc_list.append(d)
 
     def handle_type(self, field):
-        name = self._handle_param_name(field)
+        if isinstance(self.obj, model.Function):
+            name = self._handle_param_name(field)
+        else:
+            # Note: extract_fields() will issue warnings about missing field
+            #       names, so we can silently ignore them here.
+            # TODO: Processing the fields once in extract_fields() and again
+            #       in format_docstring() adds complexity and can cause
+            #       inconsistencies.
+            name = field.arg
         if name is not None:
             self.types[name] = field.body
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -276,11 +276,7 @@ class Field:
         self.source.report(message, lineno_offset=self.lineno, section='docstring')
 
 
-def format_field_list(
-        singular: str, fields: Sequence[Field], plural: Optional[str] = None
-        ) -> List[Tag]:
-    if plural is None:
-        plural = singular + 's'
+def format_field_list(singular: str, plural: str, fields: Sequence[Field]) -> List[Tag]:
     if not fields:
         return []
     if len(fields) > 1:
@@ -431,11 +427,11 @@ class FieldHandler:
             r.append(tags.tr(class_="fieldStart")(tags.td(class_="fieldName")('Returns'),
                                tags.td(colspan="2")(self.return_desc.format())))
         r.append(format_desc_list("Raises", self.raise_descs))
-        for s, p, l in (('Author', 'Authors', self.authors),
-                        ('See Also', 'See Also', self.seealsos),
-                        ('Present Since', 'Present Since', self.sinces),
-                        ('Note', 'Notes', self.notes)):
-            r.append(format_field_list(s, l, p))
+        for s_p_l in (('Author', 'Authors', self.authors),
+                      ('See Also', 'See Also', self.seealsos),
+                      ('Present Since', 'Present Since', self.sinces),
+                      ('Note', 'Notes', self.notes)):
+            r.append(format_field_list(*s_p_l))
         unknowns: Dict[str, List[FieldDesc]] = {}
         for fieldinfo in self.unknowns:
             unknowns.setdefault(fieldinfo.kind, []).append(fieldinfo)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -224,10 +224,7 @@ class FieldDesc:
     body: Optional[Tag] = None
 
     def format(self) -> Tag:
-        if self.body is None:
-            formatted = tags.transparent
-        else:
-            formatted = self.body
+        formatted: Tag = tags.transparent if self.body is None else self.body
         if self.type is not None:
             formatted = tags.transparent(formatted, ' (type: ', self.type, ')')
         return formatted
@@ -432,9 +429,9 @@ class FieldHandler:
             r += format_desc_list(f"Unknown Field: {kind}", fieldlist)
 
         if any(r):
-            return tags.table(class_='fieldTable')(r)
+            return tags.table(class_='fieldTable')(r) # type: ignore[no-any-return]
         else:
-            return tags.transparent
+            return tags.transparent # type: ignore[no-any-return]
 
 
 def reportErrors(obj: model.Documentable, errs: Sequence[ParseError]) -> None:
@@ -547,7 +544,7 @@ def format_summary(obj: model.Documentable) -> Tag:
                 )
             ]
         if len(lines) > 3:
-            return tags.span(class_='undocumented')("No summary")
+            return tags.span(class_='undocumented')("No summary") # type: ignore[no-any-return]
         pdoc = parse_docstring(obj, ' '.join(lines), source)
 
     try:
@@ -555,12 +552,12 @@ def format_summary(obj: model.Documentable) -> Tag:
     except Exception:
         # This problem will likely be reported by the full docstring as well,
         # so don't spam the log.
-        return tags.span(class_='undocumented')("Broken description")
+        return tags.span(class_='undocumented')("Broken description") # type: ignore[no-any-return]
 
     content = [stan] if stan.tagName else stan.children
     if content and isinstance(content[0], Tag) and content[0].tagName == 'p':
         content = content[0].children
-    return tags.span(*content)
+    return tags.span(*content) # type: ignore[no-any-return]
 
 
 def format_undocumented(obj: model.Documentable) -> Tag:
@@ -598,7 +595,7 @@ def type2stan(obj: model.Documentable) -> Optional[Tag]:
     if parsed_type is None:
         return None
     else:
-        return parsed_type.to_stan(_EpydocLinker(obj))
+        return parsed_type.to_stan(_EpydocLinker(obj)) # type: ignore[no-any-return]
 
 def get_parsed_type(obj: model.Documentable) -> Optional[ParsedDocstring]:
     parsed_type: Optional[ParsedDocstring] = getattr(obj, 'parsed_type', None)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -320,7 +320,8 @@ class FieldHandler:
         self.unknowns: List[FieldDesc] = []
 
     @classmethod
-    def from_ast_annotations(cls, obj: model.Documentable, annotations: Mapping[str, ast.expr]) -> "FieldHandler":
+    def from_ast_annotations(cls, obj: model.Documentable) -> "FieldHandler":
+        annotations: Mapping[str, ast.expr] = getattr(obj, 'annotations', {})
         linker = _EpydocLinker(obj)
         formatted_annotations = {
             name: AnnotationDocstring(value).to_stan(linker)
@@ -522,7 +523,7 @@ def format_docstring(obj):
     content = [stan] if stan.tagName else stan.children
     fields = pdoc.fields
     s = tags.div(*content)
-    fh = FieldHandler.from_ast_annotations(obj, getattr(source, 'annotations', {}))
+    fh = FieldHandler.from_ast_annotations(obj)
     for field in fields:
         fh.handle(Field(field, source))
     fh.resolve_types()

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -250,6 +250,28 @@ def format_desc_list(singular, descs, plural=None):
         r.append(row)
     return r
 
+
+class Field:
+    """Like pydoctor.epydoc.markup.Field, but without the gross accessor
+    methods and with a formatted body."""
+    def __init__(self, field, source):
+        self.tag = field.tag()
+        self.arg = field.arg()
+        self.source = source
+        self.lineno = field.lineno
+        self.body = field.body().to_stan(_EpydocLinker(source))
+
+    def __repr__(self):
+        r = repr(self.body)
+        if len(r) > 25:
+            r = r[:20] + '...' + r[-2:]
+        return "<%s %r %r %d %s>"%(self.__class__.__name__,
+                                   self.tag, self.arg, self.lineno, r)
+
+    def report(self, message: str) -> None:
+        self.source.report(message, lineno_offset=self.lineno, section='docstring')
+
+
 def format_field_list(singular, fields, plural=None):
     if plural is None:
         plural = singular + 's'
@@ -272,27 +294,6 @@ def format_field_list(singular, fields, plural=None):
         row(tags.td(colspan="2")(field.body))
         rows.append(row)
     return rows
-
-
-class Field:
-    """Like pydoctor.epydoc.markup.Field, but without the gross accessor
-    methods and with a formatted body."""
-    def __init__(self, field, source):
-        self.tag = field.tag()
-        self.arg = field.arg()
-        self.source = source
-        self.lineno = field.lineno
-        self.body = field.body().to_stan(_EpydocLinker(source))
-
-    def __repr__(self):
-        r = repr(self.body)
-        if len(r) > 25:
-            r = r[:20] + '...' + r[-2:]
-        return "<%s %r %r %d %s>"%(self.__class__.__name__,
-                             self.tag, self.arg, self.lineno, r)
-
-    def report(self, message: str) -> None:
-        self.source.report(message, lineno_offset=self.lineno, section='docstring')
 
 
 class FieldHandler:

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -335,8 +335,6 @@ class FieldHandler:
             field.report('Unexpected argument in %s field' % (field.tag,))
         if not self.return_desc:
             self.return_desc = FieldDesc()
-        if self.return_desc.body:
-            self.obj.system.msg('epydoc2stan', 'XXX')
         self.return_desc.body = field.body
     handle_returns = handle_return
 
@@ -345,8 +343,6 @@ class FieldHandler:
             field.report('Unexpected argument in %s field' % (field.tag,))
         if not self.return_desc:
             self.return_desc = FieldDesc()
-        if self.return_desc.type:
-            self.obj.system.msg('epydoc2stan', 'XXX')
         self.return_desc.type = field.body
     handle_rtype = handle_returntype
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -250,7 +250,7 @@ def format_desc_list(singular, descs, plural=None):
         r.append(row)
     return r
 
-def format_field_list(obj, singular, fields, plural=None):
+def format_field_list(singular, fields, plural=None):
     if plural is None:
         plural = singular + 's'
     if not fields:
@@ -430,7 +430,7 @@ class FieldHandler:
                         ('See Also', 'See Also', self.seealsos),
                         ('Present Since', 'Present Since', self.sinces),
                         ('Note', 'Notes', self.notes)):
-            r.append(format_field_list(self.obj, s, l, p))
+            r.append(format_field_list(s, l, p))
         unknowns = {}
         for fieldinfo in self.unknowns:
             unknowns.setdefault(fieldinfo.kind, []).append(fieldinfo)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -55,7 +55,7 @@ def get_parser(obj: model.Documentable) -> Callable[[str, List[ParseError]], Par
             formatname, e.__class__.__name__, e)
         obj.system.msg('epydoc2stan', msg, thresh=-1, once=True)
         mod = pydoctor.epydoc.markup.plaintext
-    return getattr(mod, 'parse_docstring') # type: ignore[no-any-return]
+    return mod.parse_docstring # type: ignore[attr-defined, no-any-return]
 
 
 def get_docstring(
@@ -225,12 +225,12 @@ class FieldDesc:
 
     def format(self) -> Tag:
         if self.body is None:
-            body = tags.transparent
+            formatted = tags.transparent
         else:
-            body = self.body
+            formatted = self.body
         if self.type is not None:
-            body = body, ' (type: ', self.type, ')'
-        return tags.transparent(body)
+            formatted = tags.transparent(formatted, ' (type: ', self.type, ')')
+        return formatted
 
 
 def format_desc_list(label: str, descs: Sequence[FieldDesc]) -> Iterator[Tag]:
@@ -264,7 +264,7 @@ class Field:
 
     @classmethod
     def from_epydoc(cls, field: EpydocField, source: model.Documentable) -> 'Field':
-        return Field(
+        return cls(
             tag=field.tag(),
             arg=field.arg(),
             source=source,

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -325,9 +325,9 @@ class FieldHandler:
         ret_type = formatted_annotations.pop('return', None)
         handler = cls(obj, formatted_annotations)
         if ret_type is not None:
-            return_type = FieldDesc()
-            return_type.body = ret_type
-            handler.handle_returntype(return_type)
+            assert isinstance(obj, model.Function), obj
+            handler.return_desc = FieldDesc()
+            handler.return_desc.type = ret_type
         return handler
 
     def handle_return(self, field):
@@ -339,7 +339,7 @@ class FieldHandler:
     handle_returns = handle_return
 
     def handle_returntype(self, field):
-        if getattr(field, 'arg', None) is not None:
+        if field.arg is not None:
             field.report('Unexpected argument in %s field' % (field.tag,))
         if not self.return_desc:
             self.return_desc = FieldDesc()

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -75,6 +75,7 @@ class Documentable:
     docstring_lineno = 0
     linenumber = 0
     sourceHref = None
+    kind: str
 
     @property
     def css_class(self):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -372,7 +372,7 @@ class Inheritable(Documentable):
 
 class Function(Inheritable):
     kind = "Function"
-    annotations: Mapping[str, ast.expr]
+    annotations: Mapping[str, Optional[ast.expr]]
 
     def setup(self):
         super().setup()

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -70,7 +70,7 @@ class Documentable:
     @ivar kind: ...
     """
     documentation_location = DocLocation.OWN_PAGE
-    docstring = None
+    docstring: Optional[str] = None
     parsed_docstring: Optional[ParsedDocstring] = None
     docstring_lineno = 0
     linenumber = 0

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -6,6 +6,7 @@ system being documented.  An instance of L{System} represents the whole system
 being documented -- a System is a bad of Documentables, in some sense.
 """
 
+import ast
 import builtins
 import datetime
 import imp
@@ -15,8 +16,9 @@ import platform
 import sys
 import types
 from enum import Enum
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Mapping, Optional, Type
 
+from pydoctor.epydoc.markup import ParsedDocstring
 from pydoctor.sphinx import SphinxInventory
 
 if TYPE_CHECKING:
@@ -69,6 +71,7 @@ class Documentable:
     """
     documentation_location = DocLocation.OWN_PAGE
     docstring = None
+    parsed_docstring: Optional[ParsedDocstring] = None
     docstring_lineno = 0
     linenumber = 0
     sourceHref = None
@@ -369,6 +372,7 @@ class Inheritable(Documentable):
 
 class Function(Inheritable):
     kind = "Function"
+    annotations: Mapping[str, ast.expr]
 
     def setup(self):
         super().setup()

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -241,7 +241,7 @@ def test_summary():
 
 
 def test_missing_field_name(capsys):
-    fromText('''
+    mod = fromText('''
     """
     A test module.
 
@@ -249,6 +249,7 @@ def test_missing_field_name(capsys):
     @type: str
     """
     ''', modname='test')
+    epydoc2stan.format_docstring(mod)
     captured = capsys.readouterr().out
     assert captured == "test:5: Missing field name in @ivar\n" \
                        "test:6: Missing field name in @type\n"


### PR DESCRIPTION
It turns out I already had a branch named `epydoc2stan-cleanup` that was merged in November 2019, hence the title.

The main purpose of this PR is to get the `epydoc2stan` module into a state where it is less complex and has better mypy and unit test coverage. All of this to reduce the chance of regressions when implementing for example #217.

The following commits fix some problems in error reporting:
- Do not print 'XXX' on duplicate `@return` or `@rtype`
- Avoid duplicate warning for missing `@type` name on module/class
- Use annotations from Documentable itself instead of docsource

The other commits shouldn't change functionality, so if you spot any changed behavior during review, please make note of it.
