### PR TITLE
Do more with parameter inspection

### DIFF
--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -5,8 +5,8 @@ Convert epydoc markup into renderable content.
 from collections import defaultdict
 from importlib import import_module
 from typing import (
-    Callable, DefaultDict, Dict, Iterable, Iterator, List, Mapping, Optional,
-    Sequence, Tuple
+    Callable, ClassVar, DefaultDict, Dict, Iterable, Iterator, List, Mapping,
+    Optional, Sequence, Tuple
 )
 import ast
 import itertools
@@ -158,6 +158,7 @@ class _EpydocLinker(DocstringLinker):
 
 @attr.s(auto_attribs=True)
 class FieldDesc:
+    _UNDOCUMENTED: ClassVar[Tag] = tags.span(class_='undocumented')("Undocumented")
 
     kind: str
     name: Optional[str] = None
@@ -165,7 +166,7 @@ class FieldDesc:
     body: Optional[Tag] = None
 
     def format(self) -> Tag:
-        formatted: Tag = tags.transparent if self.body is None else self.body
+        formatted = self.body or self._UNDOCUMENTED
         if self.type is not None:
             formatted = tags.transparent(formatted, ' (type: ', self.type, ')')
         return formatted
@@ -387,8 +388,7 @@ class FieldHandler:
             except KeyError:
                 if index == 0 and name in ('self', 'cls'):
                     continue
-                param = FieldDesc(kind='param', name=name, type=type_doc,
-                            body=tags.span(class_='undocumented')("Undocumented"))
+                param = FieldDesc(kind='param', name=name, type=type_doc)
                 any_info |= type_doc is not None
             else:
                 param.type = type_doc

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -332,6 +332,8 @@ class FieldHandler:
         if name is not None:
             # TODO: How should this be matched to the type annotation?
             self.add_info(self.parameter_descs, name, field)
+            if name in self.types:
+                field.report('Parameter "%s" is documented as keyword' % (name,))
 
 
     def handled_elsewhere(self, field: Field) -> None:

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -337,6 +337,8 @@ class FieldHandler:
     def handle_param(self, field: Field) -> None:
         name = self._handle_param_name(field)
         if name is not None:
+            if any(desc.name == name for desc in self.parameter_descs):
+                field.report('Parameter "%s" was already documented' % (name,))
             self.add_info(self.parameter_descs, name, field)
             if name not in self.types:
                 self._handle_param_not_found(name, field)

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -93,7 +93,6 @@ class Documentable:
     @ivar kind: ...
     """
     docstring: Optional[str] = None
-    system: 'System'
     parsed_docstring: Optional[ParsedDocstring] = None
     docstring_lineno = 0
     linenumber = 0
@@ -430,6 +429,22 @@ class Class(CanContainImportsDocumentable):
             return self._localNameToFullName_map[name]
         else:
             return self.parent._localNameToFullName(name)
+
+    @property
+    def constructor_params(self) -> Mapping[str, Optional[ast.expr]]:
+        """A mapping of constructor parameter names to their type annotation.
+        If a parameter is not annotated, its value is L{None}.
+        """
+
+        # We assume that the constructor parameters are the same as the
+        # __init__() parameters. This is incorrect if __new__() or the class
+        # call have different parameters.
+        for base in self.allbases(include_self=True):
+            init = base.contents.get('__init__')
+            if isinstance(init, Function):
+                return init.annotations
+        else:
+            return {}
 
 
 class Inheritable(Documentable):

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -84,10 +84,12 @@ def test_func_undocumented_return_something() -> None:
     func = mod.contents['get_answer']
     lines = docstring2html(func).split('\n')
     ret_idx = lines.index('<td class="fieldName">Returns</td>')
-    expected_html = """
-    <span class="undocumented">Undocumented</span> (type: <code>int</code>)</td>
-    """.strip()
-    assert lines[ret_idx + 2] == expected_html
+    expected_html = [
+        '<td class="fieldName">Returns</td>',
+        '<td colspan="2">',
+        '<span class="undocumented">Undocumented</span> (type: <code>int</code>)</td>',
+        ]
+    assert lines[ret_idx:ret_idx + 3] == expected_html
 
 
 def test_func_arg_and_ret_annotation() -> None:

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -94,7 +94,7 @@ def test_func_arg_and_ret_annotation_with_override() -> None:
         """
     ''')
     classic_mod = fromText('''
