### PR TITLE
Move anchors up to compensate for sticky navbar

### DIFF
--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -23,7 +23,7 @@
 
 a[name] {
     position: relative;
-    bottom: 70px;
+    bottom: 62px;
 }
 
 ul {

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -21,6 +21,14 @@
     margin-bottom: 1.8em;
 }
 
+a[name] {
+    position: relative;
+    bottom: 70px;
+}
+a[name]:before {
+    content: "";
+}
+
 ul {
     margin-top: 10px;
     padding-left: 10px;

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -25,9 +25,6 @@ a[name] {
     position: relative;
     bottom: 70px;
 }
-a[name]:before {
-    content: "";
-}
 
 ul {
     margin-top: 10px;


### PR DESCRIPTION
When navigating to an anchor, browsers will typically put it at the top of the page, but they don't take the sticky navbar into account, so the thing the user was looking for ends up covered by the navbar.

Since anchors are invisible, we can move their location without problems. However, they don't have an actual location by default. But if we provide invisible content, they do, and the trick works.

Fixes #270.