### PR TITLE
Support custom property decorators

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -6,7 +6,9 @@ from functools import partial
 from inspect import Parameter, Signature
 from itertools import chain
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, Sequence, Tuple, Union
+from typing import (
+    Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple, Union
+)
 
 import astor
 from pydoctor import epydoc2stan, model
@@ -24,7 +26,7 @@ else:
     _parse = ast.parse
 
 
-def node2dottedname(node):
+def node2dottedname(node: Optional[ast.expr]) -> Optional[List[str]]:
     parts = []
     while isinstance(node, ast.Attribute):
         parts.append(node.attr)
@@ -41,7 +43,7 @@ def node2dottedname(node):
     return parts
 
 
-def node2fullname(expr, ctx):
+def node2fullname(expr: Optional[ast.expr], ctx: model.Documentable) -> Optional[str]:
     dottedname = node2dottedname(expr)
     if dottedname is None:
         return None

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -555,8 +555,10 @@ class ModuleVistor(ast.NodeVisitor):
             docstring: Optional[ast.Str],
             lineno: int
             ) -> model.Attribute:
+
         attr = self.builder.addAttribute(node.name, 'Property', self.builder.current)
         attr.setLineNumber(lineno)
+
         if docstring is not None:
             attr.setDocstring(docstring)
             assert attr.docstring is not None
@@ -576,9 +578,11 @@ class ModuleVistor(ast.NodeVisitor):
                     other_fields.append(field)
             pdoc.fields = other_fields
             attr.parsed_docstring = pdoc
+
         if node.returns is not None:
             attr.annotation = self._unstring_annotation(node.returns)
         attr.decorators = node.decorator_list