-    def f(a):
+    def f(a, b):
         """
         @param a: an arg, a the best of args
         @type a: C{List[str]}
@@ -128,6 +128,48 @@ def test_func_arg_when_doc_missing() -> None:
     classic_fmt = docstring2html(classic_mod.contents['f'])
     assert annotation_fmt == classic_fmt
 
+def test_func_no_such_arg(capsys: CapSys) -> None:
+    """Warn about documented parameters that don't exist in the definition."""
+    mod = fromText('''
+    def f():
+        """
+        This function takes no arguments...
+
+        @param x: ...but it does document one.
+        """
+    ''')
+    epydoc2stan.format_docstring(mod.contents['f'])
+    captured = capsys.readouterr().out
+    assert captured == '<test>:6: Documented parameter "x" does not exist\n'
+
+def test_func_arg_not_inherited(capsys: CapSys) -> None:
+    """Do not warn about non-existing parameters from inherited docstrings."""
+    mod = fromText('''
+    class Base:
+        def __init__(self, value):
+            """
+            @param value: Preciousss.
+            """
+    class Sub(Base):
+        def __init__(self):
+            super().__init__(1)
+    ''')
+    epydoc2stan.format_docstring(mod.contents['Base'].contents['__init__'])
+    assert capsys.readouterr().out == ''
+    epydoc2stan.format_docstring(mod.contents['Sub'].contents['__init__'])
+    assert capsys.readouterr().out == ''
+
+def test_func_keyword(capsys: CapSys) -> None:
+    """Test handling of @keyword."""
+    mod = fromText('''
+    def f(**kwargs):
+        """
+        @keyword a: Advanced.
+        @keyword b: Basic.
+        """
+    ''')
+    epydoc2stan.format_docstring(mod.contents['f'])
+    assert capsys.readouterr().out == ''
 
 def test_func_missing_param_name(capsys: CapSys) -> None:
     """Param and type fields must include the name of the parameter."""
@@ -145,6 +187,44 @@ def test_func_missing_param_name(capsys: CapSys) -> None:
         '<test>:5: Parameter name missing\n'
         '<test>:6: Parameter name missing\n'
         )
+
+def test_missing_param_computed_base(capsys: CapSys) -> None:
+    """Do not warn if a parameter might be added by a computed base class."""
+    mod = fromText('''
+    from twisted.python import components
+    import zope.interface
+    class IFoo(zope.interface.Interface):
+        pass
+    class Proxy(components.proxyForInterface(IFoo)):
+        """
+        @param original: The wrapped instance.
+        """
+    ''')
+    html = docstring2html(mod.contents['Proxy'])
+    assert '<td>The wrapped instance.</td>' in html.split('\n')
+    captured = capsys.readouterr().out
+    assert captured == ''
+
+def test_constructor_param_on_class(capsys: CapSys) -> None:
+    """Constructor parameters can be documented on the class."""
+    mod = fromText('''
+    class C:
+        """
+        @param p: Constructor parameter.
+        @param q: Not a constructor parameter.
+        """
+        def __init__(self, p):
+            pass
+    ''')
+    html = docstring2html(mod.contents['C']).split('\n')
+    assert '<td>Constructor parameter.</td>' in html
+    # Non-existing parameters should still end up in the output, because:
+    # - pydoctor might be wrong about them not existing
+    # - the documentation may still be useful, for example if belongs to
+    #   an existing parameter but the name in the @param field has a typo
+    assert '<td>Not a constructor parameter.</td>' in html
+    captured = capsys.readouterr().out
+    assert captured == '<test>:5: Documented parameter "q" does not exist\n'
 
 
 def test_func_missing_exception_type(capsys: CapSys) -> None:

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -59,6 +59,38 @@ def test_html_empty_module() -> None:
     """).strip()
     assert docstring2html(mod) == expected_html
 
+
+def test_func_undocumented_return_nothing() -> None:
+    """When the returned value is undocumented and its type is None,
+    omit the "Returns" entry from the output.
+    """
+    mod = fromText('''
+    def nop() -> None:
+        """Does nothing."""
+    ''')
+    func = mod.contents['nop']
+    lines = docstring2html(func).split('\n')
+    assert '<td class="fieldName">Returns</td>' not in lines
+
+
+def test_func_undocumented_return_something() -> None:
+    """When the returned value is undocumented and its type is not None,
+    include a the "Returns" entry in the output.
+    """
+    mod = fromText('''
+    def get_answer() -> int:
+        """Mostly harmless."""
+        return 42
+    ''')
+    func = mod.contents['get_answer']
+    lines = docstring2html(func).split('\n')
+    ret_idx = lines.index('<td class="fieldName">Returns</td>')
+    expected_html = """
+    <span class="undocumented">Undocumented</span> (type: <code>int</code>)</td>
+    """.strip()
+    assert lines[ret_idx + 2] == expected_html
+
+
 def test_func_arg_and_ret_annotation() -> None:
     annotation_mod = fromText('''
     def f(a: List[str], b: "List[str]") -> bool:

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -66,7 +66,7 @@ def test_func_undocumented_return_nothing() -> None:
     """
     mod = fromText('''
     def nop() -> None:
-        """Does nothing."""
+        pass
     ''')
     func = mod.contents['nop']
     lines = docstring2html(func).split('\n')
