### PR TITLE
Replace argspec by inspect.Signature

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -503,7 +503,6 @@ class ModuleVistor(ast.NodeVisitor):
             # TODO: Log this.
             signature = Signature()
 
-        func.argspec = argspec
         func.signature = signature
         func.annotations = self._annotations_from_function(node)
         self.default(node)

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -516,8 +516,8 @@ class ModuleVistor(ast.NodeVisitor):
 
         try:
             signature = Signature(parameters)
-        except ValueError:
-            # TODO: Log this.
+        except ValueError as ex:
+            func.report(f'{func.fullName()} has invalid parameters: {ex}')
             signature = Signature()
 
         func.signature = signature

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -5,7 +5,7 @@ import sys
 from functools import partial
 from itertools import chain
 from pathlib import Path
-from typing import Dict, Iterable, Iterator, List, Mapping, Optional, Tuple, Union
+from typing import Dict, Iterable, Iterator, Mapping, Optional, Tuple, Union
 
 import astor
 from pydoctor import epydoc2stan, model
@@ -479,15 +479,7 @@ class ModuleVistor(ast.NodeVisitor):
             elif isclassmethod:
                 func.kind = 'Class Method'
 
-        args: List[str] = []
-
-        for arg in node.args.args:
-            if isinstance(arg, (ast.Tuple, ast.List)):
-                args.append([x.id for x in arg.elts])
-            elif isinstance(arg, ast.Name):
-                args.append(arg.id)
-            else:
-                args.append(arg.arg)
+        args = [arg.arg for arg in node.args.args]
 
         vararg = node.args.vararg
         varargname = None if vararg is None else vararg.arg

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -613,9 +613,18 @@ class _ValueFormatter:
         value = self.value
         if isinstance(value, ast.Num):
             return str(value.n)
-        else:
-            source: str = astor.to_source(value)
-            return source.strip()
+        if isinstance(value, ast.Str):
+            return repr(value.s)
+        if isinstance(value, ast.Constant):
+            return repr(value.value)
+        if isinstance(value, ast.UnaryOp) and isinstance(value.op, ast.USub):
+            operand = value.operand
+            if isinstance(operand, ast.Num):
+                return f'-{operand.n}'
+            if isinstance(operand, ast.Constant):
+                return f'-{operand.value}'
+        source: str = astor.to_source(value)
+        return source.strip()
 
 
 class _AnnotationStringParser(ast.NodeTransformer):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -456,7 +456,6 @@ class Function(Inheritable):
     is_async: bool
     annotations: Mapping[str, Optional[ast.expr]]
     decorators: Optional[Sequence[ast.expr]]
-    argspec: Tuple[Sequence[str], Optional[str], Optional[str], Sequence[str]]
     signature: Signature
 
     def setup(self) -> None:
@@ -711,7 +710,6 @@ class System:
                 f.parentMod = parentMod
                 f.docstring = v.__doc__
                 f.decorators = None
-                f.argspec = ((), None, None, ())
                 f.signature = Signature()
                 self.addObject(f)
             elif isinstance(v, type):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -15,6 +15,7 @@ import platform
 import sys
 import types
 from enum import Enum
