### PR TITLE
Fix getProcessedModule() for package

### DIFF
--- a/.github/workflows/system.yaml
+++ b/.github/workflows/system.yaml
@@ -10,6 +10,10 @@ jobs:
   system_tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        tox_target: [twisted-apidoc, cpython-summary]
+
     steps:
     - uses: actions/checkout@v2
 
@@ -29,6 +33,6 @@ jobs:
         python -c "print('\nENVIRONMENT VARIABLES\n=====================\n')"
         python -c "import os; [print(f'{k}={v}') for k, v in os.environ.items()]"
 
-    - name: Generate Twisted API docs
+    - name: Generate API docs
       run: |
-        tox -e twisted-apidoc
+        tox -e ${{ matrix.tox_target }}

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -200,14 +200,19 @@ class ModuleVistor(ast.NodeVisitor):
     def _importNames(self, modname: str, names: Iterable[ast.alias]) -> None:
         """Handle a C{from <modname> import <names>} statement."""
 
+        # Process the module we're importing from.
+        # If we're importing from a package, 'mod' will be the __init__ module.
         mod = self.system.getProcessedModule(modname)
-        if mod is not None:
-            expandName = mod.expandName
-        else:
-            expandName = lambda name: f'{modname}.{name}'
+        obj = self.system.objForFullName(modname)
 
         # Are we importing from a package?
-        is_package = isinstance(self.system.objForFullName(modname), model.Package)
+        is_package = isinstance(obj, model.Package)
+        assert is_package or obj is mod or mod is None
+
+        if obj is not None:
+            expandName = obj.expandName
+        else:
+            expandName = lambda name: f'{modname}.{name}'
 
         # Fetch names to export.
         current = self.builder.current

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -206,6 +206,9 @@ class ModuleVistor(ast.NodeVisitor):
         else:
             expandName = lambda name: f'{modname}.{name}'
 
+        # Are we importing from a package?
+        is_package = isinstance(self.system.objForFullName(modname), model.Package)
+
         # Fetch names to export.
         current = self.builder.current
         if isinstance(current, model.Module):
@@ -238,7 +241,9 @@ class ModuleVistor(ast.NodeVisitor):
                         ob.reparent(current, asname)
                         continue
 
-            if isinstance(self.system.objForFullName(modname), model.Package):
+            # If we're importing from a package, make sure imported modules
+            # are processed (getProcessedModule() ignores non-modules).
+            if is_package:
                 self.system.getProcessedModule(f'{modname}.{orgname}')
 
             _localNameToFullName[asname] = expandName(orgname)

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -754,9 +754,7 @@ class System:
         if mod is None:
             return None
         if isinstance(mod, Package):
-            initModule = self.getProcessedModule(modname + '.__init__')
-            assert initModule is not None
-            return initModule
+            return self.getProcessedModule(modname + '.__init__')
         if not isinstance(mod, Module):
             return None
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -16,7 +16,7 @@ import sys
 import types
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Mapping, Optional, Type
+from typing import TYPE_CHECKING, Collection, Mapping, Optional, Type
 from urllib.parse import quote
 
 from pydoctor.epydoc.markup import ParsedDocstring
@@ -352,9 +352,9 @@ class Module(CanContainImportsDocumentable):
         else:
             return DocLocation.OWN_PAGE
 
-    def setup(self):
+    def setup(self) -> None:
         super().setup()
-        self.all = None
+        self.all: Optional[Collection[str]] = None
 
     def _localNameToFullName(self, name):
         if name in self.contents:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -752,12 +752,14 @@ class System:
         self.allobjects[fullName] = obj
 
 
-    def getProcessedModule(self, modname):
+    def getProcessedModule(self, modname: str) -> Optional[_ModuleT]:
         mod = self.allobjects.get(modname)
         if mod is None:
             return None
         if isinstance(mod, Package):
