### PR TITLE
Format 'def func' and 'class Class:' lines using syntax highlighting

### DIFF
--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -4,6 +4,9 @@ This is a module demonstrating epydoc code documentation features.
 Most part of this documentation is using Python type hinting.
 """
 
+from abc import ABC
+
+
 def demo_fields_docstring_arguments(m, b):  # type: ignore
     """
     Fields are used to describe specific properties of a documented object.
@@ -67,7 +70,7 @@ class _PrivateClass:
         return True
 
 
-class DemoClass:
+class DemoClass(ABC):
     """
     This is the docstring of this class.
     """

--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -5,6 +5,7 @@ Most part of this documentation is using Python type hinting.
 """
 
 from abc import ABC
+from somelib import SomeInterface
 
 
 def demo_fields_docstring_arguments(m, b):  # type: ignore
@@ -70,7 +71,7 @@ class _PrivateClass:
         return True
 
 
-class DemoClass(ABC):
+class DemoClass(ABC, SomeInterface, _PrivateClass):
     """
     This is the docstring of this class.
     """

--- a/mypy.ini
+++ b/mypy.ini
@@ -44,3 +44,8 @@ ignore_missing_imports=True
 
 [mypy-urllib3.*]
 ignore_missing_imports=True
+
+# The following external library doesn't exist (it's used in the demo):
+
+[mypy-somelib.*]
+ignore_missing_imports=True

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -208,7 +208,8 @@ code, .code, .pre, #childList > div .functionHeader,
 #splitTables > table tr td:nth-child(2), .fieldTable tr td.fieldArg {
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }
-code, .code, #childList > div .functionHeader {
+code, .code, #childList > div .functionHeader, .fieldTable tr td.fieldArg {
+    font-size: 90%;
     color: #222222;
 }
 a > code, a.code {
@@ -226,7 +227,6 @@ It also overwrite the default values inherited from bootstrap min
 */
 code, .code {
     padding:2px 4px;
-    font-size:90%;
     background-color: #f4f4f4;
     border-radius:4px
 }

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -76,7 +76,6 @@ ul ul ul ul ul ul ul {
 
 .pre {
     white-space: pre;
-    font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
 }
 
 .undocumented {
@@ -125,7 +124,6 @@ ul ul ul ul ul ul ul {
 }
 
 #splitTables > table tr td:nth-child(2), .fieldTable tr td.fieldArg {
-    font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
     width: 200px;
 }
 
@@ -203,7 +201,16 @@ This is inline docstring content marked up as code, for example L{foo} in epytex
 or `bar` in restructuredtext
 
 - <a class="code"> links that are present in summary tables
+
+- 'functionHeader' is used for lines like `def func():` and `var =`
 */
+code, .code, .pre, #childList > div .functionHeader,
+#splitTables > table tr td:nth-child(2), .fieldTable tr td.fieldArg {
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+code, .code, #childList > div .functionHeader {
+    color: #222222;
+}
 a > code, a.code {
     color:#c7254e;
     background-color:#f9f2f4;
@@ -218,10 +225,8 @@ This defines  the "code" class, it's black on light gray,
 It also overwrite the default values inherited from bootstrap min
 */
 code, .code {
-    font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
     padding:2px 4px;
     font-size:90%;
-    color: #222222;
     background-color: #f4f4f4;
     border-radius:4px
 }
@@ -242,14 +247,6 @@ a.functionSourceLink {
     border-left-width: 1px;
     border-left-style: solid;
     background: #fafafa;
-}
-
-/* Function definitions `def func():` and `var =` */
-
-#childList > div .functionHeader {
-    font-family: monospace;
-    color: #222222;
-
 }
 
 .moduleDocstring {

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -248,7 +248,6 @@ a.functionSourceLink {
 
 #childList > div .functionHeader {
     font-family: monospace;
-    font-weight: bold;
     color: #222222;
 
 }

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -303,12 +303,18 @@ class ClassPage(CommonPage):
             for idx, (name, full_name, base) in enumerate(zipped):
                 if idx != 0:
                     r.append(', ')
+
                 if base is None:
                     # External class.
-                    tag = tags.span
+                    url = self.ob.system.intersphinx.getLink(full_name)
                 else:
                     # Internal class.
-                    tag = tags.a(href=base.url, **{"data-type": "Class"})
+                    url = base.url
+
+                if url is None:
+                    tag = tags.span
+                else:
+                    tag = tags.a(href=url, **{"data-type": "Class"})
                 r.append(tag(name, title=full_name))
             r.append(')')
         return r

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -302,9 +302,10 @@ class ClassPage(CommonPage):
             r.append('(')
             for i, (n, m, o) in enumerate(zipped):
                 if o is None:
-                    r.append(tags.span(title=m)(n))
+                    tag = tags.span
                 else:
-                    r.append(tags.a(href=o.url, **{"data-type": "Class"})(n))
+                    tag = tags.a(href=o.url, **{"data-type": "Class"})
+                r.append(tag(n, title=m))
                 if i != len(zipped)-1:
                     r.append(', ')
             r.append(')')

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -304,7 +304,7 @@ class ClassPage(CommonPage):
                 if o is None:
                     r.append(tags.span(title=m)(n))
                 else:
-                    r.append(util.taglink(o, n))
+                    r.append(tags.a(href=o.url, **{"data-type": "Class"})(n))
                 if i != len(zipped)-1:
                     r.append(', ')
             r.append(')')

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -1,6 +1,6 @@
 """The classes that turn  L{Documentable} instances into objects we can render."""
 
-from typing import Any, Iterator, List, Optional, Union
+from typing import Any, Iterator, List, Optional, Sequence, Union
 import ast
 
 from twisted.web.template import tags, Element, renderer, Tag, XMLFile
@@ -64,7 +64,7 @@ class CommonPage(Element):
     def category(self) -> str:
         return f"{self.ob.kind.lower()} documentation"
 
-    def namespace(self, obj: model.Documentable) -> List[Union[Tag, str]]:
+    def namespace(self, obj: model.Documentable) -> Sequence[Union[Tag, str]]:
         parts: List[Union[Tag, str]] = []
         ob: Optional[model.Documentable] = obj
         while ob:
@@ -295,19 +295,21 @@ class ClassPage(CommonPage):
             r.append(tags.p(p))
         return r
 
-    def classSignature(self):
+    def classSignature(self) -> Sequence[Union[Tag, str]]:
         r = []
         zipped = list(zip(self.ob.rawbases, self.ob.bases, self.ob.baseobjects))
         if zipped:
             r.append('(')
-            for i, (n, m, o) in enumerate(zipped):
-                if o is None:
+            for idx, (name, full_name, base) in enumerate(zipped):
+                if idx != 0:
+                    r.append(', ')
+                if base is None:
+                    # External class.
                     tag = tags.span
                 else:
-                    tag = tags.a(href=o.url, **{"data-type": "Class"})
-                r.append(tag(n, title=m))
-                if i != len(zipped)-1:
-                    r.append(', ')
+                    # Internal class.
+                    tag = tags.a(href=base.url, **{"data-type": "Class"})
+                r.append(tag(name, title=full_name))
             r.append(')')
         return r
 

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -282,7 +282,7 @@ class ClassPage(CommonPage):
             source = tags.transparent
         r.append(tags.p(tags.code(
             tags.span("class", class_='py-keyword'), " ",
-            self.ob.fullName(),
+            tags.span(self.ob.name, class_='py-defname'),
             self.classSignature(), ":", source
             )))
 

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -56,9 +56,6 @@ class CommonPage(Element):
     def title(self):
         return self.ob.fullName()
 
-    def mediumName(self, obj):
-        return self.ob.fullName()
-
     def heading(self):
         return tags.h1(class_=self.ob.css_class)(
             tags.code(self.namespace(self.ob))
@@ -285,7 +282,8 @@ class ClassPage(CommonPage):
             source = tags.transparent
         r.append(tags.p(tags.code(
             tags.span("class", class_='py-keyword'), " ",
-            self.mediumName(self.ob), ":", source
+            self.ob.fullName(),
+            self.classSignature(), ":", source
             )))
 
         scs = sorted(self.ob.subclasses, key=lambda o:o.fullName().lower())
@@ -297,8 +295,8 @@ class ClassPage(CommonPage):
             r.append(tags.p(p))
         return r
 
-    def mediumName(self, ob):
-        r = [super().mediumName(ob)]
+    def classSignature(self):
+        r = []
         zipped = list(zip(self.ob.rawbases, self.ob.bases, self.ob.baseobjects))
         if zipped:
             r.append('(')

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -34,7 +34,7 @@ class AttributeChild(Element):
 
     @renderer
     def attribute(self, request, tag):
-        return self.ob.name
+        return tags.span(self.ob.name, class_='py-defname')
 
     @renderer
     def sourceLink(self, request, tag):

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -38,7 +38,10 @@ class FunctionChild(Element):
         name = self.ob.name
         if name.endswith('.setter') or name.endswith('.deleter'):
             name = name[:name.rindex('.')]
-        return [def_stmt, ' ', name, signature(self.ob), ':']
+        return [
+            tags.span(def_stmt, class_='py-keyword'), ' ',
+            tags.span(name, class_='py-defname'), signature(self.ob), ':'
+            ]
 
     @renderer
     def sourceLink(self, request, tag):


### PR DESCRIPTION
Currently these code-like definition lines are formatted entirely using a bold monospace font, but it looks better and more consistent if we instead format them in the same way as code blocks.

In addition to the mentioned formatting changes, this PR also adds the use of Intersphinx to link to the documentation of external base classes.
