### PR TITLE
Handle cyclic imports better

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -209,14 +209,6 @@ class ModuleVistor(ast.NodeVisitor):
         is_package = isinstance(obj, model.Package)
         assert is_package or obj is mod or mod is None
 
-        if mod is not None and mod.state is model.ProcessingState.PROCESSED:
-            assert obj is not None
-            expandName = obj.expandName
-        else:
-            # Module information is absent or incomplete;
-            # treat it as a black box.
-            expandName = lambda name: f'{modname}.{name}'
-
         # Fetch names to export.
         current = self.builder.current
         if isinstance(current, model.Module):
@@ -254,7 +246,7 @@ class ModuleVistor(ast.NodeVisitor):
             if is_package:
                 self.system.getProcessedModule(f'{modname}.{orgname}')
 
-            _localNameToFullName[asname] = expandName(orgname)
+            _localNameToFullName[asname] = f'{modname}.{orgname}'
 
     def visit_Import(self, node):
         """Process an import statement.

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -209,9 +209,12 @@ class ModuleVistor(ast.NodeVisitor):
         is_package = isinstance(obj, model.Package)
         assert is_package or obj is mod or mod is None
 
-        if obj is not None:
+        if mod is not None and mod.state is model.ProcessingState.PROCESSED:
+            assert obj is not None
             expandName = obj.expandName
         else:
+            # Module information is absent or incomplete;
+            # treat it as a black box.
             expandName = lambda name: f'{modname}.{name}'
 
         # Fetch names to export.

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -253,7 +253,15 @@ def test_aliasing(systemcls: Type[model.System]) -> None:
     addsrc(system)
     C = system.allobjects['c.C']
     assert isinstance(C, model.Class)
-    assert C.bases == ['a.A']
+    # An older version of this test expected a.A as the result.
+    # The expected behavior was changed because:
+    # - relying on on-demand processing of other modules is unreliable when
+    #   there are cyclic imports: expandName() on a module that is still being
+    #   processed can return the not-found result for a name that does exist
+    # - code should be importing names from their official home, so if we
+    #   import b.B then for the purposes of documentation b.B is the name
+    #   we should use
+    assert C.bases == ['b.B']
 
 @systemcls_param
 def test_more_aliasing(systemcls: Type[model.System]) -> None:
@@ -282,7 +290,9 @@ def test_more_aliasing(systemcls: Type[model.System]) -> None:
     addsrc(system)
     D = system.allobjects['d.D']
     assert isinstance(D, model.Class)
-    assert D.bases == ['a.A']
+    # An older version of this test expected a.A as the result.
+    # Read the comment in test_aliasing() to learn why this was changed.
+    assert D.bases == ['c.C']
 
 @systemcls_param
 def test_aliasing_recursion(systemcls: Type[model.System]) -> None:

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -70,3 +70,10 @@ def test_allgames() -> None:
     assert moved.parentMod is mod2
     assert moved.parentMod.source_path is not None
     assert moved.parentMod.source_path.parts[-2:] == ('allgames', 'mod2.py')
+
+def test_cyclic_imports() -> None:
+    system = processPackage('cyclic_imports')
+    mod_a = system.allobjects['cyclic_imports.a']
+    assert mod_a.expandName('B') == 'cyclic_imports.b.B'
+    mod_b = system.allobjects['cyclic_imports.b']
+    assert mod_b.expandName('A') == 'cyclic_imports.a.A'

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -72,6 +72,14 @@ def test_allgames() -> None:
     assert moved.parentMod.source_path.parts[-2:] == ('allgames', 'mod2.py')
 
 def test_cyclic_imports() -> None:
+    """
+    Test whether names are resolved correctly when we have import cycles.
+    The test package contains module 'a' that defines class 'A' and module 'b'
+    that defines class 'B'; each module imports the other. Since the test data
+    is symmetrical, we will at some point be importing a module that has not
+    been fully processed yet, no matter which module gets processed first.
+    """
+
     system = processPackage('cyclic_imports')
     mod_a = system.allobjects['cyclic_imports.a']
     assert mod_a.expandName('B') == 'cyclic_imports.b.B'

--- a/pydoctor/test/testpackages/cyclic_imports/a.py
+++ b/pydoctor/test/testpackages/cyclic_imports/a.py
@@ -1,0 +1,4 @@
+from .b import B
+
+class A:
+    b: B

--- a/pydoctor/test/testpackages/cyclic_imports/b.py
+++ b/pydoctor/test/testpackages/cyclic_imports/b.py
@@ -1,0 +1,4 @@
+from .a import A
+
+class B:
+    a: A


### PR DESCRIPTION
When working on adding hyperlinks to presented annotations (#268), I noticed that several names did not become links. After some debugging, it turned out that because of circular imports, the module being imported from (`apetest.report`) wasn't fully processed yet, which led to `expandName('Report')` returning just `'Report'` instead of `apetest.report.Report` (the full name).

I wrote a fix for this particular case, which is in the first commit. It checks whether the module being imported from is already processed, and if not, it will synthesize the full name by combining the module name and the imported name (`apetest.report` and `Report`) instead of using the `expandName()` method.

While this fix works, I don't like it: in this case, the synthetic name is the same as the name we would get if the module had already been processed, but in some projects that might not always be the case. In that situation, the output that pydoctor produces can be different depending on the order in which modules are processed, which is unpredictable and can vary between runs (maybe because of the VM's hash seed, maybe because of the underlying file system).

So in the second commit, I removed the use of the `expandName()` method from the `from <somewhere> import <names>` parsing in the `_importNames()` method altogether. This means we always use the synthetic names, which makes the behavior simple and consistent. It does change the behavior of pydoctor when processing chains of aliases though, so I had to update the expected output in two test cases. I don't think this is a problem, as explained in that second commit:

> Another motivation for removing the feature is that I have some doubt about its usefulness: importing a name that is itself imported from another module is bad practice, except when the name is explicitly re-exported via `__all__`. But in the case of a re-export, the documentation will be using the re-export location, so we don't need to trace it back to the original implementation location.

We can go one step further after this simplification and also move the re-exporting code out of the `_importNames()` method and instead only record re-exported names there and then do the reparenting as a separate step after all modules have been processed. That would simplify the implementation of `_importNames()` considerably and it would remove the need for triggering additional module processing via `getProcessedModule()` from there.

Since this is complex behavior, I didn't want to do too much in this PR though, so I stuck to the changes that we need to be able to reliably hyperlink names in annotations.
