### PR TITLE
Replace --add-package and --add-module by positional arguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Simple Usage
 
 You can run pydoctor on your project like this::
 
-    $ pydoctor --make-html --html-output=docs/api --add-package=src/mylib
+    $ pydoctor --make-html --html-output=docs/api src/mylib
 
 For more info, `Read The Docs <https://pydoctor.readthedocs.io/>`_.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,7 +82,6 @@ if os.environ.get('READTHEDOCS', '') == 'True':
 
 _pydoctor_root = pathlib.Path(__file__).parent.parent.parent
 pydoctor_args = [
-    f'--add-package={_pydoctor_root}/pydoctor',
     '--html-output={outdir}/api',
     f'--project-base-dir={_pydoctor_root}',
     f'--html-viewsource-base=https://github.com/twisted/pydoctor/tree/{_git_reference}',
@@ -95,4 +94,5 @@ pydoctor_args = [
     '--intersphinx=https://twistedmatrix.com/documents/current/api/objects.inv',
     '--intersphinx=https://urllib3.readthedocs.io/en/latest/objects.inv',
     '--intersphinx=https://requests.readthedocs.io/en/latest/objects.inv',
+    f'{_pydoctor_root}/pydoctor',
     ]

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -335,12 +335,10 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
                     system.msg('addModuleFromPath', 'adding module ' + path)
                     system.addModuleFromPath(prependedpackage, path)
                 system.packages.append(path)
+        else:
+            error("No source paths given.")
 
         # step 3: move the system to the desired state
-
-        if not system.packages:
-            error("The system does not contain any code, did you "
-                  "forget an --add-package?")
 
         if system.options.projectname is None:
             name = '/'.join(ro.name for ro in system.rootobjects)

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -72,7 +72,9 @@ class CustomOption(Option):
     TYPE_CHECKER = dict(Option.TYPE_CHECKER, path=parse_path)
 
 def getparser() -> OptionParser:
-    parser = OptionParser(option_class=CustomOption, version=__version__.public())
+    parser = OptionParser(
+        option_class=CustomOption, version=__version__.public(),
+        usage="usage: %prog [options] SOURCEPATH...")
     parser.add_option(
         '-c', '--config', dest='configfile',
         help=("Use config from this file (any command line"

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -104,13 +104,10 @@ def getparser() -> OptionParser:
         default=False, help=("Produce (only) the objects.inv intersphinx file."))
     parser.add_option(
         '--add-package', action='append', dest='packages',
-        metavar='PACKAGEDIR', default=[],
-        help=("Add a package to the system.  Can be repeated "
-              "to add more than one package."))
+        metavar='PACKAGEDIR', default=[], help=SUPPRESS_HELP)
     parser.add_option(
         '--add-module', action='append', dest='modules',
-        metavar='MODULE', default=[],
-        help=("Add a module to the system.  Can be repeated."))
+        metavar='MODULE', default=[], help=SUPPRESS_HELP)
     parser.add_option(
         '--prepend-package', action='store', dest='prependedpackage',
         help=("Pretend that all packages are within this one.  "
@@ -261,6 +258,12 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
     if options.enable_intersphinx_cache_deprecated:
         print("The --enable-intersphinx-cache option is deprecated; "
               "the cache is now enabled by default.", file=sys.stderr)
+    if options.modules:
+        print("The --add-module option is deprecated; "
+              "pass modules as positional arguments instead.", file=sys.stderr)
+    if options.packages:
+        print("The --add-package option is deprecated; "
+              "pass packages as positional arguments instead.", file=sys.stderr)
 
     cache = prepareCache(clearCache=options.clear_intersphinx_cache,
                          enableCache=options.enable_intersphinx_cache,

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -334,9 +334,13 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
                 if os.path.isdir(path):
                     system.msg('addPackage', 'adding directory ' + path)
                     system.addPackage(path, prependedpackage)
-                else:
+                elif os.path.isfile(path):
                     system.msg('addModuleFromPath', 'adding module ' + path)
                     system.addModuleFromPath(prependedpackage, path)
+                elif os.path.exists(path):
+                    error(f"Source path is neither file nor directory: {path}")
+                else:
+                    error(f"Source path does not exist: {path}")
                 added_paths.add(path)
         else:
             error("No source paths given.")

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -324,9 +324,10 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
                     system.addObject(prependedpackage)
                     initmodule = system.Module(system, '__init__', prependedpackage)
                     system.addObject(initmodule)
+            added_paths = set()
             for path in args:
                 path = os.path.abspath(path)
-                if path in system.packages:
+                if path in added_paths:
                     continue
                 if os.path.isdir(path):
                     system.msg('addPackage', 'adding directory ' + path)
@@ -334,7 +335,7 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
                 else:
                     system.msg('addModuleFromPath', 'adding module ' + path)
                     system.addModuleFromPath(prependedpackage, path)
-                system.packages.append(path)
+                added_paths.add(path)
         else:
             error("No source paths given.")
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -650,8 +650,7 @@ class System:
     # - that http://divmod.org/trac/browser/trunk is the trac URL to the
     #   above directory
     #
-    # - that ~/src/Divmod/Nevow/nevow is passed to pydoctor as an
-    #   "--add-package" argument
+    # - that ~/src/Divmod/Nevow/nevow is passed to pydoctor as an argument
     #
     # we want to work out the sourceHref for nevow.flat.ten.  the answer
     # is http://divmod.org/trac/browser/trunk/Nevow/nevow/flat/ten.py.

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -516,8 +516,6 @@ class System:
         for problems that the user can fix.
         """
 
-        self.packages: List[str] = []
-
         if options:
             self.options = options
         else:

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -34,7 +34,7 @@ def test_invalid_option() -> None:
 
 def test_cannot_advance_blank_system() -> None:
     err = geterrtext('--make-html')
-    assert 'forget an --add-package?' in err
+    assert 'No source paths given' in err
 
 def test_no_systemclasses_py3() -> None:
     err = geterrtext('--system-class')

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -8,7 +8,6 @@ testpackages = os.path.join(os.path.dirname(__file__), 'testpackages')
 def processPackage(packname: str, systemcls: Type[model.System] = model.System) -> model.System:
     testpackage = os.path.join(testpackages, packname)
     system = systemcls()
-    system.packages.append(testpackage)
     system.addPackage(testpackage)
     system.process()
     return system

--- a/tox.ini
+++ b/tox.ini
@@ -119,7 +119,6 @@ description = Build only the API documentation
 
 commands =
     pydoctor \
-    --add-package=pydoctor \
     --project-name=pydoctor \
     --project-url=https://github.com/twisted/pydoctor/ \
     --html-viewsource-base=https://github.com/twisted/pydoctor/tree/master \
@@ -130,7 +129,8 @@ commands =
     --intersphinx=https://twistedmatrix.com/documents/current/api/objects.inv \
     --intersphinx=https://urllib3.readthedocs.io/en/latest/objects.inv \
     --intersphinx=https://requests.readthedocs.io/en/latest/objects.inv \
-    --make-html --warnings-as-errors
+    --make-html --warnings-as-errors \
+    pydoctor
 
 
 [testenv:docs]


### PR DESCRIPTION
The two command line options were already just added to the positional arguments, but the naming and documentation suggested otherwise.

The options remain available, but print a warning when used.

We now also reject non-existing paths passed using either option or as a positional argument.

Fixes #255.