### PR TITLE
Bring back package source link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ pydoctor 20.12.1 (unreleased)
 
 * Reject source directories outside the project base directory (if given), instead of crashing
 * Fixed bug where source directories containing symbolic links could appear to be outside of the project base directory, leading to a crash
+* Bring back source link on package pages
 
 pydoctor 20.12.0
 ^^^^^^^^^^^^^^^^

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -353,6 +353,9 @@ class Package(Documentable):
     def doctarget(self) -> Documentable:
         return self.contents['__init__'] # type: ignore[no-any-return]
     @property
+    def sourceHref(self) -> Optional[str]: # type: ignore[override]
+        return self.module.sourceHref
+    @property
     def module(self) -> 'Module':
         return self.contents['__init__'] # type: ignore[no-any-return]
     @property

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -21,7 +21,7 @@ class FakeOptions:
     """
     sourcehref = None
     projectbasedirectory: Path
-
+    docformat = 'epytext'
 
 
 class FakeDocumentable:
@@ -57,6 +57,31 @@ def test_setSourceHrefOption(projectBaseDir: Path) -> None:
     system.setSourceHref(mod, projectBaseDir / "package" / "module.py")
 
     assert mod.sourceHref == "http://example.org/trac/browser/trunk/package/module.py"
+
+
+def test_package_sourceHref() -> None:
+    """
+    A package reports its __init__.py location as its source link.
+    """
+
+    project_dir = Path("/foo/bar/ProjectName")
+
+    options = FakeOptions()
+    options.projectbasedirectory = project_dir
+
+    system = model.System()
+    system.ensurePackage('pkg')
+    system.sourcebase = "https://git.example.org/proj/main"
+    system.options = cast(Values, options)
+
+    mod_init = fromText('''
+    """Docstring."""
+    ''', modname='__init__', parent_name='pkg', system=system)
+    system.setSourceHref(mod_init, project_dir / 'src' / 'pkg' / '__init__.py')
+
+    package = system.objForFullName('pkg')
+    assert isinstance(package, model.Package)
+    assert package.sourceHref == "https://git.example.org/proj/main/src/pkg/__init__.py"
 
 
 def test_initialization_default() -> None:


### PR DESCRIPTION
Modules had a source link, but it was missing on packages, since I removed the call that stored the URL when cleaning up the code a few weeks ago.

Instead of storing the URL, we now fetch it from the `__init__` module; the package and the module should really be the same thing, but they're currently implemented as separate Documentables.

I also added a unit test.
