### PR TITLE
Support 'type' field in inline docstrings

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -585,7 +585,7 @@ class ModuleVistor(ast.NodeVisitor):
                         # empty-body docstring.
                         attr.docstring = ''
                 elif tag == 'rtype':
-                    attr.parsed_type = field.body() # type: ignore[attr-defined]
+                    attr.parsed_type = field.body()
                 else:
                     other_fields.append(field)
             pdoc.fields = other_fields

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -763,7 +763,7 @@ def extract_fields(obj: model.Documentable) -> None:
                 obj.system.addObject(attrobj)
             attrobj.setLineNumber(obj.docstring_lineno + field.lineno)
             if tag == 'type':
-                attrobj.parsed_type = field.body() # type: ignore[attr-defined]
+                attrobj.parsed_type = field.body()
             else:
                 attrobj.parsed_docstring = field.body()
                 attrobj.kind = field_name_to_human_name[tag]

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -621,7 +621,7 @@ def type2stan(obj: model.Documentable) -> Optional[Tag]:
         return parsed_type.to_stan(_EpydocLinker(obj))
 
 def get_parsed_type(obj: model.Documentable) -> Optional[ParsedDocstring]:
-    parsed_type: Optional[ParsedDocstring] = getattr(obj, 'parsed_type', None)
+    parsed_type = obj.parsed_type
     if parsed_type is not None:
         return parsed_type
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -212,6 +212,7 @@ class Field:
             )
 
     def format(self) -> Tag:
+        """Present this field's body as HTML."""
         return self.body.to_stan(_EpydocLinker(self.source))
 
     def report(self, message: str) -> None:
@@ -321,7 +322,7 @@ class FieldHandler:
     def handle_type(self, field: Field) -> None:
         if isinstance(self.obj, model.Attribute):
             if field.arg is not None:
-                field.report('Field in inline docstring should not include a name')
+                field.report('Field in variable docstring should not include a name')
             self.obj.parsed_type = field.body
             return
         elif isinstance(self.obj, model.Function):

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -319,7 +319,12 @@ class FieldHandler:
         desc_list.append(FieldDesc(kind=field.tag, name=name, body=field.format()))
 
     def handle_type(self, field: Field) -> None:
