### PR TITLE
Fixes, cleanups and type annotations for zope.interface support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,9 @@ source =
 
 [report]
 exclude_lines =
+    # Manually marked:
+    pragma: no cover
+
     # Intended to be unreachable:
     raise NotImplementedError$
     raise NotImplementedError\(

--- a/mypy.ini
+++ b/mypy.ini
@@ -31,9 +31,6 @@ disallow_untyped_defs=False
 [mypy-pydoctor.templatewriter.*]
 disallow_untyped_defs=False
 
-[mypy-pydoctor.zopeinterface]
-disallow_untyped_defs=False
-
 # The following external libraries don't support annotations (yet):
 
 [mypy-appdirs.*]

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -116,21 +116,12 @@ class ModuleVistor(ast.NodeVisitor):
             cls.setDocstring(node.body[0].value)
             epydoc2stan.extract_fields(cls)
 
-        def node2data(node):
-            dotted_name = node2dottedname(node)
-            if dotted_name is None:
-                return None
-            dotted_name = '.'.join(dotted_name)
-            full_name = self.builder.current.expandName(dotted_name)
-            obj = self.system.objForFullName(full_name)
-            return (dotted_name, full_name, obj)
-
         if node.decorator_list:
             for decnode in node.decorator_list:
                 if isinstance(decnode, ast.Call):
                     args = []
                     for arg in decnode.args:
-                        args.append(node2data(arg))
+                        args.append(node2fullname(arg, self.builder.current))
                     base = node2fullname(decnode.func, self.builder.current)
                 else:
                     base = node2fullname(decnode, self.builder.current)

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -135,7 +135,13 @@ class ModuleVistor(ast.NodeVisitor):
                 else:
                     base = node2data(decnode)
                     args = None
-                cls.decorators.append((base, args))
+                if base is None:  # pragma: no cover
+                    # There are expressions for which node2data() returns None,
+                    # but I cannot find any that don't lead to a SyntaxError
+                    # when used in a decorator.
+                    cls.report("cannot make sense of class decorator")
+                else:
+                    cls.decorators.append((base, args))
         cls.raw_decorators = node.decorator_list if node.decorator_list else []
 
         for b in cls.baseobjects:

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -82,7 +82,7 @@ class ModuleVistor(ast.NodeVisitor):
         # Ignore classes within functions.
         parent = self.builder.current
         if isinstance(parent, model.Function):
-            return
+            return None
 
         rawbases = []
         bases = []
@@ -140,6 +140,8 @@ class ModuleVistor(ast.NodeVisitor):
                 b.subclasses.append(cls)
         self.default(node)
         self.builder.popClass()
+
+        return cls
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         if not isinstance(self.builder.current, model.CanContainImportsDocumentable):

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -131,9 +131,9 @@ class ModuleVistor(ast.NodeVisitor):
                     args = []
                     for arg in decnode.args:
                         args.append(node2data(arg))
-                    base = node2data(decnode.func)
+                    base = node2fullname(decnode.func, self.builder.current)
                 else:
-                    base = node2data(decnode)
+                    base = node2fullname(decnode, self.builder.current)
                     args = None
                 if base is None:  # pragma: no cover
                     # There are expressions for which node2data() returns None,

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -121,10 +121,10 @@ class ModuleVistor(ast.NodeVisitor):
                 if isinstance(decnode, ast.Call):
                     args = []
                     for arg in decnode.args:
-                        args.append(node2fullname(arg, self.builder.current))
-                    base = node2fullname(decnode.func, self.builder.current)
+                        args.append(node2fullname(arg, parent))
+                    base = node2fullname(decnode.func, parent)
                 else:
-                    base = node2fullname(decnode, self.builder.current)
+                    base = node2fullname(decnode, parent)
                     args = None
                 if base is None:  # pragma: no cover
                     # There are expressions for which node2data() returns None,

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -427,6 +427,10 @@ class Class(CanContainImportsDocumentable):
     parent: CanContainImportsDocumentable
     bases: List[str]
     baseobjects: List[Optional['Class']]
+    decorators: Sequence[Tuple[
+        Tuple[str, str, Optional[Documentable]],
+        Optional[Sequence[Optional[Tuple[str, str, Optional[Documentable]]]]]
+        ]]
 
     def setup(self) -> None:
         super().setup()

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -428,7 +428,7 @@ class Class(CanContainImportsDocumentable):
     bases: List[str]
     baseobjects: List[Optional['Class']]
     decorators: Sequence[Tuple[
-        Tuple[str, str, Optional[Documentable]],
+        str,
         Optional[Sequence[Optional[Tuple[str, str, Optional[Documentable]]]]]
         ]]
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -427,10 +427,7 @@ class Class(CanContainImportsDocumentable):
     parent: CanContainImportsDocumentable
     bases: List[str]
     baseobjects: List[Optional['Class']]
-    decorators: Sequence[Tuple[
-        str,
-        Optional[Sequence[Optional[Tuple[str, str, Optional[Documentable]]]]]
-        ]]
+    decorators: Sequence[Tuple[str, Optional[Sequence[str]]]]
 
     def setup(self) -> None:
         super().setup()

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -500,8 +500,7 @@ def test_classdecorator(systemcls: Type[model.System]) -> None:
         pass
     ''', modname='mod', systemcls=systemcls)
     C = mod.contents['C']
-    assert C.decorators == [(('cd', 'mod.cd', mod.contents['cd']), None)], \
-      C.decorators
+    assert C.decorators == [('mod.cd', None)]
 
 
 @systemcls_param
@@ -513,11 +512,9 @@ def test_classdecorator_with_args(systemcls: Type[model.System]) -> None:
     class C:
         pass
     ''', modname='test', systemcls=systemcls)
