### PR TITLE
Support `@property` decorators

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -313,9 +313,10 @@ class ModuleVistor(ast.NodeVisitor):
             # It is handled by findAll(), which operates on the AST and
             # therefore doesn't need an Attribute instance.
             return
-        obj = self.builder.current.resolveName(target)
+        parent = self.builder.current
+        obj = parent.resolveName(target)
         if obj is None:
-            obj = self.builder.addAttribute(target, None)
+            obj = self.builder.addAttribute(target, None, parent)
         if isinstance(obj, model.Attribute):
             obj.kind = 'Variable'
             obj.annotation = annotation
@@ -327,9 +328,10 @@ class ModuleVistor(ast.NodeVisitor):
             self._handleModuleVar(target, annotation, lineno)
 
     def _handleClassVar(self, target, annotation, lineno):
-        obj = self.builder.current.contents.get(target)
+        parent = self.builder.current
+        obj = parent.contents.get(target)
         if not isinstance(obj, model.Attribute):
-            obj = self.builder.addAttribute(target, None)
+            obj = self.builder.addAttribute(target, None, parent)
         if obj.kind is None:
             obj.kind = 'Class Variable'
         obj.annotation = annotation
@@ -787,12 +789,12 @@ class ASTBuilder:
     def popFunction(self):
         self._pop(self.system.Function)
 
-    def addAttribute(self, target, kind, parent=None):
-        if parent is None:
-            parent = self.current
+    def addAttribute(self,
+            name: str, kind: Optional[str], parent: model.Documentable
+            ) -> model.Attribute:
         system = self.system
         parentMod = self.currentMod
-        attr = system.Attribute(system, target, parent)
+        attr = system.Attribute(system, name, parent)
         attr.kind = kind
         attr.parentMod = parentMod
         system.addObject(attr)

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -483,6 +483,20 @@ class ModuleVistor(ast.NodeVisitor):
             attr.setLineNumber(lineno)
             if docstring is not None:
                 attr.setDocstring(docstring)
+                assert attr.docstring is not None
+                pdoc = epydoc2stan.parse_docstring(attr, attr.docstring, attr)
+                other_fields = []
+                for field in pdoc.fields:
+                    tag = field.tag()
+                    if tag == 'return':
+                        if not pdoc.has_body:
+                            pdoc = field.body()
+                    elif tag == 'rtype':
+                        attr.parsed_type = field.body() # type: ignore[attr-defined]
+                    else:
+                        other_fields.append(field)
+                pdoc.fields = other_fields
+                attr.parsed_docstring = pdoc
             if node.returns is not None:
                 attr.annotation = self._unstring_annotation(node.returns)
             if is_classmethod:

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -491,6 +491,9 @@ class ModuleVistor(ast.NodeVisitor):
                     if tag == 'return':
                         if not pdoc.has_body:
                             pdoc = field.body()
+                            # Avoid format_summary() going back to the original
+                            # empty-body docstring.
+                            attr.docstring = ''
                     elif tag == 'rtype':
                         attr.parsed_type = field.body() # type: ignore[attr-defined]
                     else:

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -72,6 +72,7 @@ class ParsedDocstring:
     @property
     def has_body(self) -> bool:
         """Does this docstring have a non-empty body?
+
         The body is the part of the docstring that remains after the fields
         have been split off.
         """

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -59,7 +59,7 @@ class ParsedDocstring:
     markup parsers such as L{pydoctor.epydoc.markup.epytext.parse_docstring()}
     or L{pydoctor.epydoc.markup.restructuredtext.parse_docstring()}.
 
-    Subclasses must implement L{to_stan()}.
+    Subclasses must implement L{has_body()} and L{to_stan()}.
     """
 
     def __init__(self, fields: Sequence['Field']):
@@ -68,6 +68,14 @@ class ParsedDocstring:
         A list of L{Field}s, each of which encodes a single field.
         The field's bodies are encoded as C{ParsedDocstring}s.
         """
+
+    @property
+    def has_body(self) -> bool:
+        """Does this docstring have a non-empty body?
+        The body is the part of the docstring that remains after the fields
+        have been split off.
+        """
+        raise NotImplementedError()
 
     def to_stan(self, docstring_linker: 'DocstringLinker') -> Tag:
         """

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -33,7 +33,7 @@ each error.
 """
 __docformat__ = 'epytext en'
 
-from typing import List, Optional
+from typing import List, Optional, Sequence, Union
 import re
 
 from twisted.python.failure import Failure
@@ -62,14 +62,14 @@ class ParsedDocstring:
     Subclasses must implement L{to_stan()}.
     """
 
-    def __init__(self, fields):
+    def __init__(self, fields: Sequence['Field']):
         self.fields = fields
         """
         A list of L{Field}s, each of which encodes a single field.
         The field's bodies are encoded as C{ParsedDocstring}s.
         """
 
-    def to_stan(self, docstring_linker):
+    def to_stan(self, docstring_linker: 'DocstringLinker') -> Tag:
         """
         Translate this docstring to a Stan tree.
 
