### PR TITLE
Use new syntax to select pypy version

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.6]
         os: [ubuntu-20.04]
         include:
           - os: windows-latest


### PR DESCRIPTION
As suggested [here](https://github.com/actions/setup-python/issues/171#issuecomment-747917974), this should work around the regression in the `setup-python` task, as well as being more explicit about which version of pypy we want to run on.