@@ -79,7 +79,6 @@ def test_func_undocumented_return_something() -> None:
     """
     mod = fromText('''
     def get_answer() -> int:
-        """Mostly harmless."""
         return 42
     ''')
     func = mod.contents['get_answer']

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -61,8 +61,8 @@ def test_html_empty_module() -> None:
 
 
 def test_func_undocumented_return_nothing() -> None:
-    """When the returned value is undocumented and its type is None,
-    omit the "Returns" entry from the output.
+    """When the returned value is undocumented (no 'return' field) and its type
+    annotation is None, omit the "Returns" entry from the output.
     """
     mod = fromText('''
     def nop() -> None:
@@ -74,8 +74,8 @@ def test_func_undocumented_return_nothing() -> None:
 
 
 def test_func_undocumented_return_something() -> None:
-    """When the returned value is undocumented and its type is not None,
-    include a the "Returns" entry in the output.
+    """When the returned value is undocumented (no 'return' field) and its type
+    annotation is not None, include the "Returns" entry in the output.
     """
     mod = fromText('''
     def get_answer() -> int:
@@ -206,7 +206,9 @@ def test_func_no_such_arg_warn_once(capsys: CapSys) -> None:
         )
 
 def test_func_arg_not_inherited(capsys: CapSys) -> None:
-    """Do not warn about non-existing parameters from inherited docstrings."""
+    """Do not warn when a subclass method lacks parameters that are documented
+    in an inherited docstring.
+    """
     mod = fromText('''
     class Base:
         def __init__(self, value):
@@ -223,8 +225,8 @@ def test_func_arg_not_inherited(capsys: CapSys) -> None:
     epydoc2stan.format_docstring(mod.contents['Sub'].contents['__init__'])
     assert capsys.readouterr().out == ''
 
-def test_func_keyword(capsys: CapSys) -> None:
-    """Test handling of @keyword."""
+def test_func_param_as_keyword(capsys: CapSys) -> None:
+    """Warn when a parameter is documented as a @keyword."""
     mod = fromText('''
     def f(p, **kwargs):
         """

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -162,14 +162,15 @@ def test_func_arg_not_inherited(capsys: CapSys) -> None:
 def test_func_keyword(capsys: CapSys) -> None:
     """Test handling of @keyword."""
     mod = fromText('''
-    def f(**kwargs):
+    def f(p, **kwargs):
         """
         @keyword a: Advanced.
         @keyword b: Basic.
+        @keyword p: A parameter, not a keyword.
         """
     ''')
     epydoc2stan.format_docstring(mod.contents['f'])
-    assert capsys.readouterr().out == ''
+    assert capsys.readouterr().out == '<test>:6: Parameter "p" is documented as keyword\n'
 
 def test_func_missing_param_name(capsys: CapSys) -> None:
     """Param and type fields must include the name of the parameter."""

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -159,6 +159,19 @@ def test_func_arg_when_doc_missing() -> None:
     classic_fmt = docstring2html(classic_mod.contents['f'])
     assert annotation_fmt == classic_fmt
 
+def test_func_param_duplicate(capsys: CapSys) -> None:
+    """Warn when the same parameter is documented more than once."""
+    mod = fromText('''
+    def f(x, y):
+        """
+        @param x: Actual documentation.
+        @param x: Likely typo or copy-paste error.
+        """
+    ''')
+    epydoc2stan.format_docstring(mod.contents['f'])
+    captured = capsys.readouterr().out
+    assert captured == '<test>:5: Parameter "x" was already documented\n'
+
 @mark.parametrize('field', ('param', 'type'))
 def test_func_no_such_arg(field: str, capsys: CapSys) -> None:
     """Warn about documented parameters that don't exist in the definition."""

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -150,6 +150,31 @@ def test_docsources_class_attribute() -> None:
     assert base_attr in list(sub_attr.docsources())
 
 
+def test_constructor_params_simple() -> None:
+    src = '''
+    class C:
+        def __init__(self, a: int, b: str):
+            pass
+    '''
+    mod = fromText(src)
+    assert mod.contents['C'].constructor_params.keys() == {'self', 'a', 'b'}
+
+
+def test_constructor_params_inherited() -> None:
+    src = '''
+    class A:
+        def __init__(self, a: int, b: str):
+            pass
+    class B:
+        def __init__(self):
+            pass
+    class C(A, B):
+        pass
+    '''
+    mod = fromText(src)
+    assert mod.contents['C'].constructor_params.keys() == {'self', 'a', 'b'}
+
+
 def test_docstring_lineno() -> None:
     src = '''
     def f():

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -150,6 +150,15 @@ def test_docsources_class_attribute() -> None:
     assert base_attr in list(sub_attr.docsources())
 
 
+def test_constructor_params_empty() -> None:
+    src = '''
+    class C:
+        pass
+    '''
+    mod = fromText(src)
+    assert mod.contents['C'].constructor_params == {}
+
+
 def test_constructor_params_simple() -> None:
     src = '''
     class C:


### PR DESCRIPTION
Fixes #217

Known issues: (to be fixed after release)
- #229: we don't warn about duplicate `type` or `keyword` fields yet: `type` is not easy to implement, `keyword` is barely used
- #294: doesn't happen all that often
- #295: annoying but not easy to fix
