### PR TITLE
Avoid methods being classified as variables

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -329,27 +329,27 @@ class ModuleVistor(ast.NodeVisitor):
         if not self._handleAliasing(target, expr):
             self._handleModuleVar(target, annotation, lineno)
 
-    def _handleClassVar(self, target, annotation, lineno):
+    def _handleClassVar(self, name: str, annotation: Optional[ast.expr], lineno: int) -> None:
         parent = self.builder.current
-        obj = parent.contents.get(target)
+        obj = parent.contents.get(name)
         if not isinstance(obj, model.Attribute):
-            obj = self.builder.addAttribute(target, None, parent)
+            obj = self.builder.addAttribute(name, None, parent)
         if obj.kind is None:
             obj.kind = 'Class Variable'
         obj.annotation = annotation
         obj.setLineNumber(lineno)
         self.newAttr = obj
 
-    def _handleInstanceVar(self, target, annotation, lineno):
+    def _handleInstanceVar(self, name: str, annotation: Optional[ast.expr], lineno: int) -> None:
         func = self.builder.current
         if not isinstance(func, model.Function):
             return
         cls = func.parent
         if not isinstance(cls, model.Class):
             return
-        obj = cls.contents.get(target)
+        obj = cls.contents.get(name)
         if obj is None:
-            obj = self.builder.addAttribute(target, None, cls)
+            obj = self.builder.addAttribute(name, None, cls)
         if isinstance(obj, model.Attribute):
             obj.kind = 'Instance Variable'
             obj.annotation = annotation

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -330,10 +330,10 @@ class ModuleVistor(ast.NodeVisitor):
             self._handleModuleVar(target, annotation, lineno)
 
     def _handleClassVar(self, name: str, annotation: Optional[ast.expr], lineno: int) -> None:
-        parent = self.builder.current
-        obj = parent.contents.get(name)
+        cls = self.builder.current
+        obj = cls.contents.get(name)
         if not isinstance(obj, model.Attribute):
-            obj = self.builder.addAttribute(name, None, parent)
+            obj = self.builder.addAttribute(name, None, cls)
         if obj.kind is None:
             obj.kind = 'Class Variable'
         obj.annotation = annotation
@@ -350,11 +350,12 @@ class ModuleVistor(ast.NodeVisitor):
         obj = cls.contents.get(name)
         if obj is None:
             obj = self.builder.addAttribute(name, None, cls)
-        if isinstance(obj, model.Attribute):
-            obj.kind = 'Instance Variable'
-            obj.annotation = annotation
-            obj.setLineNumber(lineno)
-            self.newAttr = obj
+        elif not isinstance(obj, model.Attribute):
+            return
+        obj.kind = 'Instance Variable'
+        obj.annotation = annotation
+        obj.setLineNumber(lineno)
+        self.newAttr = obj
 
     def _handleAssignmentInClass(self, target, annotation, expr, lineno):
         if not self._handleAliasing(target, expr):

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -329,10 +329,23 @@ class ModuleVistor(ast.NodeVisitor):
         if not self._handleAliasing(target, expr):
             self._handleModuleVar(target, annotation, lineno)
 
+    def _maybeAttribute(self, cls: model.Class, name: str) -> bool:
+        """Check whether a name is a potential attribute of the given class.
+        This is used to prevent an assignment that wraps a method from
+        creating an attribute that would overwrite or shadow that method.
+
+        @return: L{True} if the name does not exist or is an existing (possibly
+            inherited) attribute, L{False} otherwise
+        """
+        obj = cls.find(name)
+        return obj is None or isinstance(obj, model.Attribute)
+
     def _handleClassVar(self, name: str, annotation: Optional[ast.expr], lineno: int) -> None:
         cls = self.builder.current
+        if not self._maybeAttribute(cls, name):
+            return
         obj = cls.contents.get(name)
-        if not isinstance(obj, model.Attribute):
+        if obj is None:
             obj = self.builder.addAttribute(name, None, cls)
         if obj.kind is None:
             obj.kind = 'Class Variable'
@@ -347,11 +360,11 @@ class ModuleVistor(ast.NodeVisitor):
         cls = func.parent
         if not isinstance(cls, model.Class):
             return
+        if not self._maybeAttribute(cls, name):
+            return
         obj = cls.contents.get(name)
         if obj is None:
             obj = self.builder.addAttribute(name, None, cls)
-        elif not isinstance(obj, model.Attribute):
-            return
         obj.kind = 'Instance Variable'
         obj.annotation = annotation
         obj.setLineNumber(lineno)

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -466,10 +466,9 @@ class Class(CanContainImportsDocumentable):
         # We assume that the constructor parameters are the same as the
         # __init__() parameters. This is incorrect if __new__() or the class
         # call have different parameters.
-        for base in self.allbases(include_self=True):
-            init = base.contents.get('__init__')
-            if isinstance(init, Function):
-                return init.annotations
+        init = self.find('__init__')
+        if isinstance(init, Function):
+            return init.annotations
         else:
             return {}
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -437,6 +437,17 @@ class Class(CanContainImportsDocumentable):
             if b is not None:
                 yield from b.allbases(True)
 
