### PR TITLE
Run unit tests on Windows

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -26,8 +26,8 @@ jobs:
       run: |
         test -r /etc/os-release && sh -c '. /etc/os-release && echo "OS: $PRETTY_NAME"'
         python --version
-        python -c 'print("\nENVIRONMENT VARIABLES\n=====================\n")'
-        python -c 'import os; [print(f"{k}={v}") for k, v in os.environ.items()]'
+        python -c "print('\nENVIRONMENT VARIABLES\n=====================\n')"
+        python -c "import os; [print(f'{k}={v}') for k, v in os.environ.items()]"
 
     - name: Run mypy
       run: |

--- a/.github/workflows/system.yaml
+++ b/.github/workflows/system.yaml
@@ -26,8 +26,8 @@ jobs:
       run: |
         test -r /etc/os-release && sh -c '. /etc/os-release && echo "OS: $PRETTY_NAME"'
         python --version
-        python -c 'print("\nENVIRONMENT VARIABLES\n=====================\n")'
-        python -c 'import os; [print(f"{k}={v}") for k, v in os.environ.items()]'
+        python -c "print('\nENVIRONMENT VARIABLES\n=====================\n')"
+        python -c "import os; [print(f'{k}={v}') for k, v in os.environ.items()]"
 
     - name: Generate Twisted API docs
       continue-on-error: true

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -30,8 +30,8 @@ jobs:
       run: |
         test -r /etc/os-release && sh -c '. /etc/os-release && echo "OS: $PRETTY_NAME"'
         python --version
-        python -c 'print("\nENVIRONMENT VARIABLES\n=====================\n")'
-        python -c 'import os; [print(f"{k}={v}") for k, v in os.environ.items()]'
+        python -c "print('\nENVIRONMENT VARIABLES\n=====================\n')"
+        python -c "import os; [print(f'{k}={v}') for k, v in os.environ.items()]"
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -8,11 +8,15 @@ on:
 
 jobs:
   unit_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        os: [ubuntu-20.04]
+        include:
+        - os: windows-latest
+        - python-version: 3.6
 
     steps:
     - uses: actions/checkout@v2

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -16,6 +16,7 @@ import platform
 import sys
 import types
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Mapping, Optional, Type
 from urllib.parse import quote
 
@@ -76,7 +77,7 @@ class Documentable:
     parsed_docstring: Optional[ParsedDocstring] = None
     docstring_lineno = 0
     linenumber = 0
-    sourceHref = None
+    sourceHref: Optional[str] = None
     kind: str
 
     @property
@@ -90,7 +91,7 @@ class Documentable:
     def __init__(
             self, system: 'System', name: str,
             parent: Optional['Documentable'] = None,
-            source_path: Optional[str] = None
+            source_path: Optional[Path] = None
             ):
         if not isinstance(self, Package):
             self.doctarget = self
@@ -144,7 +145,8 @@ class Documentable:
         its file path. In other cases, such as during unit testing,
         the full module name is returned.
         """
-        return self.source_path or self.module.fullName()
+        source_path = self.source_path
+        return self.module.fullName() if source_path is None else str(source_path)
 
     @property
     def url(self) -> str:
@@ -271,7 +273,7 @@ class Documentable:
         return self.privacyClass is not PrivacyClass.HIDDEN
 
     @property
-    def module(self):
+    def module(self) -> 'Module':
         """This object's L{Module}.
 
         For modules, this returns the object itself, otherwise
@@ -422,6 +424,9 @@ class PrivacyClass(Enum):
     VISIBLE = 2
 
 