-    cd = mod.contents['cd']
     A = mod.contents['A']
     C = mod.contents['C']
-    assert C.decorators == [(('cd', 'test.cd', cd), [('A', 'test.A', A)])], \
-      C.decorators
+    assert C.decorators == [('test.cd', [('A', 'test.A', A)])]
 
 
 @systemcls_param

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -512,9 +512,8 @@ def test_classdecorator_with_args(systemcls: Type[model.System]) -> None:
     class C:
         pass
     ''', modname='test', systemcls=systemcls)
-    A = mod.contents['A']
     C = mod.contents['C']
-    assert C.decorators == [('test.cd', [('A', 'test.A', A)])]
+    assert C.decorators == [('test.cd', ['test.A'])]
 
 
 @systemcls_param

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -365,3 +365,19 @@ def test_implementer_plainclass(capsys: CapSys) -> None:
     assert impl.implements_directly == ['mod.C']
     captured = capsys.readouterr().out
     assert captured == "mod:5: probable interface mod.C not marked as such\n"
+
+def test_classimplements_badarg(capsys: CapSys) -> None:
+    """
+    Report a warning when the arguments to classImplements() don't make sense.
+    """
+    src = '''
+    from zope.interface import Interface, classImplements
+    class IBar(Interface):
+        pass
+    def f():
+        pass
+    classImplements(f, IBar)
+    '''
+    fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
+    captured = capsys.readouterr().out
+    assert captured == 'mod:7: argument "mod.f" to classImplements() is not a class\n'

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -377,7 +377,11 @@ def test_classimplements_badarg(capsys: CapSys) -> None:
     def f():
         pass
     classImplements(f, IBar)
+    classImplements(g, IBar)
     '''
     fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
     captured = capsys.readouterr().out
-    assert captured == 'mod:7: argument "mod.f" to classImplements() is not a class\n'
+    assert captured == (
+        'mod:7: argument "mod.f" to classImplements() is not a class\n'
+        'mod:8: argument "g" to classImplements() not found\n'
+        )

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -376,12 +376,14 @@ def test_classimplements_badarg(capsys: CapSys) -> None:
         pass
     def f():
         pass
