### PR TITLE
Replace use of deprecated 'imp' module by 'importlib'

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -22,6 +22,9 @@ ignore_missing_imports=True
 [mypy-cachecontrol.*]
 ignore_missing_imports=True
 
+[mypy-cython_test_exception_raiser.*]
+ignore_missing_imports=True
+
 [mypy-incremental.*]
 ignore_missing_imports=True
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -643,10 +643,12 @@ class System:
                 self.addObject(c)
                 self._introspectThing(v, c, parentMod)
 
-    def introspectModule(self, path, module_full_name):
+    def introspectModule(self, path: Path, module_full_name: str) -> None:
         spec = importlib.util.spec_from_file_location(module_full_name, path)
         py_mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(py_mod)
+        loader = spec.loader
+        assert isinstance(loader, importlib.abc.Loader), loader
+        loader.exec_module(py_mod)
         module = self.ensureModule(module_full_name, path)
         module.docstring = py_mod.__doc__
         self._introspectThing(py_mod, module, module)
@@ -674,7 +676,7 @@ class System:
             elif not fname.startswith('.'):
                 self.addModuleFromPath(package, fullname)
 
-    def addModuleFromPath(self, package, path):
+    def addModuleFromPath(self, package: Optional[_PackageT], path: str) -> None:
         for suffix in importlib.machinery.all_suffixes():
             if not path.endswith(suffix):
                 continue

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -643,8 +643,11 @@ class System:
                 self.addObject(c)
                 self._introspectThing(v, c, parentMod)
 
-    def introspectModule(self, py_mod, module_full_name):
-        module = self.ensureModule(module_full_name, Path(py_mod.__file__))
+    def introspectModule(self, path, module_full_name):
+        spec = importlib.util.spec_from_file_location(module_full_name, path)
+        py_mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(py_mod)
+        module = self.ensureModule(module_full_name, path)
         module.docstring = py_mod.__doc__
         self._introspectThing(py_mod, module, module)
 
@@ -683,9 +686,7 @@ class System:
                     module_full_name = f'{package.fullName()}.{module_name}'
                 else:
                     module_full_name = module_name
-                py_mod = importlib.util.spec_from_file_location(
-                    module_full_name, path)
-                self.introspectModule(py_mod, module_full_name)
+                self.introspectModule(Path(path), module_full_name)
             elif suffix in importlib.machinery.SOURCE_SUFFIXES:
                 self.addModule(Path(path), module_name, package)
             break

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -625,8 +625,10 @@ class System:
 
     def _introspectThing(self, thing, parent, parentMod):
         for k, v in thing.__dict__.items():
-            if isinstance(v, (types.BuiltinFunctionType,
-                              types.FunctionType)):
+            if (isinstance(v, (types.BuiltinFunctionType, types.FunctionType))
+                    # In PyPy 7.3.1, functions from extensions are not
+                    # instances of the above abstract types.
+                    or v.__class__.__name__ == 'builtin_function_or_method'):
                 f = self.Function(self, k, parent)
                 f.parentMod = parentMod
                 f.docstring = v.__doc__

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -9,7 +9,7 @@ being documented -- a System is a bad of Documentables, in some sense.
 import ast
 import builtins
 import datetime
-import imp
+import importlib
 import inspect
 import os
 import platform
@@ -672,22 +672,21 @@ class System:
                 self.addModuleFromPath(package, fullname)
 
     def addModuleFromPath(self, package, path):
-        for (suffix, mode, impl) in imp.get_suffixes():
+        for suffix in importlib.machinery.all_suffixes():
             if not path.endswith(suffix):
                 continue
             module_name = os.path.basename(path[:-len(suffix)])
-            if impl == imp.C_EXTENSION:
+            if suffix in importlib.machinery.EXTENSION_SUFFIXES:
                 if not self.options.introspect_c_modules:
                     continue
                 if package is not None:
                     module_full_name = f'{package.fullName()}.{module_name}'
                 else:
                     module_full_name = module_name
-                py_mod = imp.load_module(
-                    module_full_name, open(path, 'rb'), path,
-                    (suffix, mode, impl))
+                py_mod = importlib.util.spec_from_file_location(
+                    module_full_name, path)
                 self.introspectModule(py_mod, module_full_name)
-            elif impl == imp.PY_SOURCE:
+            elif suffix in importlib.machinery.SOURCE_SUFFIXES:
                 self.addModule(Path(path), module_name, package)
             break
 

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -4,7 +4,6 @@ Unit tests for model.
 
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import cast
-import sys
 import zlib
 
 import pytest
@@ -169,8 +168,7 @@ class Dummy:
 def test_introspection() -> None:
     """Find docstrings from this test using introspection."""
     system = model.System()
-    py_mod = sys.modules[__name__]
-    system.introspectModule(py_mod, __name__)
+    system.introspectModule(Path(__file__), __name__)
 
     module = system.objForFullName(__name__)
     assert module is not None

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     test: pytest
     test: docutils
     test: hypothesis
+    test: cython-test-exception-raiser==1.0.0
 
     codecov: codecov
 


### PR DESCRIPTION
This was extracted from a drive-by fix in #241.