### PR TITLE
Windows paths follow-up

### DIFF
--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -1,5 +1,7 @@
 """The command-line parsing and entry point."""
 
+from optparse import Option, OptionParser, OptionValueError
+from pathlib import Path
 import datetime
 import os
 import sys
@@ -32,9 +34,18 @@ def findClassFromDottedName(dottedname, optionname):
 
 MAKE_HTML_DEFAULT = object()
 
+def check_path(option, opt, value):
+    try:
+        return Path(value)
+    except Exception as ex:
+        raise OptionValueError(f"{opt}: invalid path: {ex}")
+
+class CustomOption(Option):
+    TYPES = Option.TYPES + ("path",)
+    TYPE_CHECKER = dict(Option.TYPE_CHECKER, path=check_path)
+
 def getparser():
-    from optparse import OptionParser
-    parser = OptionParser(version=__version__.public())
+    parser = OptionParser(option_class=CustomOption, version=__version__.public())
     parser.add_option(
         '-c', '--config', dest='configfile',
         help=("Use config from this file (any command line"
@@ -49,10 +60,9 @@ def getparser():
         '--project-url', dest='projecturl',
         help=("The project url, appears in the html if given."))
     parser.add_option(
-        '--project-base-dir', dest='projectbasedirectory',
-        help=("Absolute path to the base directory of the "
-              "project.  Source links will be computed based "
-              "on this value."))
+        '--project-base-dir', dest='projectbasedirectory', type='path',
+        help=("Path to the base directory of the project.  Source links "
+              "will be computed based on this value."))
     parser.add_option(
         '--testing', dest='testing', action='store_true',
         help=("Don't complain if the run doesn't have any effects."))

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -34,7 +34,10 @@ def findClassFromDottedName(dottedname, optionname):
 
 MAKE_HTML_DEFAULT = object()
 
-def check_path(option, opt, value):
+def parse_path(option, opt, value):
+    """Parse a path value given to an option to a L{Path} object.
+    The path is not verified: it is only parsed.
+    """
     try:
         return Path(value)
     except Exception as ex:
@@ -42,7 +45,7 @@ def check_path(option, opt, value):
 
 class CustomOption(Option):
     TYPES = Option.TYPES + ("path",)
-    TYPE_CHECKER = dict(Option.TYPE_CHECKER, path=check_path)
+    TYPE_CHECKER = dict(Option.TYPE_CHECKER, path=parse_path)
 
 def getparser():
     parser = OptionParser(option_class=CustomOption, version=__version__.public())

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -573,7 +573,7 @@ class System:
         if self.sourcebase is None:
             mod.sourceHref = None
         else:
-            projBaseDir = Path(mod.system.options.projectbasedirectory)
+            projBaseDir = mod.system.options.projectbasedirectory
             relative = source_path.relative_to(projBaseDir).as_posix()
             mod.sourceHref = f'{self.sourcebase}/{relative}'
 

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -49,7 +49,7 @@ def test_projectbasedir() -> None:
     value = "projbasedirvalue"
     options, args = driver.parse_args([
             "--project-base-dir", value])
-    assert options.projectbasedirectory == value
+    assert str(options.projectbasedirectory) == value
 
 
 def test_cache_disabled_by_default() -> None:

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -2,11 +2,12 @@
 Unit tests for model.
 """
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import cast
-import os
 import sys
 import zlib
+
+import pytest
 
 from pydoctor import model
 from pydoctor.driver import parse_args
@@ -33,27 +34,26 @@ class FakeDocumentable:
 
 
 
-def test_setSourceHrefOption() -> None:
+@pytest.mark.parametrize('projectBaseDir', [
+    PurePosixPath("/foo/bar/ProjectName"),
+    PureWindowsPath("C:\\foo\\bar\\ProjectName")]
+)
+def test_setSourceHrefOption(projectBaseDir: Path) -> None:
     """
     Test that the projectbasedirectory option sets the model.sourceHref
     properly.
     """
 
-    if os.name == 'nt':
-        projectBaseDir = "C:\\foo\\bar\\ProjectName"
-    else:
-        projectBaseDir = "/foo/bar/ProjectName"
-
     mod = cast(model.Module, FakeDocumentable())
 
     options = FakeOptions()
-    options.projectbasedirectory = projectBaseDir
+    options.projectbasedirectory = str(projectBaseDir)
 
     system = model.System()
     system.sourcebase = "http://example.org/trac/browser/trunk"
     system.options = options
     mod.system = system
-    system.setSourceHref(mod, Path(projectBaseDir) / "package" / "module.py")
+    system.setSourceHref(mod, projectBaseDir / "package" / "module.py")
 
     assert mod.sourceHref == "http://example.org/trac/browser/trunk/package/module.py"
 

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -19,7 +19,7 @@ class FakeOptions:
     A fake options object as if it came from that stupid optparse thing.
     """
     sourcehref = None
-    projectbasedirectory: str
+    projectbasedirectory: Path
 
 
 
@@ -47,7 +47,7 @@ def test_setSourceHrefOption(projectBaseDir: Path) -> None:
     mod = cast(model.Module, FakeDocumentable())
 
     options = FakeOptions()
-    options.projectbasedirectory = str(projectBaseDir)
+    options.projectbasedirectory = projectBaseDir
 
     system = model.System()
     system.sourcebase = "http://example.org/trac/browser/trunk"


### PR DESCRIPTION
After #242, it is possible for Hypothesis to generate directory names that are not valid in Windows, which leads to random failures in `test_prepareCache()`. This adds a few `assume()` checks to filter out invalid directory names.

Additionally, `test_setSourceHrefOption()` was modified to use pure paths, which allows testing Windows paths on Linux and vice versa.
