### PR TITLE
Fix docstring warnings in pydoctor's source code

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,4 +91,7 @@ pydoctor_args = [
     '--project-url=https://github.com/twisted/pydoctor/',
     '--docformat=epytext',
     '--intersphinx=https://docs.python.org/3/objects.inv',
+    '--intersphinx=https://twistedmatrix.com/documents/current/api/objects.inv',
+    '--intersphinx=https://urllib3.readthedocs.io/en/latest/objects.inv',
+    '--intersphinx=https://requests.readthedocs.io/en/latest/objects.inv',
     ]

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -630,8 +630,8 @@ class _ValueFormatter:
 class _AnnotationStringParser(ast.NodeTransformer):
     """Implementation of L{ModuleVistor._unstring_annotation()}.
 
-    When given an expression, the node returned by L{visit()} will also
-    be an expression.
+    When given an expression, the node returned by L{ast.NodeVisitor.visit()}
+    will also be an expression.
     If any string literal contained in the original expression is either
     invalid Python or not a singular expression, L{SyntaxError} is raised.
     """

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -30,9 +30,6 @@ responsible for resolving identifier crossreferences
 Markup errors are represented using L{ParseError}s.  These exception
 classes record information about the cause, location, and severity of
 each error.
-
-@sort: ParsedDocstring, Field, DocstringLinker
-@group Errors and Warnings: ParseError
 """
 __docformat__ = 'epytext en'
 

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -56,8 +56,8 @@ class ParsedDocstring:
     """
     A standard intermediate representation for parsed docstrings that
     can be used to generate output.  Parsed docstrings are produced by
-    markup parsers such as L{pydoctor.epydoc.epytext.parse_docstring()}
-    or L{pydoctor.epydoc.restructuredtext.parse_docstring()}.
+    markup parsers such as L{pydoctor.epydoc.markup.epytext.parse_docstring()}
+    or L{pydoctor.epydoc.markup.restructuredtext.parse_docstring()}.
 
     Subclasses must implement L{to_stan()}.
     """

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -166,7 +166,8 @@ class Element:
         """
         Return a string representation of this element, using XML
         notation.
-        @bug: Doesn't escape '<' or '&' or '>'.
+        @note: Doesn't escape '<' or '&' or '>', so the result is only XML-like
+            and cannot actually be parsed as XML.
         """
         attribs = ''.join(f' {k}={v!r}' for k, v in self.attribs.items())
         content = ''.join(str(child) for child in self.children)

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -331,7 +331,7 @@ def parseMaxAge(maxAge: str) -> Dict[str, int]:
         followed by a single character unit.
     @return: A dictionary whose keys match L{datetime.timedelta}'s
         arguments.
-    @raises: L{InvalidMaxAge} when a string cannot be parsed.
+    @raises InvalidMaxAge: when a string cannot be parsed.
     """
     try:
         amount = int(maxAge[:-1])

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -528,7 +528,7 @@ class TestParseMaxAge:
 class ClosingBytesIO(io.BytesIO):
     """
     A L{io.BytesIO} instance that closes itself after all its data has
-    been read.  This mimics the behavior of L{HTTPResponse} in the
+    been read.  This mimics the behavior of L{http.client.HTTPResponse} in the
     standard library.
     """
 

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -694,7 +694,7 @@ def test_prepareCache(
     """
     The cache directory is deleted when C{clearCache} is L{True}; an
     L{IntersphinxCache} is created with a session on which is mounted
-    L{cachecontrol.CacheControlAdapter} for C{http} and C{https} URLs.
+    C{cachecontrol.CacheControlAdapter} for C{http} and C{https} URLs.
     """
 
     # Windows doesn't like paths ending in a space or dot.

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -566,8 +566,8 @@ class TestIntersphinxCache:
     def send_returns(self, monkeypatch: MonkeyPatch) -> Callable[[HTTPResponse], MonkeyPatch]:
         """
         Return a function that patches
-        L{requests.adapters.HTTPResponse.send} so that it returns the
-        provided L{urllib3.Response}.
+        L{requests.adapters.HTTPAdapter.send} so that it returns the
+        provided L{requests.Response}.
         """
         def send_returns(urllib3_response: HTTPResponse) -> MonkeyPatch:
             def send(

--- a/tox.ini
+++ b/tox.ini
@@ -128,6 +128,9 @@ commands =
     --project-base-dir="{toxinidir}" \
     --docformat=epytext \
     --intersphinx=https://docs.python.org/3/objects.inv \
+    --intersphinx=https://twistedmatrix.com/documents/current/api/objects.inv \
+    --intersphinx=https://urllib3.readthedocs.io/en/latest/objects.inv \
+    --intersphinx=https://requests.readthedocs.io/en/latest/objects.inv \
     --make-html --warnings-as-errors
 
 


### PR DESCRIPTION
Fixes #269.
However, because of #302, we can't actually use `--warings-as-errors` yet.
