### PR TITLE
Remove --html-write-function-pages option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ What's New?
 pydoctor dev
 ^^^^^^^^^^^^
 
-* Removed the ``--html-write-function-pages`` option. Please use the generated Intersphinx inventory (objects.inv) for deep-linking your documentation.
+* Removed the ``--html-write-function-pages`` option. As a replacement, you can use the generated Intersphinx inventory (objects.inv) for deep-linking your documentation.
 
 pydoctor 20.12.1
 ^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,11 @@ You can select a different format using the ``--docformat`` option.
 What's New?
 ~~~~~~~~~~~
 
+pydoctor dev
+^^^^^^^^^^^^
+
+* Removed the ``--html-write-function-pages`` option. Please use the generated Intersphinx inventory (objects.inv) for deep-linking your documentation.
+
 pydoctor 20.12.1
 ^^^^^^^^^^^^^^^^
 

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -135,9 +135,6 @@ def getparser() -> OptionParser:
         action='store_true', default=False,
         help=("Only generate the summary pages."))
     parser.add_option(
-        '--html-write-function-pages', dest='htmlfunctionpages',
-        default=False, action='store_true', help=SUPPRESS_HELP)
-    parser.add_option(
         '--html-output', dest='htmloutput', default='apidocs',
         help=("Directory to save HTML files to (default 'apidocs')"))
     parser.add_option(
@@ -273,11 +270,6 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
         print("The --add-package option is deprecated; "
               "pass packages as positional arguments instead.",
               file=sys.stderr, flush=True)
-    if options.htmlfunctionpages:
-        print("The --html-write-function-pages option is deprecated; "
-              "use the generated Intersphinx inventory (objects.inv) "
-              "for deep-linking your documentation.",
-              file=sys.stderr, flush=True)
 
     cache = prepareCache(clearCache=options.clear_intersphinx_cache,
                          enableCache=options.enable_intersphinx_cache,
@@ -404,7 +396,7 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
             else:
                 writer.writeModuleIndex(system)
                 subjects = system.rootobjects
-            writer.writeIndividualFiles(subjects, options.htmlfunctionpages)
+            writer.writeIndividualFiles(subjects)
             if system.docstring_syntax_errors:
                 def p(msg: str) -> None:
                     system.msg('docstring-summary', msg, thresh=-1, topthresh=1)

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -396,7 +396,3 @@ class ZopeInterfaceClassPage(ClassPage):
             r.append(tags.div(class_="interfaceinfo")('from ', util.taglink(imeth, imeth.parent.fullName())))
         r.extend(super().functionExtras(data))
         return r
-
-class FunctionPage(CommonPage):
-    def mediumName(self, ob):
-        return [super().mediumName(ob), signature(self.ob)]

--- a/pydoctor/templatewriter/writer.py
+++ b/pydoctor/templatewriter/writer.py
@@ -46,13 +46,13 @@ class TemplateWriter(ABC):
         shutil.copyfile(templatefile('pydoctor.js'),
                         os.path.join(self.base, 'pydoctor.js'))
 
-    def writeIndividualFiles(self, obs, functionpages=False):
+    def writeIndividualFiles(self, obs):
         self.dry_run = True
         for ob in obs:
-            self._writeDocsFor(ob, functionpages=functionpages)
+            self._writeDocsFor(ob)
         self.dry_run = False
         for ob in obs:
-            self._writeDocsFor(ob, functionpages=functionpages)
+            self._writeDocsFor(ob)
 
     def writeModuleIndex(self, system):
         import time
@@ -65,10 +65,10 @@ class TemplateWriter(ABC):
             f.close()
             system.msg('html', "took %fs"%(time.time() - T), wantsnl=False)
 
-    def _writeDocsFor(self, ob, functionpages):
+    def _writeDocsFor(self, ob):
         if not ob.isVisible:
             return
-        if functionpages or ob.documentation_location is model.DocLocation.OWN_PAGE:
+        if ob.documentation_location is model.DocLocation.OWN_PAGE:
             if self.dry_run:
                 self.total_pages += 1
             else:
@@ -76,7 +76,7 @@ class TemplateWriter(ABC):
                 with path.open('wb') as out:
                     self._writeDocsForOne(ob, out)
         for o in ob.contents.values():
-            self._writeDocsFor(o, functionpages)
+            self._writeDocsFor(o)
 
     def _writeDocsForOne(self, ob, fobj):
         if not ob.isVisible:

--- a/pydoctor/test/__init__.py
+++ b/pydoctor/test/__init__.py
@@ -49,7 +49,7 @@ class InMemoryWriter:
         Does nothing.
         """
 
-    def writeIndividualFiles(self, obs: Sequence[model.Documentable], functionpages: bool = False) -> None:
+    def writeIndividualFiles(self, obs: Sequence[model.Documentable]) -> None:
         """
         Trigger in memory rendering for all objects.
         """

--- a/pydoctor/test/test_templatewriter.py
+++ b/pydoctor/test/test_templatewriter.py
@@ -68,7 +68,7 @@ def test_basic_package(tmp_path: Path) -> None:
     system.options.htmlusesorttable = True
     w.prepOutputDirectory()
     root, = system.rootobjects
-    w._writeDocsFor(root, False)
+    w._writeDocsFor(root)
     w.writeModuleIndex(system)
     for ob in system.allobjects.values():
         url = ob.url


### PR DESCRIPTION
This feature existed to produce pages that third party tools could link to, but intersphinx inventories are a much better solution.

I'm leaving this PR as a draft for now, since we shouldn't merge this before [Twisted stops using function pages](https://twistedmatrix.com/trac/ticket/10057).