+
         return attr
 
     def _annotation_from_attrib(self,

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -496,7 +496,7 @@ class Function(Inheritable):
 class Attribute(Inheritable):
     kind: Optional[str] = "Attribute"
     annotation: Optional[ast.expr]
-    decorators: Optional[Sequence[ast.expr]]
+    decorators: Optional[Sequence[ast.expr]] = None
 
 
 # Work around the attributes of the same name within the System class.

--- a/pydoctor/templates/attribute-child.html
+++ b/pydoctor/templates/attribute-child.html
@@ -16,6 +16,7 @@
   </div>
   <div class="functionBody">
     <t:transparent t:render="functionExtras" />
+    <t:transparent t:render="functionDeprecated" />
     <t:transparent t:render="functionBody">
       Docstring.
     </t:transparent>

--- a/pydoctor/templates/attribute-child.html
+++ b/pydoctor/templates/attribute-child.html
@@ -7,6 +7,7 @@
     <t:attr name="name" t:render="shortFunctionAnchor" />
   </a>
   <div class="functionHeader">
+    <t:transparent t:render="decorator" />
     <t:transparent t:render="attribute">attribute</t:transparent> =
     <a class="functionSourceLink" t:render="sourceLink">
       <t:attr name="href"><t:slot name="sourceHref" /></t:attr>

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -18,7 +18,8 @@ def format_decorators(obj: Union[model.Function, model.Attribute]) -> Iterator[A
             fn = node2fullname(dec.func, obj)
             # We don't want to show the deprecated decorator;
             # it shows up as an infobox.
-            if fn == "twisted.python.deprecate.deprecated":
+            if fn in ("twisted.python.deprecate.deprecated",
+                      "twisted.python.deprecate.deprecatedProperty"):
                 break
 
         text = '@' + astor.to_source(dec).strip()

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -1,13 +1,28 @@
 """The classes that turn  L{Documentable} instances into objects we can render."""
 
-from typing import List, Optional, Union
+from typing import Any, Iterator, List, Optional, Union
+import ast
 
 from twisted.web.template import tags, Element, renderer, Tag, XMLFile
+import astor
 
 from pydoctor import epydoc2stan, model, __version__
+from pydoctor.astbuilder import node2fullname
 from pydoctor.templatewriter.pages.table import ChildTable
 from pydoctor.templatewriter import util
 
+
+def format_decorators(obj: Union[model.Function, model.Attribute]) -> Iterator[Any]:
+    for dec in obj.decorators or ():
+        if isinstance(dec, ast.Call):
+            fn = node2fullname(dec.func, obj)
+            # We don't want to show the deprecated decorator;
+            # it shows up as an infobox.
+            if fn == "twisted.python.deprecate.deprecated":
+                break
+
+        text = '@' + astor.to_source(dec).strip()
+        yield text, tags.br()
 
 def signature(function: model.Function) -> str:
     """Return a nicely-formatted source-like function signature."""

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -1,4 +1,4 @@
-from twisted.web.template import Element, XMLFile, renderer
+from twisted.web.template import Element, XMLFile, renderer, tags
 
 from pydoctor.templatewriter import util
 from pydoctor.templatewriter.pages import format_decorators
@@ -50,3 +50,10 @@ class AttributeChild(Element):
     @renderer
     def functionBody(self, request, tag):
         return self.docgetter.get(self.ob)
+
+    @renderer
+    def functionDeprecated(self, request, tag):
+        if hasattr(self.ob, "_deprecated_info"):
+            return (tags.div(self.ob._deprecated_info, role="alert", class_="deprecationNotice alert alert-warning"),)
+        else:
+            return ()

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -1,5 +1,7 @@
-from pydoctor.templatewriter import util
 from twisted.web.template import Element, XMLFile, renderer
+
+from pydoctor.templatewriter import util
+from pydoctor.templatewriter.pages import format_decorators
 
 
 class AttributeChild(Element):
@@ -25,6 +27,10 @@ class AttributeChild(Element):
     @renderer
     def shortFunctionAnchor(self, request, tag):
         return self.ob.name
+
+    @renderer
+    def decorator(self, request, tag):
+        return list(format_decorators(self.ob))
 
     @renderer
     def attribute(self, request, tag):

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -1,10 +1,7 @@
-import ast
-
-import astor
-from pydoctor.astbuilder import node2fullname
-from pydoctor.templatewriter import util
-from pydoctor.templatewriter.pages import signature
 from twisted.web.template import Element, XMLFile, renderer, tags
+
+from pydoctor.templatewriter import util
+from pydoctor.templatewriter.pages import format_decorators, signature
 
 
 class FunctionChild(Element):
@@ -33,26 +30,7 @@ class FunctionChild(Element):
 
     @renderer
     def decorator(self, request, tag):
-
-        decorators = []
-
-        if self.ob.decorators:
-            for dec in self.ob.decorators:
-                if isinstance(dec, ast.Call):
-                    fn = node2fullname(dec.func, self.ob)
-                    # We don't want to show the deprecated decorator;
-                    # it shows up as an infobox.
-                    if fn == "twisted.python.deprecate.deprecated":
-                        break
-
-                decorators.append(astor.to_source(dec).strip())
-
-        if decorators:
-            decorator = [('@' + dec, tags.br()) for dec in decorators]
-        else:
-            decorator = ()
-
-        return decorator
+        return list(format_decorators(self.ob))
 
     @renderer
     def functionDef(self, request, tag):

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -1,6 +1,7 @@
 import ast
 
 import astor
+from pydoctor.astbuilder import node2fullname
 from pydoctor.templatewriter import util
 from pydoctor.templatewriter.pages import signature
 from twisted.web.template import Element, XMLFile, renderer, tags
@@ -38,12 +39,11 @@ class FunctionChild(Element):
         if self.ob.decorators:
             for dec in self.ob.decorators:
                 if isinstance(dec, ast.Call):
-                    if isinstance(dec.func, ast.Name):
-                        fn = self.ob.expandName(dec.func.id)
-                        # We don't want to show the deprecated decorator, it shows up
-                        # as an infobox
-                        if fn == "twisted.python.deprecate.deprecated":
-                            break
+                    fn = node2fullname(dec.func, self.ob)
+                    # We don't want to show the deprecated decorator;
+                    # it shows up as an infobox.
+                    if fn == "twisted.python.deprecate.deprecated":
+                        break
 
                 decorators.append(astor.to_source(dec).strip())
 


### PR DESCRIPTION
Twisted has `@deprecatedProperty`, Django has `@cached_property` and I also found [`@async_property`](https://pypi.org/project/async-property/) when wondering whether `async def` functions could be properties.

So there are many decorators that act similar to properties. I figured it would be useful to support them all, simply by treating all decorations with names ending in "property" as property definitions.

Besides that, there is a commit to make sure that if `@deprecatedProperty` sets deprecation info on a property (this requires a change in Twisted's customizations), the deprecation notice will actually end  up in the output.

Fixes #238.