-        if isinstance(self.obj, model.Function):
+        if isinstance(self.obj, model.Attribute):
+            if field.arg is not None:
+                field.report('Field in inline docstring should not include a name')
+            self.obj.parsed_type = field.body
+            return
+        elif isinstance(self.obj, model.Function):
             name = self._handle_param_name(field)
             if name is not None and name not in self.types and not any(
                     # Don't warn about keywords or about parameters we already

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -94,6 +94,7 @@ class Documentable:
     """
     docstring: Optional[str] = None
     parsed_docstring: Optional[ParsedDocstring] = None
+    parsed_type: ParsedDocstring
     docstring_lineno = 0
     linenumber = 0
     sourceHref: Optional[str] = None

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -94,7 +94,7 @@ class Documentable:
     """
     docstring: Optional[str] = None
     parsed_docstring: Optional[ParsedDocstring] = None
-    parsed_type: ParsedDocstring
+    parsed_type: Optional[ParsedDocstring] = None
     docstring_lineno = 0
     linenumber = 0
     sourceHref: Optional[str] = None

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -1191,7 +1191,8 @@ def test_property_decorator(systemcls: Type[model.System]) -> None:
     assert isinstance(oldschool.parsed_docstring, ParsedEpytextDocstring)
     assert unwrap(oldschool.parsed_docstring) == """For rent."""
     assert flatten(format_summary(oldschool)) == '<span>For rent.</span>'
-    assert str(unwrap(oldschool.parsed_type)) == 'string'  # type: ignore[attr-defined]
+    assert isinstance(oldschool.parsed_type, ParsedEpytextDocstring)
+    assert str(unwrap(oldschool.parsed_type)) == 'string'
     fields = oldschool.parsed_docstring.fields
     assert len(fields) == 1
     assert fields[0].tag() == 'see'

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -424,7 +424,7 @@ def test_unknown_field_name(capsys: CapSys) -> None:
 
 
 def test_inline_field_type(capsys: CapSys) -> None:
-    """The C{type} field in an inline docstring updates the C{parsed_type}
+    """The C{type} field in a variable docstring updates the C{parsed_type}
     of the Attribute it documents.
     """
     mod = fromText('''
@@ -443,8 +443,8 @@ def test_inline_field_type(capsys: CapSys) -> None:
 
 
 def test_inline_field_name(capsys: CapSys) -> None:
-    """Warn if a name is given for a C{type} field in an inline docstring.
-    An inline docstring only documents a single attribute, so the name is
+    """Warn if a name is given for a C{type} field in a variable docstring.
+    A variable docstring only documents a single variable, so the name is
     redundant at best and misleading at worst.
     """
     mod = fromText('''
@@ -458,7 +458,7 @@ def test_inline_field_name(capsys: CapSys) -> None:
     assert isinstance(a, model.Attribute)
     epydoc2stan.format_docstring(a)
     captured = capsys.readouterr().out
-    assert captured == "test:5: Field in inline docstring should not include a name\n"
+    assert captured == "test:5: Field in variable docstring should not include a name\n"
 
 
 def test_EpydocLinker_look_for_intersphinx_no_link() -> None:

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -6,8 +6,9 @@ from pytest import mark, raises
 
 from pydoctor import epydoc2stan, model
 from pydoctor.epydoc.markup import DocstringLinker, flatten
+from pydoctor.epydoc.markup.epytext import ParsedEpytextDocstring
 from pydoctor.sphinx import SphinxInventory
-from pydoctor.test.test_astbuilder import fromText
+from pydoctor.test.test_astbuilder import fromText, unwrap
 
 from . import CapSys
 
@@ -420,6 +421,44 @@ def test_unknown_field_name(capsys: CapSys) -> None:
     epydoc2stan.format_docstring(mod)
     captured = capsys.readouterr().out
     assert captured == "test:5: Unknown field 'zap'\n"
+
+
+def test_inline_field_type(capsys: CapSys) -> None:
+    """The C{type} field in an inline docstring updates the C{parsed_type}
+    of the Attribute it documents.
+    """
+    mod = fromText('''
+    a = 2
+    """
+    Variable documented by inline docstring.
+    @type: number
+    """
+    ''', modname='test')
+    a = mod.contents['a']
+    assert isinstance(a, model.Attribute)
+    epydoc2stan.format_docstring(a)
+    assert isinstance(a.parsed_type, ParsedEpytextDocstring)
+    assert str(unwrap(a.parsed_type)) == 'number'
+    assert not capsys.readouterr().out
+
+
+def test_inline_field_name(capsys: CapSys) -> None:
+    """Warn if a name is given for a C{type} field in an inline docstring.
+    An inline docstring only documents a single attribute, so the name is
+    redundant at best and misleading at worst.
+    """
+    mod = fromText('''
+    a = 2
+    """
+    Variable documented by inline docstring.
+    @type a: number
+    """
+    ''', modname='test')
+    a = mod.contents['a']
+    assert isinstance(a, model.Attribute)
+    epydoc2stan.format_docstring(a)
+    captured = capsys.readouterr().out
+    assert captured == "test:5: Field in inline docstring should not include a name\n"
 
 
 def test_EpydocLinker_look_for_intersphinx_no_link() -> None:


### PR DESCRIPTION
I noticed something odd on the [documentation page I linked in #320](https://pydoctor--320.org.readthedocs.build/en/320/api/pydoctor.epydoc.markup.epytext.Element.html): the `@type` tags in the summary. These are the result of a known issue though (#86). However, the type documentation was also missing from from the blocks in which `tag`, `children` and `attribs` are documented in detail and that could not be explained by the way the summary is parsed, since those blocks are parsed from the full docstring.

It turns out that the handling of the `type` field ignored any entry without a name. This makes sense for functions, where we cannot use the type if we cannot match it to a parameter, so there we report a warning and then discard the type.

But when an attribute is documented by an inline docstring, no name is required, since an inline docstring by definition only applies to a single documentable. So discarding the type was incorrect there.

I don't know whether this is a regression as a result of the parameter annotation work or whether it never worked, but I don't feel like doing code archeology right now. I think it would be good to fix it before release in either case.

[Output after the fix.](https://pydoctor--322.org.readthedocs.build/en/322/api/pydoctor.epydoc.markup.epytext.Element.html)