+# Work around the attributes of the same name within the System class.
+_ModuleT = Module
+_PackageT = Package
 
 class System:
     """A collection of related documentable objects.
@@ -564,14 +569,19 @@ class System:
     #  http://divmod.org/trac/browser/trunk
     #                          ~/src/Divmod/Nevow/nevow/flat/ten.py
 
-    def setSourceHref(self, mod, source_path):
+    def setSourceHref(self, mod: _ModuleT, source_path: Path) -> None:
         if self.sourcebase is None:
             mod.sourceHref = None
         else:
-            projBaseDir = mod.system.options.projectbasedirectory
-            mod.sourceHref = self.sourcebase + source_path[len(projBaseDir):]
+            projBaseDir = Path(mod.system.options.projectbasedirectory)
+            relative = source_path.relative_to(projBaseDir).as_posix()
+            mod.sourceHref = f'{self.sourcebase}/{relative}'
 
-    def addModule(self, modpath, modname, parentPackage=None):
+    def addModule(self,
+            modpath: Path,
+            modname: str,
+            parentPackage: Optional[_PackageT] = None
+            ) -> None:
         mod = self.Module(self, modname, parentPackage, modpath)
         self.addObject(mod)
         self.progress(
@@ -581,9 +591,15 @@ class System:
         self.module_count += 1
         self.setSourceHref(mod, modpath)
 
-    def ensureModule(self, module_full_name, modpath):
-        if module_full_name in self.allobjects:
-            return self.allobjects[module_full_name]
+    def ensureModule(self, module_full_name: str, modpath: Path) -> _ModuleT:
+        try:
+            module: Module = self.allobjects[module_full_name]
+            assert isinstance(module, Module)
+        except KeyError:
+            pass
+        else:
+            return module
+
         if '.' in module_full_name:
             parent_name, module_name = module_full_name.rsplit('.', 1)
             parent_package = self.ensurePackage(parent_name)
@@ -628,7 +644,7 @@ class System:
                 self._introspectThing(v, c, parentMod)
 
     def introspectModule(self, py_mod, module_full_name):
-        module = self.ensureModule(module_full_name, py_mod.__file__)
+        module = self.ensureModule(module_full_name, Path(py_mod.__file__))
         module.docstring = py_mod.__doc__
         self._introspectThing(py_mod, module, module)
 
@@ -672,7 +688,7 @@ class System:
                     (suffix, mode, impl))
                 self.introspectModule(py_mod, module_full_name)
             elif impl == imp.PY_SOURCE:
-                self.addModule(path, module_name, package)
+                self.addModule(Path(path), module_name, package)
             break
 
     def handleDuplicate(self, obj):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -99,7 +99,7 @@ class Documentable:
         self.system = system
         self.name = name
         self.parent = parent
-        self.parentMod = None
+        self.parentMod: Optional[Module] = None
         self.source_path = source_path
         self.setup()
 

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -48,7 +48,7 @@ def fromText(
         buildercls: Optional[Type[astbuilder.ASTBuilder]] = None,
         systemcls: Type[model.System] = model.System
         ) -> model.Module:
-    ast = astbuilder.parse(textwrap.dedent(text))
+    ast = astbuilder._parse(textwrap.dedent(text))
     return fromAST(ast, modname, system, buildercls, systemcls)
 
 def unwrap(parsed_docstring: ParsedEpytextDocstring) -> str:
@@ -343,7 +343,7 @@ def test_nested_class_inheriting_from_same_module(systemcls: Type[model.System])
 
 @systemcls_param
 def test_all_recognition(systemcls: Type[model.System]) -> None:
-    ast = astbuilder.parse(textwrap.dedent('''
+    ast = astbuilder._parse(textwrap.dedent('''
     def f():
         pass
     __all__ = ['f']
@@ -355,7 +355,7 @@ def test_all_recognition(systemcls: Type[model.System]) -> None:
 
 @systemcls_param
 def test_all_in_class_non_recognition(systemcls: Type[model.System]) -> None:
-    ast = astbuilder.parse(textwrap.dedent('''
+    ast = astbuilder._parse(textwrap.dedent('''
     class C:
         __all__ = ['f']
     '''))

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -4,6 +4,7 @@ Unit tests for model.
 
 from pathlib import Path
 from typing import cast
+import os
 import sys
 import zlib
 
@@ -37,9 +38,11 @@ def test_setSourceHrefOption() -> None:
     Test that the projectbasedirectory option sets the model.sourceHref
     properly.
     """
-    viewSourceBase = "http://example.org/trac/browser/trunk"
-    projectBaseDir = "/foo/bar/ProjectName"
-    moduleRelativePart = "/package/module.py"
+
+    if os.name == 'nt':
+        projectBaseDir = "C:\\foo\\bar\\ProjectName"
+    else:
+        projectBaseDir = "/foo/bar/ProjectName"
 
     mod = cast(model.Module, FakeDocumentable())
 
@@ -47,13 +50,12 @@ def test_setSourceHrefOption() -> None:
     options.projectbasedirectory = projectBaseDir
 
     system = model.System()
-    system.sourcebase = viewSourceBase
+    system.sourcebase = "http://example.org/trac/browser/trunk"
     system.options = options
     mod.system = system