+    def find(self, name: str) -> Optional[Documentable]:
+        """Look up a name in this class and its base classes.
+
+        @return: the object with the given name, or L{None} if there isn't one
+        """
+        for base in self.allbases(include_self=True):
+            obj: Optional[Documentable] = base.contents.get(name)
+            if obj is not None:
+                return obj
+        return None
+
     def _localNameToFullName(self, name: str) -> str:
         if name in self.contents:
             o: Documentable = self.contents[name]

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -552,41 +552,61 @@ def test_methoddecorator(systemcls: Type[model.System], capsys: CapSys) -> None:
 def test_assignment_to_method_in_class(systemcls: Type[model.System]) -> None:
     """An assignment to a method in a class body does not change the type
     of the documentable.
+
+    If the name we assign to exists and it does not belong to an Attribute
+    (it's a Function instead, in this test case), the assignment will be
+    ignored.
     """
     mod = fromText('''
     class Base:
-        def base_method(): ...
+        def base_method():
+            """Base method docstring."""
 
     class Sub(Base):
         base_method = wrap_method(base_method)
+        """Overriding the docstring is not supported."""
 
-        def sub_method(): ...
+        def sub_method():
+            """Sub method docstring."""
         sub_method = wrap_method(sub_method)
+        """Overriding the docstring is not supported."""
     ''', systemcls=systemcls)
     assert isinstance(mod.contents['Base'].contents['base_method'], model.Function)
     assert mod.contents['Sub'].contents.get('base_method') is None
-    assert isinstance(mod.contents['Sub'].contents['sub_method'], model.Function)
+    sub_method = mod.contents['Sub'].contents['sub_method']
+    assert isinstance(sub_method, model.Function)
+    assert sub_method.docstring == """Sub method docstring."""
 
 
 @systemcls_param
 def test_assignment_to_method_in_init(systemcls: Type[model.System]) -> None:
     """An assignment to a method inside __init__() does not change the type
     of the documentable.
+
+    If the name we assign to exists and it does not belong to an Attribute
+    (it's a Function instead, in this test case), the assignment will be
+    ignored.
     """
     mod = fromText('''
     class Base:
-        def base_method(): ...
+        def base_method():
+            """Base method docstring."""
 
     class Sub(Base):
-        def sub_method(): ...
+        def sub_method():
+            """Sub method docstring."""
 
         def __init__(self):
             self.base_method = wrap_method(self.base_method)
+            """Overriding the docstring is not supported."""
             self.sub_method = wrap_method(self.sub_method)
+            """Overriding the docstring is not supported."""
     ''', systemcls=systemcls)
     assert isinstance(mod.contents['Base'].contents['base_method'], model.Function)
     assert mod.contents['Sub'].contents.get('base_method') is None
-    assert isinstance(mod.contents['Sub'].contents['sub_method'], model.Function)
+    sub_method = mod.contents['Sub'].contents['sub_method']
+    assert isinstance(sub_method, model.Function)
+    assert sub_method.docstring == """Sub method docstring."""
 
 
 @systemcls_param

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -549,6 +549,47 @@ def test_methoddecorator(systemcls: Type[model.System], capsys: CapSys) -> None:
 
 
 @systemcls_param
+def test_assignment_to_method_in_class(systemcls: Type[model.System]) -> None:
+    """An assignment to a method in a class body does not change the type
+    of the documentable.
+    """
+    mod = fromText('''
+    class Base:
+        def base_method(): ...
+
+    class Sub(Base):
+        base_method = wrap_method(base_method)
+
+        def sub_method(): ...
+        sub_method = wrap_method(sub_method)
+    ''', systemcls=systemcls)
+    assert isinstance(mod.contents['Base'].contents['base_method'], model.Function)
+    assert mod.contents['Sub'].contents.get('base_method') is None
+    assert isinstance(mod.contents['Sub'].contents['sub_method'], model.Function)
+
+
+@systemcls_param
+def test_assignment_to_method_in_init(systemcls: Type[model.System]) -> None:
+    """An assignment to a method inside __init__() does not change the type
+    of the documentable.
+    """
+    mod = fromText('''
+    class Base:
+        def base_method(): ...
+
+    class Sub(Base):
+        def sub_method(): ...
+
+        def __init__(self):
+            self.base_method = wrap_method(self.base_method)
+            self.sub_method = wrap_method(self.sub_method)
+    ''', systemcls=systemcls)
+    assert isinstance(mod.contents['Base'].contents['base_method'], model.Function)
+    assert mod.contents['Sub'].contents.get('base_method') is None
+    assert isinstance(mod.contents['Sub'].contents['sub_method'], model.Function)
+
+
+@systemcls_param
 def test_import_star(systemcls: Type[model.System]) -> None:
     mod_a = fromText('''
     def f(): pass

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -160,6 +160,8 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             interface = self.builder.pushClass(target, lineno)
             interface.isinterface = True
             interface.implementedby_directly = []
+            interface.bases = []
+            interface.baseobjects = []
             self.builder.popClass()
             self.newAttr = interface
 

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -179,7 +179,9 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
 
         if not isinstance(expr, ast.Call):
             return
-        attr = self.builder.current.contents[target]
+        attr = self.builder.current.contents.get(target)
+        if attr is None:
+            return
         funcName = self.funcNameFromCall(expr)
         if funcName is None:
             return


### PR DESCRIPTION
Fixes for the incorrect classifications that cause warnings in Twisted in PR #322. See that PR for code examples that pydoctor handled incorrectly.

When an assignment wraps a method, that assignment would create an `Attribute` object in the code model. Then when documenting that object, the docstring was inherited from a method and pydoctor would warn that fields like `@type name: str` don't need a parameter name when attached to a variable (`Attribute`).

The solution I picked is that before creating an `Attribute`, pydoctor will check whether the name already exists in the class itself or through inheritance. If the name exists and it does not belong to an `Attribute` (because it's a `Function` instead, for example), the assignment will be ignored. I think this solution is good enough for now and it solves all the false positive warnings in Twisted.

One thing to revisit later is whether `Class.allbases()` uses the correct method resolution order. But the current implementation seems to be good enough for Twisted at least.

Another thing we could consider is whether it is useful to be able to place a docstring after a wrapped method. I don't see an immediate use for it, but there might be. For now, I picked the safer option of ignoring the assignment completely, so if a docstring follows it, that will be ignored as well.
