### PR TITLE
Fix system test

### DIFF
--- a/.github/workflows/system.yaml
+++ b/.github/workflows/system.yaml
@@ -30,6 +30,5 @@ jobs:
         python -c "import os; [print(f'{k}={v}') for k, v in os.environ.items()]"
 
     - name: Generate Twisted API docs
-      continue-on-error: true
       run: |
         tox -e twisted-apidoc

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -655,7 +655,7 @@ class System:
         module.docstring = py_mod.__doc__
         self._introspectThing(py_mod, module, module)
 
-    def addPackage(self, dirpath, parentPackage=None):
+    def addPackage(self, dirpath: str, parentPackage: Optional[_PackageT] = None) -> None:
         if not os.path.exists(dirpath):
             raise Exception(f"package path {dirpath!r} does not exist!")
         if not os.path.exists(os.path.join(dirpath, '__init__.py')):
@@ -668,7 +668,7 @@ class System:
         package_name = os.path.basename(dirpath)
         package_full_name = prefix + package_name
         package = self.ensurePackage(package_full_name)
-        self.setSourceHref(package, dirpath)
+        self.setSourceHref(package, Path(dirpath))
         for fname in sorted(os.listdir(dirpath)):
             fullname = os.path.join(dirpath, fname)
             if os.path.isdir(fullname):

--- a/tox.ini
+++ b/tox.ini
@@ -49,8 +49,6 @@ commands =
     twisted-apidoc: git clone --depth 1 --branch trunk https://github.com/twisted/twisted.git {toxworkdir}/twisted-trunk
     twisted-apidoc: /bin/sh -c "{toxworkdir}/twisted-trunk/bin/admin/build-apidocs {toxworkdir}/twisted-trunk/src {toxworkdir}/twisted-apidocs-build > {toxworkdir}/twisted-apidocs.log"
     twisted-apidoc: /bin/cat {toxworkdir}/twisted-apidocs.log
-    ; Fail if the output of running pydoctor on Twisted is not emtpy.
-    twisted-apidoc: /bin/sh -c "test ! -s {toxworkdir}/twisted-apidocs.log"
 
 
 [testenv:mypy]


### PR DESCRIPTION
Make sure our system test actually turns red when pydoctor crashes.

The system test broke in #242, but we didn't notice because the error wasn't shown at the top level.