### PR TITLE
[Fixes #240] Add support for source href with Windows paths.

### DIFF
--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -569,7 +569,7 @@ class System:
             mod.sourceHref = None
         else:
             projBaseDir = mod.system.options.projectbasedirectory
-            mod.sourceHref = self.sourcebase + source_path[len(projBaseDir):]
+            mod.sourceHref = self.sourcebase + source_path[len(projBaseDir):].replace("\\", "/")
 
     def addModule(self, modpath, modname, parentPackage=None):
         mod = self.Module(self, modname, parentPackage, modpath)

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -30,7 +30,7 @@ class FakeDocumentable:
 
 
 
-def test_setSourceHrefOption() -> None:
+def test_setSourceHrefOptionUnix() -> None:
     """
     Test that the projectbasedirectory option sets the model.sourceHref
     properly.
@@ -50,9 +50,27 @@ def test_setSourceHrefOption() -> None:
     mod.system = system
     system.setSourceHref(mod, projectBaseDir + moduleRelativePart)
 
-    expected = viewSourceBase + moduleRelativePart
-    assert mod.sourceHref == expected
+    assert mod.sourceHref == "http://example.org/trac/browser/trunk/package/module.py"
 
+def test_setSourceHrefOptionWindows() -> None:
+    """
+    Test that the projectbasedirectory option sets the model.sourceHref
+    properly.
+    """
+    projectBaseDir = "C:\\foo\\bar\\ProjectName"
+
+    mod = FakeDocumentable()
+
+    options = FakeOptions()
+    options.projectbasedirectory = projectBaseDir
+
+    system = model.System()
+    system.sourcebase = "http://example.org/trac/browser/trunk"
+    system.options = options
+    mod.system = system
+    system.setSourceHref(mod, projectBaseDir + "\\package\\module.py")
+
+    assert mod.sourceHref == "http://example.org/trac/browser/trunk/package/module.py"
 
 def test_initialization_default() -> None:
     """

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -54,8 +54,8 @@ def test_setSourceHrefOptionUnix() -> None:
 
 def test_setSourceHrefOptionWindows() -> None:
     """
-    Test that the projectbasedirectory option sets the model.sourceHref
-    properly.
+    System.sourceHref is set to a valid URL even when the source file is a
+    Windows path.
     """
     projectBaseDir = "C:\\foo\\bar\\ProjectName"
 


### PR DESCRIPTION
This updates the source HREF generation to generate valid HREF when the source path is on windows.

As a drive by, it updates the usage of imp lib with importlib.... as imp is deprecated. 