-            return self.getProcessedModule(modname + '.__init__').parent
+            initModule = self.getProcessedModule(modname + '.__init__')
+            assert initModule is not None
+            return initModule.parent
         if not isinstance(mod, Module):
             return None
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -7,7 +7,6 @@ being documented -- a System is a bad of Documentables, in some sense.
 """
 
 import ast
-import builtins
 import datetime
 import importlib
 import inspect
@@ -363,8 +362,6 @@ class Module(CanContainImportsDocumentable):
             return o.fullName()
         elif name in self._localNameToFullName_map:
             return self._localNameToFullName_map[name]
-        elif name in builtins.__dict__:
-            return name
         else:
             return name
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -759,7 +759,7 @@ class System:
         if isinstance(mod, Package):
             initModule = self.getProcessedModule(modname + '.__init__')
             assert initModule is not None
-            return initModule.parent
+            return initModule
         if not isinstance(mod, Module):
             return None
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -354,7 +354,17 @@ class Module(CanContainImportsDocumentable):
 
     def setup(self) -> None:
         super().setup()
+
         self.all: Optional[Collection[str]] = None
+        """Names listed in the C{__all__} variable of this module.
+
+        These names are considered to be exported by the module,
+        both for the purpose of C{from <module> import *} and
+        for the purpose of publishing names from private modules.
+
+        If no C{__all__} variable was found in the module, or its
+        contents could not be parsed, this is L{None}.
+        """
 
     def _localNameToFullName(self, name):
         if name in self.contents:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -556,13 +556,15 @@ class System:
             return PrivacyClass.PRIVATE
         return PrivacyClass.VISIBLE
 
-    def addObject(self, obj):
+    def addObject(self, obj: Documentable) -> None:
         """Add C{object} to the system."""
-        fullName = obj.fullName()
-        if obj.parent and obj.parent.fullName() != fullName:
+
+        if obj.parent:
             obj.parent.contents[obj.name] = obj
         else:
             self.rootobjects.append(obj)
+
+        fullName = obj.fullName()
         if fullName in self.allobjects:
             self.handleDuplicate(obj)
         else:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -763,6 +763,7 @@ class System:
         if mod.state is ProcessingState.UNPROCESSED:
             self.processModule(mod)
 
+        assert mod.state in (ProcessingState.PROCESSING, ProcessingState.PROCESSED)
         return mod
 
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -564,11 +564,9 @@ class System:
         else:
             self.rootobjects.append(obj)
 
-        fullName = obj.fullName()
-        if fullName in self.allobjects:
+        first = self.allobjects.setdefault(obj.fullName(), obj)
+        if obj is not first:
             self.handleDuplicate(obj)
-        else:
-            self.allobjects[fullName] = obj
 
     # if we assume:
     #

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -473,6 +473,24 @@ def test_import_from_package(systemcls: Type[model.System]) -> None:
 
 
 @systemcls_param
+def test_import_module_from_package(systemcls: Type[model.System]) -> None:
+    """Importing a module from a package should not look in __init__ module."""
+    system = systemcls()
+    system.ensurePackage('a')
+    fromText('''
+    # This module intentionally left blank.
+    ''', modname='__init__', parent_name='a', system=system)
+    mod_b = fromText('''
+    def f(): pass
+    ''', modname='b', parent_name='a', system=system)
+    mod_c = fromText('''
+    from a import b
+    f = b.f
+    ''', modname='c', system=system)
+    assert mod_c.resolveName('f') == mod_b.contents['f']
+
+
+@systemcls_param
 def test_inline_docstring_modulevar(systemcls: Type[model.System]) -> None:
     mod = fromText('''
     """regular module docstring

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -23,6 +23,7 @@ systemcls_param = pytest.mark.parametrize(
 def fromAST(
         ast: ast.Module,
         modname: str = '<test>',
+        parent_name: Optional[str] = None,
         system: Optional[model.System] = None,
         buildercls: Optional[Type[astbuilder.ASTBuilder]] = None,
         systemcls: Type[model.System] = model.System
@@ -34,22 +35,30 @@ def fromAST(
     if buildercls is None:
         buildercls = _system.defaultBuilder
     builder = buildercls(_system)
+    if parent_name is None:
+        full_name = modname
+    else:
+        full_name = f'{parent_name}.{modname}'
+        # Set containing package as parent.
+        builder.current = _system.allobjects[parent_name]
     mod: model.Module = builder._push(_system.Module, modname, None)
     builder._pop(_system.Module)
     builder.processModuleAST(ast, mod)
-    mod = _system.allobjects[modname]
+    mod = _system.allobjects[full_name]
     mod.state = model.ProcessingState.PROCESSED
     return mod
 
 def fromText(
         text: str,
+        *,
         modname: str = '<test>',
+        parent_name: Optional[str] = None,
         system: Optional[model.System] = None,
         buildercls: Optional[Type[astbuilder.ASTBuilder]] = None,
         systemcls: Type[model.System] = model.System
         ) -> model.Module:
     ast = astbuilder._parse(textwrap.dedent(text))
-    return fromAST(ast, modname, system, buildercls, systemcls)
+    return fromAST(ast, modname, parent_name, system, buildercls, systemcls)
 
 def unwrap(parsed_docstring: ParsedEpytextDocstring) -> str:
     epytext = parsed_docstring._tree
@@ -236,9 +245,9 @@ def test_aliasing(systemcls: Type[model.System]) -> None:
         class C(B):
             pass
         '''
-        fromText(src_a, 'a', system)
-        fromText(src_b, 'b', system)
-        fromText(src_c, 'c', system)
+        fromText(src_a, modname='a', system=system)
+        fromText(src_b, modname='b', system=system)
+        fromText(src_c, modname='c', system=system)
 
     system = systemcls()
     addsrc(system)
@@ -262,10 +271,10 @@ def test_more_aliasing(systemcls: Type[model.System]) -> None:
         class D(C):
             pass
         '''
-        fromText(src_a, 'a', system)
-        fromText(src_b, 'b', system)
-        fromText(src_c, 'c', system)
-        fromText(src_d, 'd', system)
+        fromText(src_a, modname='a', system=system)
+        fromText(src_b, modname='b', system=system)
+        fromText(src_c, modname='c', system=system)
+        fromText(src_d, modname='d', system=system)
 
     system = systemcls()
     addsrc(system)
@@ -281,7 +290,7 @@ def test_aliasing_recursion(systemcls: Type[model.System]) -> None:
     class D(C):
         pass
     '''
-    mod = fromText(src, 'mod', system)
+    mod = fromText(src, modname='mod', system=system)
     assert mod.contents['D'].bases == ['mod.C'], mod.contents['D'].bases
 
 @systemcls_param
@@ -456,7 +465,7 @@ def test_import_from_package(systemcls: Type[model.System]) -> None:
     system.ensurePackage('a')
     mod_a = fromText('''
     def f(): pass
-    ''', modname='a.__init__', system=system)
+    ''', modname='__init__', parent_name='a', system=system)
     mod_b = fromText('''
     from a import f
     ''', modname='b', system=system)

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -459,8 +459,21 @@ def test_import_star(systemcls: Type[model.System]) -> None:
 
 
 @systemcls_param
-def test_import_from_package(systemcls: Type[model.System]) -> None:
-    """Importing from a package should look in __init__ module."""
+def test_import_func_from_package(systemcls: Type[model.System]) -> None:
+    """Importing a function from a package should look in the C{__init__}
+    module.
+
+    In this test the following hierarchy is constructed::
+
+        package a
+          module __init__
+            defines function 'f'
+        module b
+          imports function 'f'
+
+    We verify that when module C{b} imports the name C{f} from package C{a},
+    it imports the function C{f} from the module C{a.__init__}.
+    """
     system = systemcls()
     system.ensurePackage('a')
     mod_a = fromText('''
@@ -474,7 +487,21 @@ def test_import_from_package(systemcls: Type[model.System]) -> None:
 
 @systemcls_param
 def test_import_module_from_package(systemcls: Type[model.System]) -> None:
-    """Importing a module from a package should not look in __init__ module."""
+    """Importing a module from a package should not look in C{__init__}
+    module.
+
+    In this test the following hierarchy is constructed::
+
+        package a
+          module __init__
+          module b
+            defines function 'f'
+        module c
+          imports module 'a.b'
+
+    We verify that when module C{c} imports the name C{b} from package C{a},
+    it imports the module C{a.b} which contains C{f}.
+    """
     system = systemcls()
     system.ensurePackage('a')
     fromText('''

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -450,6 +450,20 @@ def test_import_star(systemcls: Type[model.System]) -> None:
 
 
 @systemcls_param
+def test_import_from_package(systemcls: Type[model.System]) -> None:
+    """Importing from a package should look in __init__ module."""
+    system = systemcls()
+    system.ensurePackage('a')
+    mod_a = fromText('''
+    def f(): pass
+    ''', modname='a.__init__', system=system)
+    mod_b = fromText('''
+    from a import f
+    ''', modname='b', system=system)
+    assert mod_b.resolveName('f') == mod_a.contents['f']
+
+
+@systemcls_param
 def test_inline_docstring_modulevar(systemcls: Type[model.System]) -> None:
     mod = fromText('''
     """regular module docstring

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -66,7 +66,7 @@ def test_implementer() -> None:
     implements_test(src)
 
 def implements_test(src: str) -> None:
-    mod = fromText(src, 'zi', systemcls=ZopeInterfaceSystem)
+    mod = fromText(src, modname='zi', systemcls=ZopeInterfaceSystem)
     ifoo = mod.contents['IFoo']
     ibar = mod.contents['IBar']
     foo = mod.contents['Foo']
@@ -99,7 +99,7 @@ def test_subclass_with_same_name() -> None:
     class A(A):
         pass
     '''
-    fromText(src, 'zi', systemcls=ZopeInterfaceSystem)
+    fromText(src, modname='zi', systemcls=ZopeInterfaceSystem)
 
 def test_multiply_inheriting_interfaces() -> None:
     src = '''
@@ -111,7 +111,7 @@ def test_multiply_inheriting_interfaces() -> None:
     class Two: implements(ITwo)
     class Both(One, Two): pass
     '''
-    mod = fromText(src, 'zi', systemcls=ZopeInterfaceSystem)
+    mod = fromText(src, modname='zi', systemcls=ZopeInterfaceSystem)
     assert len(mod.contents['Both'].allImplementedInterfaces) == 2
 
 def test_attribute(capsys: CapSys) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,11 @@ envlist =
 
 
 [testenv]
-whitelist_externals =
+allowlist_externals =
     git
     rm
+    sh
+    touch
 passenv = *
 
 
@@ -49,6 +51,26 @@ commands =
     twisted-apidoc: git clone --depth 1 --branch trunk https://github.com/twisted/twisted.git {toxworkdir}/twisted-trunk
     twisted-apidoc: /bin/sh -c "{toxworkdir}/twisted-trunk/bin/admin/build-apidocs {toxworkdir}/twisted-trunk/src {toxworkdir}/twisted-apidocs-build > {toxworkdir}/twisted-apidocs.log"
     twisted-apidoc: /bin/cat {toxworkdir}/twisted-apidocs.log
+
+
+[testenv:cpython-apidocs]
+description = Build CPython API documentation
+
+deps =
+    docutils
+
+commands =
+    sh -c "if [ ! -d {toxworkdir}/cpython ]; then \
+        git clone --depth 1 https://github.com/python/cpython.git {toxworkdir}/cpython; \
+        fi"
+    sh -c "cd {toxworkdir}/cpython && git pull"
+    touch {toxworkdir}/cpython/Lib/__init__.py
+    rm -rf {toxworkdir}/cpython-output
+    pydoctor \
+        --docformat=restructuredtext \
+        --project-base-dir={toxworkdir}/cpython \
+        --html-output={toxworkdir}/cpython-output \
+        {toxworkdir}/cpython/Lib
 
 
 [testenv:mypy]

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,28 @@ commands =
         {toxworkdir}/cpython/Lib
 
 
+[testenv:cpython-summary]
+description = Parse CPython code and write a summary only
+
+deps =
+    docutils
+
+commands =
+    sh -c "if [ ! -d {toxworkdir}/cpython ]; then \
+        git clone --depth 1 https://github.com/python/cpython.git {toxworkdir}/cpython; \
+        fi"
+    sh -c "cd {toxworkdir}/cpython && git pull"
+    touch {toxworkdir}/cpython/Lib/__init__.py
+    rm -rf {toxworkdir}/cpython-summary-output
+    # TODO: Switch to restructuredtext when #261 is fixed.
+    pydoctor \
+        --docformat=plaintext \
+        --project-base-dir={toxworkdir}/cpython \
+        --html-output={toxworkdir}/cpython-summary-output \
+        --html-summary-pages \
+        {toxworkdir}/cpython/Lib
+
+
 [testenv:mypy]
 description = run mypy (static type checker)
 


### PR DESCRIPTION
When called with a package name, `getProcessedModule()` would force the `__init__` module to be processed, but then returned the `Package` object instead of the `Module` object. This is contrary to what its name suggests and what `visit_ImportFrom()` expects.

I also added type annotations to narrow down the place where the wrong type originated.

The purpose of this PR is to fix the bug described in #259.