@@ -79,7 +79,6 @@ class ParsedDocstring:
 
         @param docstring_linker: An HTML translator for crossreference
             links into and out of the docstring.
-        @type docstring_linker: L{DocstringLinker}
         @return: The docstring presented as a tree.
         """
         raise NotImplementedError()
@@ -90,19 +89,18 @@ _RE_CONTROL = re.compile((
     ) + ']'
     ).encode())
 
-def html2stan(html):
+def html2stan(html: Union[bytes, str]) -> Tag:
     """
     Convert an HTML string to a Stan tree.
 
     @param html: An HTML fragment; multiple roots are allowed.
-    @type html: C{string}
     @return: The fragment as a tree with a transparent root node.
     """
     if isinstance(html, str):
         html = html.encode('utf8')
 
     html = _RE_CONTROL.sub(lambda m:b'\\x%02x' % ord(m.group()), html)
-    stan = XMLString(b'<div>%s</div>' % html).load()[0]
+    stan: Tag = XMLString(b'<div>%s</div>' % html).load()[0]
     assert stan.tagName == 'div'
     stan.tagName = ''
     return stan

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -1330,6 +1330,10 @@ class ParsedEpytextDocstring(ParsedDocstring):
     def __str__(self) -> str:
         return str(self._tree)
 
+    @property
+    def has_body(self) -> bool:
+        return self._tree is not None
+
     def to_stan(self, docstring_linker: DocstringLinker) -> Tag:
         if self._stan is not None:
             return self._stan

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -131,10 +131,12 @@ __docformat__ = 'epytext en'
 #   4. helpers
 #   5. testing
 
+from typing import Any, Optional, Sequence, Union
 import re
+
 from twisted.web.template import CharRef, Tag, tags
 from pydoctor.epydoc.doctest import colorize_doctest
-from pydoctor.epydoc.markup import Field, ParseError, ParsedDocstring
+from pydoctor.epydoc.markup import DocstringLinker, Field, ParseError, ParsedDocstring
 
 ##################################################
 ## DOM-Like Encoding
@@ -1319,16 +1321,16 @@ class ParsedEpytextDocstring(ParsedDocstring):
         '<=': 8804, '>=': 8805,
         }
 
-    def __init__(self, body, fields):
+    def __init__(self, body: Optional[Element], fields: Sequence['Field']):
         ParsedDocstring.__init__(self, fields)
         self._tree = body
         # Caching:
-        self._stan = None
+        self._stan: Optional[Tag] = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self._tree)
 
-    def to_stan(self, docstring_linker):
+    def to_stan(self, docstring_linker: DocstringLinker) -> Tag:
         if self._stan is not None:
             return self._stan
         if self._tree is None:
@@ -1337,7 +1339,11 @@ class ParsedEpytextDocstring(ParsedDocstring):
             self._stan = self._to_stan(self._tree, docstring_linker)
         return self._stan
 
-    def _to_stan(self, tree, linker, seclevel=0):
+    def _to_stan(self,
+            tree: Union[Element, str],
+            linker: DocstringLinker,
+            seclevel: int = 0
+            ) -> Any:
         if isinstance(tree, str):
             return tree
 

--- a/pydoctor/epydoc/markup/plaintext.py
+++ b/pydoctor/epydoc/markup/plaintext.py
@@ -34,5 +34,9 @@ class ParsedPlaintextDocstring(ParsedDocstring):
         ParsedDocstring.__init__(self, ())
         self._text = text
 
+    @property
+    def has_body(self) -> bool:
+        return bool(self._text)
+
     def to_stan(self, docstring_linker: DocstringLinker) -> Tag:
         return tags.p(self._text, class_='pre')  # type: ignore[no-any-return]

--- a/pydoctor/epydoc/markup/plaintext.py
+++ b/pydoctor/epydoc/markup/plaintext.py
@@ -11,9 +11,9 @@ verbatim output, preserving all whitespace.
 """
 __docformat__ = 'epytext en'
 
-from twisted.web.template import tags
+from twisted.web.template import Tag, tags
 
