### PR TITLE
CSS: Add visual contrast between fields and members

### DIFF
--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -198,7 +198,7 @@ code > .code {
     border-left-color: #03a9f4;
     border-left-width: 1px;
     border-left-style: solid;
-    background: #f6f6f6;
+    background: #fafafa;
 }
 
 #childList > div .functionHeader {

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -142,6 +142,15 @@ tr.private {
     margin-top: 10px;
 }
 
+.fieldArg {
+    font-weight: bold;
+    color: #c7254e;
+}
+
+.fieldName {
+    font-weight: bold;
+}
+
 
 #childList > div {
     margin: 20px;
@@ -185,15 +194,17 @@ code > .code {
     padding: 0px;
 }
 
-
 #childList > div {
     border-left-color: #03a9f4;
     border-left-width: 1px;
     border-left-style: solid;
+    background: #f6f6f6;
 }
 
 #childList > div .functionHeader {
     font-family: monospace;
+    font-weight: bold;
+    color: #c7254e;
 }
 
 .moduleDocstring {


### PR DESCRIPTION
Closes #260 

It looks like  this now 

<img width="901" alt="by default 2020-11-06 at 12 48 58 AM" src="https://user-images.githubusercontent.com/19967168/98331114-dc4f3c80-1fc9-11eb-8c94-c20761e9b302.png">


