### PR TITLE
Include async functions in output

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -438,7 +438,13 @@ class ModuleVistor(ast.NodeVisitor):
 
         self.generic_visit(node)
 
+    def visit_AsyncFunctionDef(self, node):
+        self._handleFunctionDef(node, is_async=True)
+
     def visit_FunctionDef(self, node):
+        self._handleFunctionDef(node, is_async=False)
+
+    def _handleFunctionDef(self, node, is_async):
         # Ignore inner functions.
         if isinstance(self.builder.current, model.Function):
             return
@@ -448,6 +454,7 @@ class ModuleVistor(ast.NodeVisitor):
             lineno = node.decorator_list[0].lineno
 
         func = self.builder.pushFunction(node.name, lineno)
+        func.is_async = is_async
         if len(node.body) > 0 and isinstance(node.body[0], ast.Expr) and isinstance(node.body[0].value, ast.Str):
             func.setDocstring(node.body[0].value)
         func.decorators = node.decorator_list

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -452,6 +452,7 @@ class Inheritable(Documentable):
 
 class Function(Inheritable):
     kind = "Function"
+    is_async: bool
     annotations: Mapping[str, Optional[ast.expr]]
     decorators: Optional[Sequence[ast.expr]]
     argspec: Tuple[Sequence[str], Optional[str], Optional[str], Sequence[str]]

--- a/pydoctor/templates/function-child.html
+++ b/pydoctor/templates/function-child.html
@@ -8,9 +8,8 @@
   </a>
   <div class="functionHeader">
     <t:transparent t:render="decorator" />
-    def
-    <t:transparent t:render="functionName">
-      functionName():
+    <t:transparent t:render="functionDef">
+      def functionName():
     </t:transparent>
     <a class="functionSourceLink" t:render="sourceLink">
       <t:attr name="href"><t:slot name="sourceHref" /></t:attr>

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -55,8 +55,9 @@ class FunctionChild(Element):
         return decorator
 
     @renderer
-    def functionName(self, request, tag):
-        return [self.ob.name, '(', signature(self.ob.argspec), '):']
+    def functionDef(self, request, tag):
+        def_stmt = 'async def' if self.ob.is_async else 'def'
+        return [def_stmt, ' ', self.ob.name, '(', signature(self.ob.argspec), '):']
 
     @renderer
     def sourceLink(self, request, tag):

--- a/pydoctor/templatewriter/pages/table.py
+++ b/pydoctor/templatewriter/pages/table.py
@@ -1,5 +1,7 @@
-from pydoctor.templatewriter import util
 from twisted.web.template import Element, TagLoader, XMLFile, renderer
+
+from pydoctor.model import Function
+from pydoctor.templatewriter import util
 
 
 class TableRow(Element):
@@ -19,7 +21,13 @@ class TableRow(Element):
 
     @renderer
     def kind(self, request, tag):
-        return tag.clear()(self.child.kind)
+        child = self.child
+        kind = child.kind
+        if isinstance(child, Function) and child.is_async:
+            # The official name is "coroutine function", but that is both
+            # a bit long and not as widely recognized.
+            kind = f'Async {kind}'
+        return tag.clear()(kind)
 
     @renderer
     def name(self, request, tag):

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -123,7 +123,7 @@ def test_no_docstring(systemcls: Type[model.System]) -> None:
     assert m.docstring is None
 
 @systemcls_param
-def test_simple(systemcls: Type[model.System]) -> None:
+def test_function_simple(systemcls: Type[model.System]) -> None:
     src = '''
     """ MOD DOC """
     def f():
@@ -134,6 +134,22 @@ def test_simple(systemcls: Type[model.System]) -> None:
     func, = mod.contents.values()
     assert func.fullName() == '<test>.f'
     assert func.docstring == """This is a docstring."""
+    assert func.is_async is False
+
+
+@systemcls_param
+def test_function_async(systemcls: Type[model.System]) -> None:
+    src = '''
+    """ MOD DOC """
+    async def a():
+        """This is a docstring."""
+    '''
+    mod = fromText(src, systemcls=systemcls)
+    assert len(mod.contents) == 1
+    func, = mod.contents.values()
+    assert func.fullName() == '<test>.a'
+    assert func.docstring == """This is a docstring."""
+    assert func.is_async is True
 
 
 @systemcls_param


### PR DESCRIPTION
An `async def` statement is parsed to an `AsyncFunctionDef` node in the AST, but this node type was ignored until now.

Fixes #279.