-from pydoctor.epydoc.markup import ParsedDocstring
+from pydoctor.epydoc.markup import DocstringLinker, ParsedDocstring
 
 def parse_docstring(docstring, errors):
     """
@@ -30,9 +30,9 @@ def parse_docstring(docstring, errors):
 
 class ParsedPlaintextDocstring(ParsedDocstring):
 
-    def __init__(self, text):
+    def __init__(self, text: str):
         ParsedDocstring.__init__(self, ())
         self._text = text
 
-    def to_stan(self, docstring_linker):
-        return tags.p(self._text, class_='pre')
+    def to_stan(self, docstring_linker: DocstringLinker) -> Tag:
+        return tags.p(self._text, class_='pre')  # type: ignore[no-any-return]

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -43,6 +43,7 @@ the list.
 __docformat__ = 'epytext en'
 
 # Imports
+from typing import Sequence
 import re
 
 from docutils.core import publish_string
@@ -57,10 +58,10 @@ import docutils.nodes
 import docutils.transforms.frontmatter
 import docutils.utils
 
-from twisted.web.template import tags
+from twisted.web.template import Tag, tags
 from pydoctor.epydoc.doctest import colorize_codeblock, colorize_doctest
 from pydoctor.epydoc.markup import (
-    Field, ParseError, ParsedDocstring, flatten, html2stan
+    DocstringLinker, Field, ParseError, ParsedDocstring, flatten, html2stan
 )
 from pydoctor.epydoc.markup.plaintext import ParsedPlaintextDocstring
 
@@ -121,29 +122,25 @@ class ParsedRstDocstring(ParsedDocstring):
     An encoded version of a ReStructuredText docstring.  The contents
     of the docstring are encoded in the L{_document} instance
     variable.
-
-    @ivar _document: A ReStructuredText document, encoding the
-        docstring.
-    @type _document: C{docutils.nodes.document}
     """
-    def __init__(self, document, fields):
-        """
-        @type document: C{docutils.nodes.document}
-        """
+
+    def __init__(self, document: docutils.nodes.document, fields: Sequence[Field]):
         self._document = document
+        """A ReStructuredText document, encoding the docstring."""
 
         document.reporter = OptimizedReporter(
             document.reporter.source, 'SEVERE', 'SEVERE', '')
 
         ParsedDocstring.__init__(self, fields)
 
-    def to_stan(self, docstring_linker):
+    def to_stan(self, docstring_linker: DocstringLinker) -> Tag:
         # Inherit docs
         visitor = _EpydocHTMLTranslator(self._document, docstring_linker)
         self._document.walkabout(visitor)
         return html2stan(''.join(visitor.body))
 
-    def __repr__(self): return '<ParsedRstDocstring: ...>'
+    def __repr__(self) -> str:
+        return '<ParsedRstDocstring: ...>'
 
 class _EpydocReader(StandaloneReader):
     """

--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -51,7 +51,7 @@ from docutils.writers import Writer
 from docutils.writers.html4css1 import HTMLTranslator, Writer as HTMLWriter
 from docutils.readers.standalone import Reader as StandaloneReader
 from docutils.utils import new_document
-from docutils.nodes import NodeVisitor, SkipNode
+from docutils.nodes import NodeVisitor, SkipNode, Text
 from docutils.frontend import OptionParser
 from docutils.parsers.rst import Directive, directives
 import docutils.nodes
@@ -132,6 +132,13 @@ class ParsedRstDocstring(ParsedDocstring):
             document.reporter.source, 'SEVERE', 'SEVERE', '')
 
         ParsedDocstring.__init__(self, fields)
+
+    @property
+    def has_body(self) -> bool:
+        return any(
+            isinstance(child, Text) or child.children
+            for child in self._document.children
+            )
 
     def to_stan(self, docstring_linker: DocstringLinker) -> Tag:
         # Inherit docs

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -618,7 +618,7 @@ def type2stan(obj: model.Documentable) -> Optional[Tag]:
     if parsed_type is None:
         return None
     else:
-        return parsed_type.to_stan(_EpydocLinker(obj)) # type: ignore[no-any-return]
+        return parsed_type.to_stan(_EpydocLinker(obj))
 
 def get_parsed_type(obj: model.Documentable) -> Optional[ParsedDocstring]:
     parsed_type: Optional[ParsedDocstring] = getattr(obj, 'parsed_type', None)

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -495,6 +495,8 @@ class Function(Inheritable):
 
 class Attribute(Inheritable):
     kind: Optional[str] = "Attribute"
+    annotation: Optional[ast.expr]
+    decorators: Optional[Sequence[ast.expr]]
 
 
 # Work around the attributes of the same name within the System class.

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -141,7 +141,7 @@ tr.class, tr.classvariable, tr.baseclassvariable {
     background-color: #fffde7;
 }
 
-tr.instancevariable, tr.baseinstancevariable, tr.variable, tr.attribute {
+tr.instancevariable, tr.baseinstancevariable, tr.variable, tr.attribute, tr.property {
     background-color: #f3e5f5;
 }
 

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -57,7 +57,10 @@ class FunctionChild(Element):
     @renderer
     def functionDef(self, request, tag):
         def_stmt = 'async def' if self.ob.is_async else 'def'
-        return [def_stmt, ' ', self.ob.name, signature(self.ob), ':']
+        name = self.ob.name
+        if name.endswith('.setter') or name.endswith('.deleter'):
+            name = name[:name.rindex('.')]
+        return [def_stmt, ' ', name, signature(self.ob), ':']
 
     @renderer
     def sourceLink(self, request, tag):

--- a/pydoctor/test/epydoc/test_restructuredtext.py
+++ b/pydoctor/test/epydoc/test_restructuredtext.py
@@ -10,6 +10,27 @@ def rst2html(s: str) -> str:
     assert not errors
     return flatten(parsed.to_stan(None))
 
+def test_rst_body_empty() -> None:
+    src = """
+    :return: a number
+    :rtype: int
+    """
+    errors: List[ParseError] = []
+    pdoc = parse_docstring(src, errors)
+    assert not errors
+    assert not pdoc.has_body
+    assert len(pdoc.fields) == 2
+
+def test_rst_body_nonempty() -> None:
+    src = """
+    Only body text, no fields.
+    """
+    errors: List[ParseError] = []
+    pdoc = parse_docstring(src, errors)
+    assert not errors
+    assert pdoc.has_body
+    assert len(pdoc.fields) == 0
+
 def test_rst_anon_link_target_missing() -> None:
     src = """
     This link's target is `not defined anywhere`__.

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -1168,13 +1168,32 @@ def test_property_decorator(systemcls: Type[model.System]) -> None:
         def prop(self) -> str:
             """For sale."""
             return 'seaside'
