### PR TITLE
Tweak coverage exclusions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,14 @@ exclude_lines =
     # Intended to be unreachable:
     raise NotImplementedError$
     raise NotImplementedError\(
+    raise AssertionError$
+    raise AssertionError\(
+    assert False$
+    assert False,
+
+    # Debug-only code:
+    def __repr__\(
+
+    # Exclusive to mypy:
+    if TYPE_CHECKING:$
+    \.\.\.$

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,9 @@
 [run]
 branch = True
+omit =
+    pydoctor/test/*
+source =
+    pydoctor
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 omit =
+    pydoctor/sphinx_ext/*
     pydoctor/test/*
 source =
     pydoctor

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
 
 commands =
     test: coverage erase
-    test: coverage run --source pydoctor --omit pydoctor/test/* --branch -m pytest {posargs:pydoctor}
+    test: coverage run -m pytest {posargs:pydoctor}
     test: coverage report -m
 
     ; Publish coverage data on codecov.io


### PR DESCRIPTION
By excluding things we don't intend to cover, lines that should be covered but are not stand out more.