+    classImplements()
     classImplements(f, IBar)
     classImplements(g, IBar)
     '''
     fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
     captured = capsys.readouterr().out
     assert captured == (
-        'mod:7: argument "mod.f" to classImplements() is not a class\n'
-        'mod:8: argument "g" to classImplements() not found\n'
+        'mod:7: required argument to classImplements() missing\n'
+        'mod:8: argument "mod.f" to classImplements() is not a class\n'
+        'mod:9: argument "g" to classImplements() not found\n'
         )

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -87,9 +87,7 @@ def implements_test(src: str) -> None:
     assert onlybar.allImplementedInterfaces == ['zi.IBar']
 
     assert ifoo.implementedby_directly == [foo]
-    assert ifoo.allImplementations == [foo, foobar]
     assert ibar.implementedby_directly == [foobar, onlybar]
-    assert ibar.allImplementations == [foobar, onlybar]
 
 
 def test_subclass_with_same_name() -> None:
@@ -304,7 +302,10 @@ def test_docsources_from_moduleprovides() -> None:
 def test_interfaceallgames() -> None:
     system = processPackage('interfaceallgames', systemcls=ZopeInterfaceSystem)
     mod = system.allobjects['interfaceallgames.interface']
-    assert [o.fullName() for o in mod.contents['IAnInterface'].allImplementations] == ['interfaceallgames.implementation.Implementation']
+    iface = mod.contents['IAnInterface']
+    assert [o.fullName() for o in iface.implementedby_directly] == [
+        'interfaceallgames.implementation.Implementation'
+        ]
 
 def test_implementer_with_none() -> None:
     """

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -366,6 +366,20 @@ def test_implementer_plainclass(capsys: CapSys) -> None:
     captured = capsys.readouterr().out
     assert captured == "mod:5: probable interface mod.C not marked as such\n"
 
+def test_implementer_nocall(capsys: CapSys) -> None:
+    """
+    Report a warning when @implementer is used without calling it.
+    """
+    src = '''
+    import zope.interface
+    @zope.interface.implementer
+    class C:
+        pass
+    '''
+    fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
+    captured = capsys.readouterr().out
+    assert captured == "mod:3: @implementer requires arguments\n"
+
 def test_classimplements_badarg(capsys: CapSys) -> None:
     """
     Report a warning when the arguments to classImplements() don't make sense.

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -266,11 +266,10 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
                                 funcName == 'zope.interface.classImplementsOnly')
     visit_Call_zope_interface_classImplementsOnly = visit_Call_zope_interface_classImplements
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        super().visit_ClassDef(node)
-        cls = self.builder.current.contents.get(node.name)
+    def visit_ClassDef(self, node: ast.ClassDef) -> Optional[ZopeInterfaceClass]:
+        cls = super().visit_ClassDef(node)
         if cls is None:
-            return
+            return None
         assert isinstance(cls, ZopeInterfaceClass)
 
         bases = [self.builder.current.expandName(base) for base in cls.bases]
@@ -293,6 +292,8 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
                     cls.report('@implementer requires arguments')
                     continue
                 addInterfaceInfoToClass(cls, args, False)
+
+        return cls
 
 
 class ZopeInterfaceASTBuilder(astbuilder.ASTBuilder):

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -230,6 +230,13 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
 
     def visit_Call_zope_interface_classImplements(self, funcName, node):
         parent = self.builder.current
+        if not node.args:
+            self.builder.system.msg(
+                'zopeinterface',
+                f'{parent.description}:{node.lineno}: '
+                f'required argument to classImplements() missing',
+                thresh=-1)
+            return
         clsname = parent.expandName(astor.to_source(node.args[0]).strip())
         cls = self.system.allobjects.get(clsname)
         if not isinstance(cls, ZopeInterfaceClass):

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -281,6 +281,9 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
 
         for ((dn, fn, o), args) in cls.decorators:
             if fn == 'zope.interface.implementer':
+                if args is None:
+                    cls.report('@implementer requires arguments')
+                    continue
                 addInterfaceInfoToClass(cls, args, False)
 
 

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -304,7 +304,7 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             if schema_prog.match(n) or (o and o.isschemafield):
                 cls.isschemafield = True
 
-        for (dn_, fn, o_), args in cls.decorators:
+        for fn, args in cls.decorators:
             if fn == 'zope.interface.implementer':
                 if args is None:
                     cls.report('@implementer requires arguments')

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -273,15 +273,7 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
             return
         assert isinstance(cls, ZopeInterfaceClass)
 
-        bases = []
-
-        for base in cls.bases:
-            if isinstance(base, ast.Name):
-                bases.append(self.builder.current.expandName(base.id))
-            elif isinstance(base, str):
-                bases.append(self.builder.current.expandName(base))
-            else:
-                raise Exception(base)
+        bases = [self.builder.current.expandName(base) for base in cls.bases]
 
         if 'zope.interface.interface.InterfaceClass' in bases:
             cls.isinterfaceclass = True

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -232,16 +232,12 @@ class ZopeInterfaceModuleVisitor(astbuilder.ModuleVistor):
         parent = self.builder.current
         clsname = parent.expandName(astor.to_source(node.args[0]).strip())
         cls = self.system.allobjects.get(clsname)
-        if cls is None:
-            self.builder.system.msg(
-                "parsing",
-                "classImplements on unknown class %r"%clsname)
-            return
         if not isinstance(cls, ZopeInterfaceClass):
+            problem = 'not found' if cls is None else 'is not a class'
             self.builder.system.msg(
                 'zopeinterface',
                 f'{parent.description}:{node.lineno}: '
-                f'argument "{clsname}" to classImplements() is not a class',
+                f'argument "{clsname}" to classImplements() {problem}',
                 thresh=-1)
             return
         addInterfaceInfoToClass(cls, node.args[1:],

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -46,20 +46,6 @@ class ZopeInterfaceClass(model.Class):
                     r.append(interface)
         return r
 
-    @property
-    def allImplementations(self):
-        r = list(self.implementedby_directly)
-        stack = list(r)
-        while stack:
-            c = stack.pop(0)
-            for sc in c.subclasses:
-                if sc.implementsOnly:
-                    continue
-                stack.append(sc)
-                if sc not in r:
-                    r.append(sc)
-        return r
-
 
 def _inheritedDocsources(obj):
     if not isinstance(obj.parent, (model.Class, model.Module)):

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -1,6 +1,6 @@
 """Support for Zope interfaces."""
 
-from typing import Iterable, Iterator, List, Optional, Tuple, Union
+from typing import Iterable, Iterator, List, Optional, Union
 import ast
 import re
 
@@ -79,10 +79,7 @@ class ZopeInterfaceAttribute(model.Attribute):
 
 def addInterfaceInfoToScope(
         scope: Union[ZopeInterfaceClass, ZopeInterfaceModule],
-        interfaceargs: Iterable[Optional[Union[
-            Tuple[str, str, Optional[model.Documentable]],
-            ast.expr
-            ]]]
+        interfaceargs: Iterable[Optional[Union[str, ast.expr]]]
         ) -> None:
     for arg in interfaceargs:
         # If you do implementer(*()), the argument ends up being None, which we
@@ -90,10 +87,10 @@ def addInterfaceInfoToScope(
         if arg is None:
             continue
 
-        if not isinstance(arg, tuple):
-            fullName = scope.expandName(astor.to_source(arg).strip())
+        if isinstance(arg, str):
+            fullName = arg
         else:
-            fullName = arg[1]
+            fullName = scope.expandName(astor.to_source(arg).strip())
         obj = scope.system.objForFullName(fullName)
         if isinstance(obj, ZopeInterfaceClass):
             scope.implements_directly.append(fullName)
@@ -112,19 +109,13 @@ def addInterfaceInfoToScope(
 
 def addInterfaceInfoToModule(
         module: ZopeInterfaceModule,
-        interfaceargs: Iterable[Optional[Union[
-            Tuple[str, str, Optional[model.Documentable]],
-            ast.expr
-            ]]]
+        interfaceargs: Iterable[Optional[Union[str, ast.expr]]]
         ) -> None:
     addInterfaceInfoToScope(module, interfaceargs)
 
 def addInterfaceInfoToClass(
         cls: ZopeInterfaceClass,
-        interfaceargs: Iterable[Optional[Union[
-            Tuple[str, str, Optional[model.Documentable]],
-            ast.expr
-            ]]],
+        interfaceargs: Iterable[Optional[Union[str, ast.expr]]],
         implementsOnly: bool
         ) -> None:
     cls.implementsOnly = implementsOnly

--- a/pydoctor/zopeinterface.py
+++ b/pydoctor/zopeinterface.py
@@ -19,7 +19,7 @@ class ZopeInterfaceModule(model.Module):
     def allImplementedInterfaces(self) -> Iterable[str]:
         """Return all the interfaces provided by this module
         """
-        return list(self.implements_directly)
+        return self.implements_directly
 
 
 class ZopeInterfaceClass(model.Class):
@@ -44,9 +44,9 @@ class ZopeInterfaceClass(model.Class):
 
         This returns them in something like the classic class MRO.
         """
-        r = list(self.implements_directly)
         if self.implementsOnly:
-            return r
+            return self.implements_directly
+        r = list(self.implements_directly)
         for b in self.baseobjects:
             if b is None:
                 continue


### PR DESCRIPTION
After I added annotations, mypy flagged several cases where pydoctor made invalid assumptions about types. These could lead to crashes when analyzing invalid code. Since projects don't tend to keep invalid code around, this is unlikely to occur often in practice, but of course it shouldn't happen at all. In one case, the method (`allImplementations` property) was broken but it was never called, so it couldn't lead to problems.