### PR TITLE
Convert --project-base-dir argument to absolute path

### DIFF
--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -55,10 +55,12 @@ MAKE_HTML_DEFAULT = object()
 
 def parse_path(option: Option, opt: str, value: str) -> Path:
     """Parse a path value given to an option to a L{Path} object.
-    The path is not verified: it is only parsed.
+    The path is converted to an absolute path, as required by
+    L{System.setSourceHref()}.
+    The path does not need to exist.
     """
     try:
-        return Path(value)
+        return Path(value).resolve()
     except Exception as ex:
         raise OptionValueError(f"{opt}: invalid path: {ex}")
 

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -60,7 +60,10 @@ def parse_path(option: Option, opt: str, value: str) -> Path:
     The path does not need to exist.
     """
     try:
-        return Path(value).resolve()
+        # We explicitly make the path relative to the current working dir
+        # because on Windows resolve() does not produce an absolute path
+        # when operating on a non-existing path.
+        return Path(Path.cwd(), value).resolve()
     except Exception as ex:
         raise OptionValueError(f"{opt}: invalid path: {ex}")
 

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -1,6 +1,7 @@
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
+import os
 import sys
 
 from pydoctor import driver
@@ -54,7 +55,10 @@ def test_projectbasedir() -> None:
     on the options object, as an absolute path.
     """
 
-    absolute = "/home/name/src/project"
+    if os.name == 'nt':
+        absolute = r"C:\Users\name\src\project"
+    else:
+        absolute = "/home/name/src/project"
     options, args = driver.parse_args(["--project-base-dir", absolute])
     assert str(options.projectbasedirectory) == absolute
 

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -1,5 +1,6 @@
 from contextlib import redirect_stdout
 from io import StringIO
+from pathlib import Path
 import sys
 
 from pydoctor import driver
@@ -50,12 +51,18 @@ def test_invalid_systemclasses() -> None:
 def test_projectbasedir() -> None:
     """
     The --project-base-dir option should set the projectbasedirectory attribute
-    on the options object.
+    on the options object, as an absolute path.
     """
-    value = "projbasedirvalue"
-    options, args = driver.parse_args([
-            "--project-base-dir", value])
-    assert str(options.projectbasedirectory) == value
+
+    absolute = "/home/name/src/project"
+    options, args = driver.parse_args(["--project-base-dir", absolute])
+    assert str(options.projectbasedirectory) == absolute
+
+    relative = "projbasedirvalue"
+    options, args = driver.parse_args(["--project-base-dir", relative])
+    assert options.projectbasedirectory.is_absolute()
+    assert options.projectbasedirectory.name == relative
+    assert options.projectbasedirectory.parent == Path.cwd()
 
 
 def test_cache_disabled_by_default() -> None:

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -49,12 +49,11 @@ def test_invalid_systemclasses() -> None:
     assert 'is not a subclass' in err
 
 
-def test_projectbasedir() -> None:
+def test_projectbasedir_absolute() -> None:
     """
-    The --project-base-dir option should set the projectbasedirectory attribute
-    on the options object, as an absolute path.
+    The --project-base-dir option, when given an absolute path, should set that
+    path as the projectbasedirectory attribute on the options object.
     """
-
     if os.name == 'nt':
         absolute = r"C:\Users\name\src\project"
     else:
@@ -62,6 +61,13 @@ def test_projectbasedir() -> None:
     options, args = driver.parse_args(["--project-base-dir", absolute])
     assert str(options.projectbasedirectory) == absolute
 
+
+def test_projectbasedir_relative() -> None:
+    """
+    The --project-base-dir option, when given a relative path, should convert
+    that path to absolute and set it as the projectbasedirectory attribute on
+    the options object.
+    """
     relative = "projbasedirvalue"
     options, args = driver.parse_args(["--project-base-dir", relative])
     assert options.projectbasedirectory.is_absolute()


### PR DESCRIPTION
The `Path.relative_to()` method used in `System.setSourceHref()` will only work on absolute paths.

This fixes a crash when passing for example `--project-base-dir .` or `--project-base-dir src`.