+from inspect import Signature
 from optparse import Values
 from pathlib import Path
 from typing import (
@@ -456,6 +457,7 @@ class Function(Inheritable):
     annotations: Mapping[str, Optional[ast.expr]]
     decorators: Optional[Sequence[ast.expr]]
     argspec: Tuple[Sequence[str], Optional[str], Optional[str], Sequence[str]]
+    signature: Signature
 
     def setup(self) -> None:
         super().setup()
@@ -710,6 +712,7 @@ class System:
                 f.docstring = v.__doc__
                 f.decorators = None
                 f.argspec = ((), None, None, ())
+                f.signature = Signature()
                 self.addObject(f)
             elif isinstance(v, type):
                 c = self.Class(self, k, parent)

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -1,6 +1,6 @@
 """The classes that turn  L{Documentable} instances into objects we can render."""
 
-from typing import List, Optional, Union
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
 
 from twisted.web.template import tags, Element, renderer, Tag, XMLFile
 
@@ -8,14 +8,16 @@ from pydoctor import epydoc2stan, model, __version__
 from pydoctor.templatewriter.pages.table import ChildTable
 from pydoctor.templatewriter import util
 
-def getBetterThanArgspec(argspec):
+def getBetterThanArgspec(
+        argspec: Tuple[Sequence[str], Optional[str], Optional[str], Sequence[str]]
+        ) -> Tuple[Iterable[str], Iterable[Tuple[str, str]]]:
     """Ok, maybe argspec's format isn't the best after all: This takes an
     argspec and returns (regularArguments, [(kwarg, kwval), (kwarg, kwval)])."""
     args = argspec[0]
     defaults = argspec[-1]
     if not defaults:
         return (args, [])
-    backargs = args[:]
+    backargs = list(args)
     backargs.reverse()
     defaults = list(defaults)
     defaults.reverse()
@@ -29,7 +31,9 @@ def _strtup(tup):
         return str(tup)
     return '(' + ', '.join(map(_strtup, tup)) + ')'
 
-def signature(argspec):
+def signature(
+        argspec: Tuple[Sequence[str], Optional[str], Optional[str], Sequence[str]]
+        ) -> str:
     """Return a nicely-formatted source-like signature, formatted from an
     argspec.
     """

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -1,7 +1,6 @@
 """The classes that turn  L{Documentable} instances into objects we can render."""
 
-from inspect import Parameter, Signature
-from typing import Iterable, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import List, Optional, Union
 
 from twisted.web.template import tags, Element, renderer, Tag, XMLFile
 
@@ -10,53 +9,9 @@ from pydoctor.templatewriter.pages.table import ChildTable
 from pydoctor.templatewriter import util
 
 
-class _Preformatted:
-    """Wrapper for a string that returns that exact string from __repr__(),
-    without any added quotes.
-    """
-    def __init__(self, text: str):
-        self.text = text
-    def __repr__(self) -> str:
-        return self.text
-
-def iter_argspec(
-        args: Sequence[str],
-        varargname: Optional[str],
-        varkwname: Optional[str],
-        defaults: Sequence[str]
-        ) -> Iterator[Parameter]:
-
-    if defaults:
-        withdefaults = list(zip(reversed(args), reversed(defaults)))
-        withdefaults.reverse()
-        nodefaults = args[:-len(withdefaults)]
-    else:
-        withdefaults = []
-        nodefaults = args
-
-    for name in nodefaults:
-        yield Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
-    if varargname:
-        yield Parameter(varargname, Parameter.VAR_POSITIONAL)
-    for name, default in withdefaults:
-        yield Parameter(name, Parameter.POSITIONAL_OR_KEYWORD, default=_Preformatted(default))
-    if varkwname:
-        yield Parameter(varkwname, Parameter.VAR_KEYWORD)
-
-def signature(
-        argspec: Tuple[Sequence[str], Optional[str], Optional[str], Sequence[str]]
-        ) -> str:
-    """Return a nicely-formatted source-like signature, formatted from an
-    argspec.
-    """
-
-    try:
-        sig = Signature(parameters=list(iter_argspec(*argspec)))
-    except ValueError as ex:
-        # TODO: Log this as well.
-        return f'(invalid signature: {ex})'
-    else:
-        return str(sig)
+def signature(function: model.Function) -> str:
+    """Return a nicely-formatted source-like function signature."""
+    return str(function.signature)
 
 class DocGetter:
     def get(self, ob, summary=False):
@@ -428,4 +383,4 @@ class ZopeInterfaceClassPage(ClassPage):
 
 class FunctionPage(CommonPage):
     def mediumName(self, ob):
-        return [super().mediumName(ob), signature(self.ob.argspec)]
+        return [super().mediumName(ob), signature(self.ob)]

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -25,12 +25,6 @@ def getBetterThanArgspec(
     kws.reverse()
     return (args[:-len(kws)], kws)
 
-def _strtup(tup):
-    # Ugh
-    if not isinstance(tup, (tuple, list)):
-        return str(tup)
-    return '(' + ', '.join(map(_strtup, tup)) + ')'
-
 def signature(
         argspec: Tuple[Sequence[str], Optional[str], Optional[str], Sequence[str]]
         ) -> str:
@@ -39,19 +33,15 @@ def signature(
     """
     regargs, kwargs = getBetterThanArgspec(argspec)
     varargname, varkwname = argspec[1:3]
-    things = []
-    for regarg in regargs:
-        if isinstance(regarg, list):
-            things.append(_strtup(regarg))
-        else:
-            things.append(regarg)
+
+    things = list(regargs)
     if varargname:
         things.append(f'*{varargname}')
-
     for k, v in kwargs:
         things.append(f'{k}={v}')
     if varkwname:
         things.append(f'**{varkwname}')
+
     return ', '.join(things)
 
 class DocGetter:

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -57,7 +57,7 @@ class FunctionChild(Element):
     @renderer
     def functionDef(self, request, tag):
         def_stmt = 'async def' if self.ob.is_async else 'def'
-        return [def_stmt, ' ', self.ob.name, '(', signature(self.ob.argspec), '):']
+        return [def_stmt, ' ', self.ob.name, signature(self.ob.argspec), ':']
 
     @renderer
     def sourceLink(self, request, tag):

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -57,7 +57,7 @@ class FunctionChild(Element):
     @renderer
     def functionDef(self, request, tag):
         def_stmt = 'async def' if self.ob.is_async else 'def'
-        return [def_stmt, ' ', self.ob.name, signature(self.ob.argspec), ':']
+        return [def_stmt, ' ', self.ob.name, signature(self.ob), ':']
 
     @renderer
     def sourceLink(self, request, tag):

--- a/pydoctor/test/__init__.py
+++ b/pydoctor/test/__init__.py
@@ -7,6 +7,7 @@ import pytest
 
 from pydoctor import epydoc2stan, model
 
+posonlyargs = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python 3.8")
 typecomment = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python 3.8")
 
 

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -12,7 +12,7 @@ from pydoctor.epydoc.markup.epytext import ParsedEpytextDocstring
 from pydoctor.epydoc2stan import get_parsed_type
 from pydoctor.zopeinterface import ZopeInterfaceSystem
 
-from . import CapSys, typecomment
+from . import CapSys, posonlyargs, typecomment
 import pytest
 
 
@@ -154,7 +154,13 @@ def test_function_async(systemcls: Type[model.System]) -> None:
 
 @pytest.mark.parametrize('signature', (
     '()',
+    '(*, a, b=None)',
+    '(*, a=(), b)',
     '(a, b=3, *c, **kw)',
+    # TODO: These are technically correct but ugly:
+    '(f=(True))',
+    '(x=0.1, y=(-2))',
+    '(s="""theory""")',
     ))
 @systemcls_param
 def test_function_signature(signature: str, systemcls: Type[model.System]) -> None:
@@ -165,6 +171,21 @@ def test_function_signature(signature: str, systemcls: Type[model.System]) -> No
     docfunc, = mod.contents.values()
     assert isinstance(docfunc, model.Function)
     assert str(docfunc.signature) == signature
+
+@posonlyargs
+@pytest.mark.parametrize('signature', (
+    '(x, y, /)',
+    '(x, y=0, /)',
+    '(x, y, /, z, w)',
+    '(x, y, /, z, w=42)',
+    '(x, y, /, z=0, w=0)',
+    '(x, y=3, /, z=5, w=7)',
+    '(x, /, *v, a=1, b=2)',
+    '(x, /, *, a=1, b=2, **kwargs)',
+    ))
+@systemcls_param
+def test_function_signature_posonly(signature: str, systemcls: Type[model.System]) -> None:
+    test_function_signature(signature, systemcls)
 
 
 @pytest.mark.parametrize('signature', (

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -157,10 +157,9 @@ def test_function_async(systemcls: Type[model.System]) -> None:
     '(*, a, b=None)',
     '(*, a=(), b)',
     '(a, b=3, *c, **kw)',
-    # TODO: These are technically correct but ugly:
-    '(f=(True))',
-    '(x=0.1, y=(-2))',
-    '(s="""theory""")',
+    '(f=True)',
+    '(x=0.1, y=-2)',
+    '(s=\'theory\', t="con\'text")',
     ))
 @systemcls_param
 def test_function_signature(signature: str, systemcls: Type[model.System]) -> None:

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -192,7 +192,7 @@ def test_function_signature_posonly(signature: str, systemcls: Type[model.System
     '(a, a)',
     ))
 @systemcls_param
-def test_function_badsig(signature: str, systemcls: Type[model.System]) -> None:
+def test_function_badsig(signature: str, systemcls: Type[model.System], capsys: CapSys) -> None:
     """When a function has an invalid signature, an error is logged and
     the empty signature is returned.
 
@@ -200,11 +200,12 @@ def test_function_badsig(signature: str, systemcls: Type[model.System]) -> None:
     recover from. This test checks what happens if the AST can be produced
     but inspect.Signature() rejects the parsed parameters.
     """
-    mod = fromText(f'def f{signature}: ...', systemcls=systemcls)
+    mod = fromText(f'def f{signature}: ...', systemcls=systemcls, modname='mod')
     docfunc, = mod.contents.values()
     assert isinstance(docfunc, model.Function)
     assert str(docfunc.signature) == '()'
-    # TODO: Test logging.
+    captured = capsys.readouterr().out
+    assert captured.startswith("mod:1: mod.f has invalid parameters: ")
 
 
 @systemcls_param


### PR DESCRIPTION
This replaces the `argspec` data structure by the `inspect.Signature` class, as suggested by @mwhudson. Besides simplifying the code, this PR also adds support for position-only and keyword-only parameters and it improves the presentation of parameter default values.

Closes #283