### PR TITLE
Annotation presentation

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+
+[report]
+exclude_lines =
+    # Intended to be unreachable:
+    raise NotImplementedError$
+    raise NotImplementedError\(

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -649,7 +649,6 @@ def _annotation_for_value(value: object) -> Optional[ast.expr]:
         return None
     name = type(value).__name__
     if isinstance(value, (dict, list, set, tuple)):
-        name = name.capitalize()
         ann_elem = _annotation_for_elements(value)
         if isinstance(value, dict):
             ann_value = _annotation_for_elements(value.values())
@@ -658,7 +657,7 @@ def _annotation_for_value(value: object) -> Optional[ast.expr]:
             elif ann_elem is not None:
                 ann_elem = ast.Tuple(elts=[ann_elem, ann_value])
         if ann_elem is not None:
-            if name == 'Tuple':
+            if name == 'tuple':
                 ann_elem = ast.Tuple(elts=[ann_elem, ast.Ellipsis()])
             return ast.Subscript(value=ast.Name(id=name),
                                  slice=ast.Index(value=ann_elem))

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -609,14 +609,14 @@ class _AnnotationStringParser(ast.NodeTransformer):
         else:
             # Other subscript; unstring the slice.
             slice = self.visit(node.slice)
-        return ast.Subscript(value, slice, node.ctx)
+        return ast.copy_location(ast.Subscript(value, slice, node.ctx), node)
 
     # For Python >= 3.8:
 
     def visit_Constant(self, node: ast.Constant) -> ast.expr:
         value = node.value
         if isinstance(value, str):
-            return self._parse_string(value)
+            return ast.copy_location(self._parse_string(value), node)
         else:
             const = self.generic_visit(node)
             assert isinstance(const, ast.Constant), const
@@ -625,7 +625,7 @@ class _AnnotationStringParser(ast.NodeTransformer):
     # For Python < 3.8:
 
     def visit_Str(self, node: ast.Str) -> ast.expr:
-        return self._parse_string(node.s)
+        return ast.copy_location(self._parse_string(node.s), node)
 
 def _infer_type(expr: ast.expr) -> Optional[ast.expr]:
     """Infer an expression's type.

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -638,7 +638,11 @@ def _infer_type(expr: ast.expr) -> Optional[ast.expr]:
     except ValueError:
         return None
     else:
-        return _annotation_for_value(value)
+        ann = _annotation_for_value(value)
+        if ann is None:
+            return None
+        else:
+            return ast.fix_missing_locations(ast.copy_location(ann, expr))
 
 def _annotation_for_value(value: object) -> Optional[ast.expr]:
     if value is None:

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -500,7 +500,10 @@ class ModuleVistor(ast.NodeVisitor):
         self.default(node)
         self.builder.popFunction()
 
-    def _annotation_from_attrib(self, expr, ctx):
+    def _annotation_from_attrib(self,
+            expr: ast.expr,
+            ctx: model.Documentable
+            ) -> Optional[ast.expr]:
         """Get the type of an C{attr.ib} definition.
         @param expr: The expression's AST.
         @param ctx: The context in which this expression is evaluated.
@@ -624,7 +627,7 @@ class _AnnotationStringParser(ast.NodeTransformer):
     def visit_Str(self, node: ast.Str) -> ast.expr:
         return self._parse_string(node.s)
 
-def _infer_type(expr):
+def _infer_type(expr: ast.expr) -> Optional[ast.expr]:
     """Infer an expression's type.
     @param expr: The expression's AST.
     @return: A type annotation, or None if the expression has no obvious type.
@@ -637,7 +640,7 @@ def _infer_type(expr):
     else:
         return _annotation_for_value(value)
 
-def _annotation_for_value(value):
+def _annotation_for_value(value: object) -> Optional[ast.expr]:
     if value is None:
         return None
     name = type(value).__name__
@@ -657,7 +660,7 @@ def _annotation_for_value(value):
                                  slice=ast.Index(value=ann_elem))
     return ast.Name(id=name)
 
-def _annotation_for_elements(sequence):
+def _annotation_for_elements(sequence: Iterable[object]) -> Optional[ast.expr]:
     names = set()
     for elem in sequence:
         ann = _annotation_for_value(elem)

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -184,9 +184,22 @@ class DocstringLinker:
     target URL for crossreference links.
     """
 
+    def resolve_identifier(self, identifier: str) -> Optional[str]:
+        """
+        Resolve a Python identifier.
+        This will resolve the identifier like Python itself would.
+
+        @param identifier: The name of the Python identifier that
+            should be linked to.
+        @return: The URL of the target, or L{None} if not found.
+        """
+        raise NotImplementedError()
+
     def resolve_identifier_xref(self, identifier: str, lineno: int) -> str:
         """
         Resolve a crossreference link to a Python identifier.
+        This will resolve the identifier to any reasonable target,
+        even if it has to look in places where Python itself would not.
 
         @param identifier: The name of the Python identifier that
             should be linked to.

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -1017,9 +1017,7 @@ def test_inferred_variable_types(systemcls: Type[model.System]) -> None:
     assert type2str(C.contents['d'].annotation) == 'Dict[str, int]'
     assert type2str(C.contents['e'].annotation) == 'Tuple[bool, ...]'
     assert type2str(C.contents['f'].annotation) == 'float'
-    # The Python 2.7 implementation of literal_eval() does not support
-    # set literals.
-    assert type2str(C.contents['g'].annotation) in ('Set[int]', None)
+    assert type2str(C.contents['g'].annotation) == 'Set[int]'
     # Element type is unknown, not uniform or too complex.
     assert type2str(C.contents['h'].annotation) == 'List'
     assert type2str(C.contents['i'].annotation) == 'List'
@@ -1036,9 +1034,7 @@ def test_inferred_variable_types(systemcls: Type[model.System]) -> None:
     assert type2str(C.contents['s'].annotation) == 'List[str]'
     # Check that type is inferred on assignments with multiple targets.
     assert type2str(C.contents['t'].annotation) == 'str'
-    # On Python 2.7, bytes literals are parsed into ast.Str objects,
-    # so there is no way to tell them apart from ASCII strings.
-    assert type2str(mod.contents['m'].annotation) in ('bytes', 'str')
+    assert type2str(mod.contents['m'].annotation) == 'bytes'
 
 @systemcls_param
 def test_type_from_attrib(systemcls: Type[model.System]) -> None:

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -964,13 +964,13 @@ def test_annotated_variables(systemcls: Type[model.System]) -> None:
 @systemcls_param
 def test_type_comment(systemcls: Type[model.System], capsys: CapSys) -> None:
     mod = fromText('''
-    d = {} # type: Dict[str, int]
+    d = {} # type: dict[str, int]
     i = [] # type: ignore[misc]
     ''', systemcls=systemcls)
-    assert type2str(mod.contents['d'].annotation) == 'Dict[str, int]'
+    assert type2str(mod.contents['d'].annotation) == 'dict[str, int]'
     # We don't use ignore comments for anything at the moment,
     # but do verify that their presence doesn't break things.
-    assert type2str(mod.contents['i'].annotation) == 'List'
+    assert type2str(mod.contents['i'].annotation) == 'list'
     assert not capsys.readouterr().out
 
 @systemcls_param
@@ -1038,15 +1038,15 @@ def test_inferred_variable_types(systemcls: Type[model.System]) -> None:
     C = mod.contents['C']
     assert str_and_line(C.contents['a']) == ('str', 3)
     assert str_and_line(C.contents['b']) == ('int', 4)
-    assert str_and_line(C.contents['c']) == ('List[str]', 5)
-    assert str_and_line(C.contents['d']) == ('Dict[str, int]', 6)
-    assert str_and_line(C.contents['e']) == ('Tuple[bool, ...]', 7)
+    assert str_and_line(C.contents['c']) == ('list[str]', 5)
+    assert str_and_line(C.contents['d']) == ('dict[str, int]', 6)
+    assert str_and_line(C.contents['e']) == ('tuple[bool, ...]', 7)
     assert str_and_line(C.contents['f']) == ('float', 8)
-    assert str_and_line(C.contents['g']) == ('Set[int]', 9)
+    assert str_and_line(C.contents['g']) == ('set[int]', 9)
     # Element type is unknown, not uniform or too complex.
-    assert str_and_line(C.contents['h']) == ('List', 10)
-    assert str_and_line(C.contents['i']) == ('List', 11)
-    assert str_and_line(C.contents['j']) == ('Tuple', 12)
+    assert str_and_line(C.contents['h']) == ('list', 10)
+    assert str_and_line(C.contents['i']) == ('list', 11)
+    assert str_and_line(C.contents['j']) == ('tuple', 12)
     # It is unlikely that a variable actually will contain only None,
     # so we should treat this as not be able to infer the type.
     assert C.contents['n'].annotation is None
@@ -1056,7 +1056,7 @@ def test_inferred_variable_types(systemcls: Type[model.System]) -> None:
     assert C.contents['y'].annotation is None
     # Type inference isn't different for module and instance variables,
     # so we don't need to re-test everything.
-    assert str_and_line(C.contents['s']) == ('List[str]', 17)
+    assert str_and_line(C.contents['s']) == ('list[str]', 17)
     # Check that type is inferred on assignments with multiple targets.
     assert str_and_line(C.contents['t']) == ('str', 18)
     assert str_and_line(mod.contents['m']) == ('bytes', 19)

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -97,7 +97,11 @@ def type2str(type_expr: Optional[ast.expr]) -> Optional[str]:
         assert isinstance(src, str)
         return src.strip()
 
-def str_and_line(obj: model.Documentable) -> Tuple[str, int]:
+def ann_str_and_line(obj: model.Documentable) -> Tuple[str, int]:
+    """Return the textual representation and line number of an object's
+    type annotation.
+    @param obj: Documentable object with a type annotation.
+    """
     ann = obj.annotation # type: ignore[attr-defined]
     assert ann is not None
     return type2str(ann), ann.lineno
@@ -992,9 +996,9 @@ def test_unstring_annotation(systemcls: Type[model.System]) -> None:
     b: 'str' = 'B'
     c: list["Thingy"]
     ''', systemcls=systemcls)
-    assert str_and_line(mod.contents['a']) == ('int', 2)
-    assert str_and_line(mod.contents['b']) == ('str', 3)
-    assert str_and_line(mod.contents['c']) == ('list[Thingy]', 4)
+    assert ann_str_and_line(mod.contents['a']) == ('int', 2)
+    assert ann_str_and_line(mod.contents['b']) == ('str', 3)
+    assert ann_str_and_line(mod.contents['c']) == ('list[Thingy]', 4)
 
 @pytest.mark.parametrize('annotation', ("[", "pass", "1 ; 2"))
 @systemcls_param
@@ -1045,17 +1049,17 @@ def test_inferred_variable_types(systemcls: Type[model.System]) -> None:
     m = b'octets'
     ''', modname='test', systemcls=systemcls)
     C = mod.contents['C']
-    assert str_and_line(C.contents['a']) == ('str', 3)
-    assert str_and_line(C.contents['b']) == ('int', 4)
-    assert str_and_line(C.contents['c']) == ('list[str]', 5)
-    assert str_and_line(C.contents['d']) == ('dict[str, int]', 6)
-    assert str_and_line(C.contents['e']) == ('tuple[bool, ...]', 7)
-    assert str_and_line(C.contents['f']) == ('float', 8)
-    assert str_and_line(C.contents['g']) == ('set[int]', 9)
+    assert ann_str_and_line(C.contents['a']) == ('str', 3)
+    assert ann_str_and_line(C.contents['b']) == ('int', 4)
+    assert ann_str_and_line(C.contents['c']) == ('list[str]', 5)
+    assert ann_str_and_line(C.contents['d']) == ('dict[str, int]', 6)
+    assert ann_str_and_line(C.contents['e']) == ('tuple[bool, ...]', 7)
+    assert ann_str_and_line(C.contents['f']) == ('float', 8)
+    assert ann_str_and_line(C.contents['g']) == ('set[int]', 9)
     # Element type is unknown, not uniform or too complex.
-    assert str_and_line(C.contents['h']) == ('list', 10)
-    assert str_and_line(C.contents['i']) == ('list', 11)
-    assert str_and_line(C.contents['j']) == ('tuple', 12)
+    assert ann_str_and_line(C.contents['h']) == ('list', 10)
+    assert ann_str_and_line(C.contents['i']) == ('list', 11)
+    assert ann_str_and_line(C.contents['j']) == ('tuple', 12)
     # It is unlikely that a variable actually will contain only None,
     # so we should treat this as not be able to infer the type.
     assert C.contents['n'].annotation is None
@@ -1065,10 +1069,10 @@ def test_inferred_variable_types(systemcls: Type[model.System]) -> None:
     assert C.contents['y'].annotation is None
     # Type inference isn't different for module and instance variables,
     # so we don't need to re-test everything.
-    assert str_and_line(C.contents['s']) == ('list[str]', 17)
+    assert ann_str_and_line(C.contents['s']) == ('list[str]', 17)
     # Check that type is inferred on assignments with multiple targets.
-    assert str_and_line(C.contents['t']) == ('str', 18)
-    assert str_and_line(mod.contents['m']) == ('bytes', 19)
+    assert ann_str_and_line(C.contents['t']) == ('str', 18)
+    assert ann_str_and_line(mod.contents['m']) == ('bytes', 19)
 
 @systemcls_param
 def test_type_from_attrib(systemcls: Type[model.System]) -> None:

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -973,6 +973,20 @@ def test_type_comment(systemcls: Type[model.System], capsys: CapSys) -> None:
     assert type2str(mod.contents['i'].annotation) == 'List'
     assert not capsys.readouterr().out
 
+@systemcls_param
+def test_unstring_annotation(systemcls: Type[model.System]) -> None:
+    """Annotations or parts thereof that are strings are parsed and
+    line number information is preserved.
+    """
+    mod = fromText('''
+    a: "int"
+    b: 'str' = 'B'
+    c: list["Thingy"]
+    ''', systemcls=systemcls)
+    assert str_and_line(mod.contents['a']) == ('int', 2)
+    assert str_and_line(mod.contents['b']) == ('str', 3)
+    assert str_and_line(mod.contents['c']) == ('list[Thingy]', 4)
+
 @pytest.mark.parametrize('annotation', ("[", "pass", "1 ; 2"))
 @systemcls_param
 def test_bad_string_annotation(

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -7,7 +7,7 @@ import astor
 from twisted.python._pydoctor import TwistedSystem
 
 from pydoctor import astbuilder, model
-from pydoctor.epydoc.markup import ParsedDocstring, flatten
+from pydoctor.epydoc.markup import DocstringLinker, ParsedDocstring, flatten
 from pydoctor.epydoc.markup.epytext import ParsedEpytextDocstring
 from pydoctor.epydoc2stan import get_parsed_type
 from pydoctor.zopeinterface import ZopeInterfaceSystem
@@ -71,8 +71,17 @@ def unwrap(parsed_docstring: ParsedEpytextDocstring) -> str:
     assert isinstance(value, str)
     return value
 
+class NotFoundLinker(DocstringLinker):
+    """A DocstringLinker implementation that cannot find any links."""
+
+    def resolve_identifier(self, identifier: str) -> Optional[str]:
+        return None
+
+    def resolve_identifier_xref(self, identifier: str, lineno: int) -> str:
+        raise LookupError(identifier)
+
 def to_html(parsed_docstring: ParsedDocstring) -> str:
-    return flatten(parsed_docstring.to_stan(None))
+    return flatten(parsed_docstring.to_stan(NotFoundLinker()))
 
 @overload
 def type2str(type_expr: None) -> None: ...

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -314,9 +314,11 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_absolute_id() -> None:
     target = model.Module(system, 'ignore-name')
     sut = epydoc2stan._EpydocLinker(target)
 
-    url = sut.resolve_identifier_xref('base.module.other', 0)
+    url = sut.resolve_identifier('base.module.other')
+    url_xref = sut.resolve_identifier_xref('base.module.other', 0)
 
     assert "http://tm.tld/some.html" == url
+    assert "http://tm.tld/some.html" == url_xref
 
 
 def test_EpydocLinker_resolve_identifier_xref_intersphinx_relative_id() -> None:
@@ -338,9 +340,11 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_relative_id() -> None:
     sut = epydoc2stan._EpydocLinker(target)
 
     # This is called for the L{ext_module<Pretty Text>} markup.
-    url = sut.resolve_identifier_xref('ext_module', 0)
+    url = sut.resolve_identifier('ext_module')
+    url_xref = sut.resolve_identifier_xref('ext_module', 0)
 
     assert "http://tm.tld/some.html" == url
+    assert "http://tm.tld/some.html" == url_xref
 
 
 def test_EpydocLinker_resolve_identifier_xref_intersphinx_link_not_found(capsys: CapSys) -> None:
@@ -360,6 +364,8 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_link_not_found(capsys:
     sut = epydoc2stan._EpydocLinker(target)
 
     # This is called for the L{ext_module} markup.
+    assert sut.resolve_identifier('ext_module') is None
+    assert not capsys.readouterr().out
     with raises(LookupError):
         sut.resolve_identifier_xref('ext_module', 0)
 
@@ -395,9 +401,11 @@ def test_EpydocLinker_resolve_identifier_xref_order(capsys: CapSys) -> None:
     mod.system.intersphinx = cast(SphinxInventory, InMemoryInventory())
     linker = epydoc2stan._EpydocLinker(mod)
 
-    url = linker.resolve_identifier_xref('socket.socket', 0)
+    url = linker.resolve_identifier('socket.socket')
+    url_xref = linker.resolve_identifier_xref('socket.socket', 0)
 
     assert 'https://docs.python.org/3/library/socket.html#socket.socket' == url
+    assert 'https://docs.python.org/3/library/socket.html#socket.socket' == url_xref
     assert not capsys.readouterr().out
 
 

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -409,6 +409,27 @@ def test_EpydocLinker_resolve_identifier_xref_order(capsys: CapSys) -> None:
     assert not capsys.readouterr().out
 
 
+def test_EpydocLinker_resolve_identifier_xref_internal_full_name() -> None:
+    """Link to an internal object referenced by its full name."""
+
+    # Object we want to link to.
+    int_mod = fromText('''
+    class C:
+        pass
+    ''', modname='internal_module')
+    system = int_mod.system
+
+    # Dummy module that we want to link from.
+    target = model.Module(system, 'ignore-name')
+    sut = epydoc2stan._EpydocLinker(target)
+
+    url = sut.resolve_identifier('internal_module.C')
+    url_xref = sut.resolve_identifier_xref('internal_module.C', 0)
+
+    assert "internal_module.C.html" == url
+    assert "internal_module.C.html" == url_xref
+
+
 def test_xref_not_found_epytext(capsys: CapSys) -> None:
     """
     When a link in an epytext docstring cannot be resolved, the reference


### PR DESCRIPTION
Until now, annotations were presented in the output as plain text. This PR changes that by processing the AST for the annotation and linking type names to their internal or external documentation.

This addresses one of the two use cases requested in #268.

The line number preservation changes aren't strictly necessary, since we don't actually report errors when presenting annotations, but having line number information for annotations might be useful in the future.
