### PR TITLE
Use a mapping for pydoctor_url_path for multi project builds.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,4 +107,7 @@ pydoctor_args = {
         ] + _common_args,
     }
 
-pydoctor_url_path = '/en/{rtd_version}/api/'
+pydoctor_url_path = {
+    'main': '/en/{rtd_version}/api',
+    'epydoc_demo': '/en/{rtd_version}/docformat/epytext/demo/',
+    }

--- a/docs/test.py
+++ b/docs/test.py
@@ -16,7 +16,8 @@ def test_help_output_extension():
     The help output extension will include the CLI help on the Sphinx page.
     """
     with open(BASE_DIR / 'help.html', 'r') as stream:
-        assert '--project-url=PROJECTURL' in stream.read()
+        page = stream.read()
+        assert '--project-url=PROJECTURL' in page, page
 
 
 def test_rtd_pydoctor_call():
@@ -26,7 +27,8 @@ def test_rtd_pydoctor_call():
     """
     # The pydoctor index is generated and overwrites the Sphinx files.
     with open(API_DIR / 'index.html', 'r') as stream:
-        assert 'moduleIndex.html' in stream.read()
+        page = stream.read()
+        assert 'moduleIndex.html' in page, page
 
 
 def test_rtd_pydoctor_multiple_call():
@@ -35,12 +37,14 @@ def test_rtd_pydoctor_multiple_call():
     API doc source.
     """
     with open(BASE_DIR / 'docformat' / 'epytext' / 'demo' / 'index.html', 'r') as stream:
-        assert 'pydoctor-epytext-demo API Documentation' in stream.read()
+        page = stream.read()
+        assert 'pydoctor-epytext-demo API Documentation' in page, page
 
 
 def test_rtd_extension_inventory():
     """
     The Sphinx inventory is available during normalsphinx-build.
     """
-    with open(BASE_DIR / 'usage.html', 'rb') as stream:
-        assert 'href="/en/latest/api/pydoctor.sphinx_ext.build_apidocs.html"' in stream.read().decode()
+    with open(BASE_DIR / 'usage.html', 'r') as stream:
+        page = stream.read()
+        assert 'href="/en/latest/api/pydoctor.sphinx_ext.build_apidocs.html"' in page, page

--- a/pydoctor/sphinx_ext/build_apidocs.py
+++ b/pydoctor/sphinx_ext/build_apidocs.py
@@ -9,6 +9,8 @@ Inside the Sphinx conf.py file you need to define the following configuration op
   - C{pydoctor_url_path} - defined the URL path to the API documentation
                            You can use C{{rtd_version}} to have the URL automatically updated
                            based on Read The Docs build.
+                        - (private usage) a mapping with values URL path definition.
+                          Make sure each definition will produce a unique URL.
 
   - C{pydoctor_args} - Sequence with all the pydoctor command line arguments used to trigger the build.
                      - (private usage) a mapping with values as sequence of pydoctor command line arguments.
@@ -86,6 +88,10 @@ def on_config_inited(app: Sphinx, config: Config) -> None:
         # We have a single pydoctor call
         runs = {'main': runs}
 
+    pydoctor_url_path = config.pydoctor_url_path
+    if not isinstance(runs, Mapping):
+        pydoctor_url_path = {'main': pydoctor_url_path}
+
     for key, value in runs.items():
         arguments = _get_arguments(value, placeholders)
 
@@ -94,10 +100,10 @@ def on_config_inited(app: Sphinx, config: Config) -> None:
         temp_path = output_path.with_suffix('.pydoctor_temp')
 
         # Update intersphinx_mapping.
-        pydoctor_url_path = config.pydoctor_url_path
-        if pydoctor_url_path:
+        url_path = pydoctor_url_path.get(key)
+        if url_path:
             intersphinx_mapping = config.intersphinx_mapping
-            url = pydoctor_url_path.format(**{'rtd_version': rtd_version})
+            url = url_path.format(**{'rtd_version': rtd_version})
             intersphinx_mapping[key + '-api-docs'] = (url, str(temp_path / 'objects.inv'))
 
         # Build the API docs in temporary path.
@@ -146,7 +152,7 @@ def setup(app: Sphinx) ->  Mapping[str, Any]:
     @return: The extension version and runtime options.
     """
     app.add_config_value("pydoctor_args", None, "env")
-    app.add_config_value("pydoctor_url_path", "", "env")
+    app.add_config_value("pydoctor_url_path", None, "env")
 
     # Make sure we have a lower priority than intersphinx extension.
     app.connect('config-inited', on_config_inited, priority=790)

--- a/pydoctor/sphinx_ext/build_apidocs.py
+++ b/pydoctor/sphinx_ext/build_apidocs.py
@@ -9,8 +9,8 @@ Inside the Sphinx conf.py file you need to define the following configuration op
   - C{pydoctor_url_path} - defined the URL path to the API documentation
                            You can use C{{rtd_version}} to have the URL automatically updated
                            based on Read The Docs build.
-                        - (private usage) a mapping with values URL path definition.
-                          Make sure each definition will produce a unique URL.
+                         - (private usage) a mapping with values URL path definition.
+                           Make sure each definition will produce a unique URL.
 
   - C{pydoctor_args} - Sequence with all the pydoctor command line arguments used to trigger the build.
                      - (private usage) a mapping with values as sequence of pydoctor command line arguments.


### PR DESCRIPTION
This fixed the bug in which Sphinx will overwrite 2 inventory files if they have the same URL.

Just used a mapping just like we have for the pydoctor_args.

We don't have tests for this.

Pydoctor own system / docs tests are using the mapping code, but we don't have tests for the non-mapping configuration.

I plan to use the non-mapping configuration in Twisted.