### PR TITLE
Fix recognition of '@abc.abstractproperty'

### DIFF
--- a/docs/source/codedoc.rst
+++ b/docs/source/codedoc.rst
@@ -110,7 +110,7 @@ Further reading:
 Properties
 ----------
 
-A method with a decoration ending in ``property`` will be included in the generated API documentation as an attribute rather than a method::
+A method with a decoration ending in ``property`` or ``Property`` will be included in the generated API documentation as an attribute rather than a method::
 
     class Knight:
 

--- a/docs/source/codedoc.rst
+++ b/docs/source/codedoc.rst
@@ -106,6 +106,29 @@ Further reading:
 - `Python Standard Library: typing -- Support for type hints <https://docs.python.org/3/library/typing.html>`_
 - `PEP 483 -- The Theory of Type Hints <https://www.python.org/dev/peps/pep-0483/>`_
 
+
+Properties
+----------
+
+A method with a decoration ending in ``property`` will be included in the generated API documentation as an attribute rather than a method::
+
+    class Knight:
+
+        @property
+        def name(self):
+            return self._name
+
+        @abc.abstractproperty
+        def age(self):
+            raise NotImplementedError
+
+        @customProperty
+        def quest(self):
+            return f'Find the {self._object}'
+
+All you have to do for pydoctor to recognize your custom properties is stick to this naming convention.
+
+
 Using ``attrs``
 ---------------
 

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -1517,6 +1517,9 @@ def test_property_custom(systemcls: Type[model.System], capsys: CapSys) -> None:
         @async_property
         async def remote_value(self):
             return await get_remote_value()
+        @abc.abstractproperty
+        def name(self):
+            raise NotImplementedError
     ''', modname='mod', systemcls=systemcls)
     C = mod.contents['C']
 
@@ -1527,6 +1530,10 @@ def test_property_custom(systemcls: Type[model.System], capsys: CapSys) -> None:
     async_prop = C.contents['remote_value']
     assert isinstance(async_prop, model.Attribute)
     assert async_prop.kind == 'Property'
+
+    abstract_prop = C.contents['name']
+    assert isinstance(abstract_prop, model.Attribute)
+    assert abstract_prop.kind == 'Property'
 
 
 @pytest.mark.parametrize('decoration', ('classmethod', 'staticmethod'))


### PR DESCRIPTION
Property decorators containing one or more dots were not recognized by the original implementation of custom properties support. This PR fixes that. It also adds [documentation of the supported properties syntax](https://pydoctor--344.org.readthedocs.build/en/344/codedoc.html#properties).