### PR TITLE
Avoid crashes where relative_to() raises ValueError

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -17,8 +17,10 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
         os: [ubuntu-20.04]
         include:
-        - os: windows-latest
-        - python-version: 3.6
+          - os: windows-latest
+            python-version: 3.6
+          - os: macos-latest
+            python-version: 3.6
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,12 @@ You can select a different format using the ``--docformat`` option.
 What's New?
 ~~~~~~~~~~~
 
+pydoctor 20.12.1 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Reject source directories outside the project base directory (if given), instead of crashing
+* Fixed bug where source directories containing symbolic links could appear to be outside of the project base directory, leading to a crash
+
 pydoctor 20.12.0
 ^^^^^^^^^^^^^^^^
 

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -53,17 +53,25 @@ def findClassFromDottedName(
 
 MAKE_HTML_DEFAULT = object()
 
-def parse_path(option: Option, opt: str, value: str) -> Path:
-    """Parse a path value given to an option to a L{Path} object.
+def resolve_path(path: str) -> Path:
+    """Parse a given path string to a L{Path} object.
+
     The path is converted to an absolute path, as required by
     L{System.setSourceHref()}.
     The path does not need to exist.
     """
+
+    # We explicitly make the path relative to the current working dir
+    # because on Windows resolve() does not produce an absolute path
+    # when operating on a non-existing path.
+    return Path(Path.cwd(), path).resolve()
+
+def parse_path(option: Option, opt: str, value: str) -> Path:
+    """Parse a path value given to an option to a L{Path} object
+    using L{resolve_path()}.
+    """
     try:
-        # We explicitly make the path relative to the current working dir
-        # because on Windows resolve() does not produce an absolute path
-        # when operating on a non-existing path.
-        return Path(Path.cwd(), value).resolve()
+        return resolve_path(value)
     except Exception as ex:
         raise OptionValueError(f"{opt}: invalid path: {ex}")
 
@@ -331,17 +339,17 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
                     initmodule = system.Module(system, '__init__', prependedpackage)
                     system.addObject(initmodule)
             added_paths = set()
-            for path in args:
-                path = os.path.abspath(path)
+            for arg in args:
+                path = resolve_path(arg)
                 if path in added_paths:
                     continue
-                if os.path.isdir(path):
-                    system.msg('addPackage', 'adding directory ' + path)
-                    system.addPackage(path, prependedpackage)
-                elif os.path.isfile(path):
-                    system.msg('addModuleFromPath', 'adding module ' + path)
-                    system.addModuleFromPath(prependedpackage, path)
-                elif os.path.exists(path):
+                if path.is_dir():
+                    system.msg('addPackage', f"adding directory {path}")
+                    system.addPackage(str(path), prependedpackage)
+                elif path.is_file():
+                    system.msg('addModuleFromPath', f"adding module {path}")
+                    system.addModuleFromPath(prependedpackage, str(path))
+                elif path.exists():
                     error(f"Source path is neither file nor directory: {path}")
                 else:
                     error(f"Source path does not exist: {path}")

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -343,6 +343,13 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
                 path = resolve_path(arg)
                 if path in added_paths:
                     continue
+                if options.projectbasedirectory is not None:
+                    # Note: Path.is_relative_to() was only added in Python 3.9,
+                    #       so we have to use this workaround for now.
+                    try:
+                        path.relative_to(options.projectbasedirectory)
+                    except ValueError as ex:
+                        error(f"Source path lies outside base directory: {ex}")
                 if path.is_dir():
                     system.msg('addPackage', f"adding directory {path}")
                     system.addPackage(str(path), prependedpackage)

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -173,3 +173,20 @@ def test_main_return_non_zero_on_warnings() -> None:
     assert exit_code == 3
     assert "__init__.py:8: Unknown field 'bad_field'" in stream.getvalue()
     assert 'report_module.py:9: Cannot find link target for "BadLink"' in stream.getvalue()
+
+
+def test_main_symlinked_paths(tmp_path: Path) -> None:
+    """
+    The project base directory and package/module directories are normalized
+    in the same way, such that System.setSourceHref() can call Path.relative_to()
+    on them.
+    """
+    link = tmp_path / 'src'
+    link.symlink_to(Path.cwd(), target_is_directory=True)
+
+    exit_code = driver.main(args=[
+        '--project-base-dir=.',
+        '--html-viewsource-base=http://example.com',
+        f'{link}/pydoctor/test/testpackages/basic/'
+        ])
+    assert exit_code == 0

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -3,6 +3,8 @@ from io import StringIO
 from pathlib import Path
 import sys
 
+from pytest import raises
+
 from pydoctor import driver
 
 from . import CapSys
@@ -190,3 +192,16 @@ def test_main_symlinked_paths(tmp_path: Path) -> None:
         f'{link}/pydoctor/test/testpackages/basic/'
         ])
     assert exit_code == 0
+
+
+def test_main_source_outside_basedir(capsys: CapSys) -> None:
+    """
+    If a --project-base-dir is given, all package and module paths must
+    be located inside that base directory.
+    """
+    with raises(SystemExit):
+        driver.main(args=[
+            '--project-base-dir=docs',
+            'pydoctor/test/testpackages/basic/'
+            ])
+    assert "Source path lies outside base directory:" in capsys.readouterr().err

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -64,6 +64,22 @@ def test_projectbasedir_absolute(tmp_path: Path) -> None:
     assert options.projectbasedirectory.is_absolute()
 
 
+def test_projectbasedir_symlink(tmp_path: Path) -> None:
+    """
+    The --project-base-dir option, when given a path containing a symbolic link,
+    should resolve the path to the target directory.
+    """
+    target = tmp_path / 'target'
+    target.mkdir()
+    link = tmp_path / 'link'
+    link.symlink_to('target', target_is_directory=True)
+    assert link.samefile(target)
+
+    options, args = driver.parse_args(["--project-base-dir", str(link)])
+    assert options.projectbasedirectory.samefile(target)
+    assert options.projectbasedirectory.is_absolute()
+
+
 def test_projectbasedir_relative() -> None:
     """
     The --project-base-dir option, when given a relative path, should convert


### PR DESCRIPTION
Twisted's pydoctor tests failed on macOS when computing a relative path. The problem seems to be caused by symbolic links in the source path leading to a mismatch between the absolute source path and the absolute project base directory, since both are converted to absolute paths in different ways. So while macOS had the right circumstances to trigger this bug in the default test setup, the bug itself can occur on all platforms.