### PR TITLE
Improve parsing of intersphinx inventories

### DIFF
--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -94,14 +94,14 @@ class _EpydocLinker(DocstringLinker):
 
         # Check if the fullID exists in an intersphinx inventory.
         fullID = self.obj.expandName(identifier)
-        target_name = self.look_for_intersphinx(fullID)
-        if not target_name:
+        target_url = self.look_for_intersphinx(fullID)
+        if not target_url:
             # FIXME: https://github.com/twisted/pydoctor/issues/125
             # expandName is unreliable so in the case fullID fails, we
             # try our luck with 'identifier'.
-            target_name = self.look_for_intersphinx(identifier)
-        if target_name:
-            return target_name
+            target_url = self.look_for_intersphinx(identifier)
+        if target_url:
+            return target_url
 
         # Since there was no global match, go look for the name in the
         # context where it was used.

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -117,7 +117,8 @@ class SphinxInventory:
                     'Failed to parse line "%s" for %s' % (line, base_url),
                     )
                 continue
-            result[name] = (base_url, location)
+            if typ.startswith('py:'):
+                result[name] = (base_url, location)
         return result
 
     def getLink(self, name: str) -> Optional[str]:

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -117,8 +117,12 @@ class SphinxInventory:
                     'Failed to parse line "%s" for %s' % (line, base_url),
                     )
                 continue
-            if typ.startswith('py:'):
-                result[name] = (base_url, location)
+
+            if not typ.startswith('py:'):
+                # Non-Python references are ignored.
+                continue
+
+            result[name] = (base_url, location)
         return result
 
     def getLink(self, name: str) -> Optional[str]:

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -437,6 +437,7 @@ def test_parseInventory_invalid_lines(inv_reader: InvReader) -> None:
     base_url = 'http://tm.tld'
     content = (
         'good.attr py:attribute -1 some.html -\n'
+        'missing.display.name py:attribute 1 some.html\n'
         'bad.attr bad format\n'
         'very.bad\n'
         '\n'
@@ -450,6 +451,11 @@ def test_parseInventory_invalid_lines(inv_reader: InvReader) -> None:
         'good.again': (base_url, 'again.html'),
         } == result
     assert [
+        (
+            'sphinx',
+            'Failed to parse line "missing.display.name py:attribute 1 some.html" for http://tm.tld',
+            -1,
+            ),
         (
             'sphinx',
             'Failed to parse line "bad.attr bad format" for http://tm.tld',

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -404,7 +404,9 @@ def test_parseInventory_single_line(inv_reader_nolog: sphinx.SphinxInventory) ->
 
 def test_parseInventory_spaces() -> None:
     """
-    Check that columns that contain spaces are not split up.
+    Sphinx inventory lines always contain 5 values, separated by spaces.
+    However, the first and fifth value can contain internal spaces.
+    The parser must be able to tell apart separators from internal spaces.
     """
 
     # Space in first (name) column.

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -460,6 +460,26 @@ def test_parseInventory_invalid_lines(inv_reader: InvReader) -> None:
         ] == inv_reader._logger.messages
 
 
+def test_parseInventory_type_filter(inv_reader: InvReader) -> None:
+    """
+    Ignore entries that don't have a 'py:' type field.
+    """
+
+    base_url = 'https://docs.python.org/3'
+    content = (
+        'dict std:label -1 reference/expressions.html#$ Dictionary displays\n'
+        'dict py:class 1 library/stdtypes.html#$ -\n'
+        'dict std:2to3fixer 1 library/2to3.html#2to3fixer-$ -\n'
+        )
+
+    result = inv_reader._parseInventory(base_url, content)
+
+    assert {
+        'dict': (base_url, 'library/stdtypes.html#$'),
+        } == result
+    assert [] == inv_reader._logger.messages
+
+
 maxAgeAmounts = st.integers() | st.just("\x00")
 maxAgeUnits = st.sampled_from(tuple(sphinx._maxAgeUnits)) | st.just("\x00")
 

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -402,6 +402,33 @@ def test_parseInventory_single_line(inv_reader_nolog: sphinx.SphinxInventory) ->
     assert {'some.attr': ('http://base.tld', 'some.html')} == result
 
 
+def test_parseInventory_spaces() -> None:
+    """
+    Check that columns that contain spaces are not split up.
+    """
+
+    # Space in first (name) column.
+    assert sphinx._parseInventoryLine(
+        'key function std:term -1 glossary.html#term-key-function -'
+        ) == (
+        'key function', 'std:term', -1, 'glossary.html#term-key-function', '-'
+        )
+
+    # Space in last (display name) column.
+    assert sphinx._parseInventoryLine(
+        'doctest-execution-context std:label -1 library/doctest.html#$ What’s the Execution Context?'
+        ) == (
+        'doctest-execution-context', 'std:label', -1, 'library/doctest.html#$', 'What’s the Execution Context?'
+        )
+
+    # Space in both first and last column.
+    assert sphinx._parseInventoryLine(
+        'async def std:label -1 reference/compound_stmts.html#async-def Coroutine function definition'
+        ) == (
+        'async def', 'std:label', -1, 'reference/compound_stmts.html#async-def', 'Coroutine function definition'
+        )
+
+
 def test_parseInventory_invalid_lines(inv_reader: InvReader) -> None:
     """
     Skip line and log an error.


### PR DESCRIPTION
I noticed that `L{dict}` was being linked to the 2to3 documentation, rather than the built-in type. This is due to there being 3 pages with the name `dict` and our inventory parser remembers the last one it sees, even if that is not the most relevant one.

While investigating that problem, I also found that `L{key}` in Twisted's documentation was not flagged as an error despite there not being any function or constant named `key` in the Python standard library. It turns out the name `key function` was split in two by the parser. (To be fair to our parser, using spaces as separators while also allowing spaces in fields is a very unfortunate choice for a format.)