-    system.setSourceHref(mod, Path(projectBaseDir + moduleRelativePart))
+    system.setSourceHref(mod, Path(projectBaseDir) / "package" / "module.py")
 
-    expected = viewSourceBase + moduleRelativePart
-    assert mod.sourceHref == expected
+    assert mod.sourceHref == "http://example.org/trac/browser/trunk/package/module.py"
 
 
 def test_initialization_default() -> None:

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -2,6 +2,8 @@
 Unit tests for model.
 """
 
+from pathlib import Path
+from typing import cast
 import sys
 import zlib
 
@@ -39,7 +41,7 @@ def test_setSourceHrefOption() -> None:
     projectBaseDir = "/foo/bar/ProjectName"
     moduleRelativePart = "/package/module.py"
 
-    mod = FakeDocumentable()
+    mod = cast(model.Module, FakeDocumentable())
 
     options = FakeOptions()
     options.projectbasedirectory = projectBaseDir
@@ -48,7 +50,7 @@ def test_setSourceHrefOption() -> None:
     system.sourcebase = viewSourceBase
     system.options = options
     mod.system = system
-    system.setSourceHref(mod, projectBaseDir + moduleRelativePart)
+    system.setSourceHref(mod, Path(projectBaseDir + moduleRelativePart))
 
     expected = viewSourceBase + moduleRelativePart
     assert mod.sourceHref == expected

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -62,7 +62,7 @@ def test_allgames() -> None:
     moved = mod2.contents['NotInSourceAll']
     assert isinstance(moved, model.Class)
     assert moved.source_path is not None
-    assert moved.source_path.endswith('/allgames/mod1.py')
+    assert moved.source_path.parts[-2:] == ('allgames', 'mod1.py')
     assert moved.parentMod is mod2
     assert moved.parentMod.source_path is not None
-    assert moved.parentMod.source_path.endswith('/allgames/mod2.py')
+    assert moved.parentMod.source_path.parts[-2:] == ('allgames', 'mod2.py')

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -50,11 +50,19 @@ def test_allgames() -> None:
     """
 
     system = processPackage("allgames")
+    mod1 = system.allobjects['allgames.mod1']
+    assert isinstance(mod1, model.Module)
+    mod2 = system.allobjects['allgames.mod2']
+    assert isinstance(mod2, model.Module)
     # InSourceAll is not moved into mod2, but NotInSourceAll is.
-    assert 'InSourceAll' in system.allobjects['allgames.mod1'].contents
-    assert 'NotInSourceAll' in system.allobjects['allgames.mod2'].contents
+    assert 'InSourceAll' in mod1.contents
+    assert 'NotInSourceAll' in mod2.contents
     # Source paths must be unaffected by the move, so that error messages
     # point to the right source code.
-    moved = system.allobjects['allgames.mod2'].contents['NotInSourceAll']
+    moved = mod2.contents['NotInSourceAll']
+    assert isinstance(moved, model.Class)
+    assert moved.source_path is not None
     assert moved.source_path.endswith('/allgames/mod1.py')
+    assert moved.parentMod is mod2
+    assert moved.parentMod.source_path is not None
     assert moved.parentMod.source_path.endswith('/allgames/mod2.py')

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -93,9 +93,10 @@ def test_generate_empty_functional(inv_writer: InvWriter) -> None:
 
     inv_writer.generate(subjects=[], basepath='base-path')
 
+    inventory_path = Path('base-path') / 'objects.inv'
     expected_log = [(
         'sphinx',
-        'Generating objects inventory at base-path/objects.inv',
+        f'Generating objects inventory at {inventory_path}',
         0
         )]
     assert expected_log == inv_writer._logger.messages

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -614,7 +614,7 @@ def cacheDirectory(request, tmp_path_factory):
     clearCache=st.booleans(),
     enableCache=st.booleans(),
     cacheDirectoryName=st.text(
-        alphabet=sorted(set(string.printable) - set('\\/:*?"<>|\x0c\x0b\n')),
+        alphabet=sorted(set(string.printable) - set('\\/:*?"<>|\x0c\x0b\t\r\n')),
         min_size=3,             # Avoid ..
         max_size=32,            # Avoid upper length on path
     ),


### PR DESCRIPTION
This modifies the `unit` workflow to include a test on Windows. It also fixes the tests and the code to make the tests pass on Windows.

The use of `pathlib.Path.as_posix()` fixes #240.