+        @property
+        def oldschool(self):
+            """
+            @return: For rent.
+            @rtype: string
+            @see: U{https://example.com/}
+            """
+            return 'downtown'
     ''', modname='test', systemcls=systemcls)
     C = mod.contents['C']
+
     prop = C.contents['prop']
     assert isinstance(prop, model.Attribute)
     assert prop.kind == 'Property'
     assert prop.docstring == """For sale."""
     assert type2str(prop.annotation) == 'str'
+
+    oldschool = C.contents['oldschool']
+    assert isinstance(oldschool, model.Attribute)
+    assert oldschool.kind == 'Property'
+    assert isinstance(oldschool.parsed_docstring, ParsedEpytextDocstring)
+    assert unwrap(oldschool.parsed_docstring) == """For rent."""
+    assert str(unwrap(oldschool.parsed_type)) == 'string'  # type: ignore[attr-defined]
+    fields = oldschool.parsed_docstring.fields
+    assert len(fields) == 1
+    assert fields[0].tag() == 'see'
 
 @pytest.mark.parametrize('decoration', ('classmethod', 'staticmethod'))
 @systemcls_param

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -62,6 +62,7 @@ def fromText(
 
 def unwrap(parsed_docstring: ParsedEpytextDocstring) -> str:
     epytext = parsed_docstring._tree
+    assert epytext is not None
     assert epytext.tag == 'epytext'
     assert len(epytext.children) == 1
     para = epytext.children[0]

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -9,7 +9,7 @@ from twisted.python._pydoctor import TwistedSystem
 from pydoctor import astbuilder, model
 from pydoctor.epydoc.markup import DocstringLinker, ParsedDocstring, flatten
 from pydoctor.epydoc.markup.epytext import ParsedEpytextDocstring
-from pydoctor.epydoc2stan import get_parsed_type
+from pydoctor.epydoc2stan import format_summary, get_parsed_type
 from pydoctor.zopeinterface import ZopeInterfaceSystem
 
 from . import CapSys, posonlyargs, typecomment
@@ -1190,6 +1190,7 @@ def test_property_decorator(systemcls: Type[model.System]) -> None:
     assert oldschool.kind == 'Property'
     assert isinstance(oldschool.parsed_docstring, ParsedEpytextDocstring)
     assert unwrap(oldschool.parsed_docstring) == """For rent."""
+    assert flatten(format_summary(oldschool)) == '<span>For rent.</span>'
     assert str(unwrap(oldschool.parsed_type)) == 'string'  # type: ignore[attr-defined]
     fields = oldschool.parsed_docstring.fields
     assert len(fields) == 1


### PR DESCRIPTION
There are a lot of different ways to implement and document properties. I tried to support the most common ones.

My personal favorite syntax:
```py
    class C:
        @property
        def prop(self) -> str:
            """For sale."""
            return 'seaside'
```

And a more traditional syntax, used in Twisted:
```py
class C:
        @property
        def oldschool(self):
            """
            @return: For rent.
            @rtype: L{str}
            """
            return 'downtown'
```

There is also support for `setter` and `deleter` methods, although that is very rudimentary: these methods are renamed to `<propname>.setter` and `<propname>.deleter` respectively and listed in the documentation as separate methods. Still, that is better than how they're handled today, which is overwriting the getter (since all accessor methods have the same name).

Please run this on your projects and check whether the output looks reasonable.

Fixes #233.
