### PR TITLE
Use sticky top bar as navigation bar

### DIFF
--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -67,11 +67,9 @@ class Documentable:
     @ivar parent: ...
     @ivar parentMod: ...
     @ivar name: ...
-    @ivar documentation_location: ...
     @ivar sourceHref: ...
     @ivar kind: ...
     """
-    documentation_location = DocLocation.OWN_PAGE
     docstring: Optional[str] = None
     system: 'System'
     parsed_docstring: Optional[ParsedDocstring] = None
@@ -79,6 +77,13 @@ class Documentable:
     linenumber = 0
     sourceHref: Optional[str] = None
     kind: str
+
+    @property
+    def documentation_location(self) -> DocLocation:
+        """Page location where we are documented.
+        The default implementation returns L{DocLocation.OWN_PAGE}.
+        """
+        return DocLocation.OWN_PAGE
 
     @property
     def css_class(self):
@@ -341,6 +346,13 @@ class Module(CanContainImportsDocumentable):
     kind = "Module"
     state = ProcessingState.UNPROCESSED
 
+    @property
+    def documentation_location(self) -> DocLocation:
+        if self.name == '__init__':
+            return DocLocation.PARENT_PAGE
+        else:
+            return DocLocation.OWN_PAGE
+
     def setup(self):
         super().setup()
         self.all = None
@@ -385,7 +397,10 @@ class Class(CanContainImportsDocumentable):
 
 
 class Inheritable(Documentable):
-    documentation_location = DocLocation.PARENT_PAGE
+
+    @property
+    def documentation_location(self) -> DocLocation:
+        return DocLocation.PARENT_PAGE
 
     def docsources(self):
         yield self

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -8,7 +8,10 @@
     top: 0;
     background-color: #fff;
 }
-
+.page-header h1 {
+    overflow: hidden;
+    max-height: 44px;
+}
 
 ul {
     margin-top: 10px;

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -4,6 +4,9 @@
 
 .page-header {
     margin-top: 22px;
+    position: sticky;
+    top: 0;
+    background-color: #fff;
 }
 
 

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -7,11 +7,18 @@
     position: sticky;
     top: 0;
     background-color: #fff;
+    padding-bottom: 12px;
+    margin-bottom: 0;
+    border-bottom: 0;
 }
 .page-header h1 {
-    overflow: visible hidden;
-    min-width: min-content;
-    max-height: 44px;
+    margin-bottom: 0;
+}
+
+.categoryHeader {
+    font-size: 24px;
+    color: #777;
+    margin-bottom: 1.8em;
 }
 
 ul {

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -7,9 +7,9 @@
     position: sticky;
     top: 0;
     background-color: #fff;
-    padding-bottom: 12px;
-    margin-bottom: 0;
+    margin-bottom: 3px;
     border-bottom: 0;
+    box-shadow: 0px 0px 8px 8px #fff;
 }
 .page-header h1 {
     margin-bottom: 0;

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -9,7 +9,8 @@
     background-color: #fff;
 }
 .page-header h1 {
-    overflow: hidden;
+    overflow: visible hidden;
+    min-width: min-content;
     max-height: 44px;
 }
 

--- a/pydoctor/templates/common.html
+++ b/pydoctor/templates/common.html
@@ -27,18 +27,13 @@
 
       <div class="page-header">
         <t:slot name="heading"><h1>Heading</h1></t:slot>
-
-        <span id="partOf">
-          <t:slot name="part">Part of something</t:slot>
-          <a t:render="source">View Source</a>
-          <a t:render="inhierarchy">(View In Hierarchy)</a>
-        </span>
       </div>
 
       <div class="extrasDocstring">
         <t:slot name="extras">
-          A docstring.
+          Inheritance info.
         </t:slot>
+        <p><a t:render="inhierarchy">View In Hierarchy</a></p>
       </div>
 
       <div class="moduleDocstring">

--- a/pydoctor/templates/common.html
+++ b/pydoctor/templates/common.html
@@ -29,6 +29,10 @@
         <t:slot name="heading"><h1>Heading</h1></t:slot>
       </div>
 
+      <div class="categoryHeader">
+        <t:slot name="category">something documentation</t:slot>
+      </div>
+
       <div class="extrasDocstring">
         <t:slot name="extras">
           Inheritance info.

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -204,7 +204,7 @@ class ModulePage(CommonPage):
 
         sourceHref = util.srclink(self.ob)
         if sourceHref:
-            r.append(tags.a("View Source", href=sourceHref))
+            r.append(tags.a("(source)", href=sourceHref))
 
         return r
 

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -82,9 +82,11 @@ class CommonPage(Element):
 
     def heading(self):
         return tags.h1(class_=self.ob.css_class)(
-            tags.code(self.namespace(self.ob)), " ",
-            tags.small(self.ob.kind.lower(), " documentation"),
+            tags.code(self.namespace(self.ob))
             )
+
+    def category(self) -> str:
+        return f"{self.ob.kind.lower()} documentation"
 
     def namespace(self, obj: model.Documentable) -> List[Union[Tag, str]]:
         parts: List[Union[Tag, str]] = []
@@ -184,6 +186,7 @@ class CommonPage(Element):
         return tag.fillSlots(
             title=self.title(),
             heading=self.heading(),
+            category=self.category(),
             part=self.part(),
             extras=self.extras(),
             docstring=self.docstring(),

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -90,13 +90,11 @@ class CommonPage(Element):
         parts: List[Union[Tag, str]] = []
         ob: Optional[model.Documentable] = obj
         while ob:
-            if parts:
-                parts.append('.')
-            parts.append(util.taglink(ob, ob.name))
+            if ob.documentation_location is model.DocLocation.OWN_PAGE:
+                if parts:
+                    parts.append('.')
+                parts.append(util.taglink(ob, ob.name))
             ob = ob.parent
-            if isinstance(ob, model.Module) and ob.name == '__init__':
-                # The __init__ module is documented on the package page.
-                ob = ob.parent
         parts.reverse()
         return parts
 

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -8,7 +8,7 @@ from twisted.python.filepath import FilePath
 from twisted.web.template import Tag, tags
 
 
-def srclink(o):
+def srclink(o: model.Documentable) -> Optional[str]:
     return o.sourceHref
 
 def templatefile(filename):

--- a/pydoctor/templatewriter/writer.py
+++ b/pydoctor/templatewriter/writer.py
@@ -59,8 +59,7 @@ class TemplateWriter:
     def writeDocsFor(self, ob, functionpages):
         if not ob.isVisible:
             return
-        isfunc = ob.documentation_location is model.DocLocation.PARENT_PAGE
-        if (isfunc and functionpages) or not isfunc:
+        if functionpages or ob.documentation_location is model.DocLocation.OWN_PAGE:
             if self.dry_run:
                 self.total_pages += 1
             else:


### PR DESCRIPTION
This moves some information elements out of the top bar, so a minimal top bar is left that we can then make sticky. This allows for quick navigation up the hierarchy.