### PR TITLE
Hyperlink exception types in `raises` fields

### DIFF
--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -495,10 +495,7 @@ class FieldHandler:
 
         r += format_desc_list('Parameters', self.parameter_descs)
         if self.return_desc:
-            r.append(tags.tr(class_="fieldStart")(
-                tags.td("Returns", class_="fieldName"),
-                self.return_desc.format()
-                ))
+            r += format_desc_list('Returns', [self.return_desc])
         r += format_desc_list("Raises", self.raise_descs)
         for s_p_l in (('Author', 'Authors', self.authors),
                       ('See Also', 'See Also', self.seealsos),

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -308,7 +308,7 @@ class FieldHandler:
 
     def __init__(self, obj: model.Documentable):
         self.obj = obj
-        self.linker = _EpydocLinker(self.obj)
+        self._linker = _EpydocLinker(self.obj)
 
         self.types: Dict[str, Optional[Tag]] = {}
 
@@ -326,7 +326,7 @@ class FieldHandler:
             ) -> None:
         formatted_annotations = {
             name: None if value is None
-                       else AnnotationDocstring(value).to_stan(self.linker)
+                       else AnnotationDocstring(value).to_stan(self._linker)
             for name, value in annotations.items()
             }
         ret_type = formatted_annotations.pop('return', None)
@@ -445,7 +445,7 @@ class FieldHandler:
             field.report('Exception type missing')
             typ_fmt = tags.span(class_='undocumented')("Unknown exception")
         else:
-            typ_fmt = self.linker.link_to(name, name)
+            typ_fmt = self._linker.link_to(name, name)
         self.raise_descs.append(RaisesDesc(type=typ_fmt, body=field.format()))
     handle_raise = handle_raises
     handle_except = handle_raises

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -376,9 +376,6 @@ class FieldHandler:
                 return
         field.report('Documented parameter "%s" does not exist' % (name,))
 
-    def add_info(self, desc_list: List[FieldDesc], name: Optional[str], field: Field) -> None:
-        desc_list.append(FieldDesc(name=name, body=field.format()))
-
     def handle_type(self, field: Field) -> None:
         if isinstance(self.obj, model.Attribute):
             if field.arg is not None:
@@ -408,7 +405,7 @@ class FieldHandler:
         if name is not None:
             if any(desc.name == name for desc in self.parameter_descs):
                 field.report('Parameter "%s" was already documented' % (name,))
-            self.add_info(self.parameter_descs, name, field)
+            self.parameter_descs.append(FieldDesc(name=name, body=field.format()))
             if name not in self.types:
                 self._handle_param_not_found(name, field)
 
@@ -418,7 +415,7 @@ class FieldHandler:
         name = self._handle_param_name(field)
         if name is not None:
             # TODO: How should this be matched to the type annotation?
-            self.add_info(self.parameter_descs, name, field)
+            self.parameter_descs.append(FieldDesc(name=name, body=field.format()))
             if name in self.types:
                 field.report('Parameter "%s" is documented as keyword' % (name,))
 
@@ -435,7 +432,7 @@ class FieldHandler:
         name = field.arg
         if name is None:
             field.report('Exception type missing')
-        self.add_info(self.raise_descs, name, field)
+        self.raise_descs.append(FieldDesc(name=name, body=field.format()))
     handle_raise = handle_raises
     handle_except = handle_raises
     
@@ -455,7 +452,7 @@ class FieldHandler:
     def handleUnknownField(self, field: Field) -> None:
         name = field.tag
         field.report(f"Unknown field '{name}'" )
-        self.add_info(self.unknowns[name], field.arg, field)
+        self.unknowns[name].append(FieldDesc(name=field.arg, body=field.format()))
 
     def handle(self, field: Field) -> None:
         m = getattr(self, 'handle_' + field.tag, self.handleUnknownField)

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -371,7 +371,9 @@ def test_func_raise_linked() -> None:
 
 
 def test_func_raise_missing_exception_type(capsys: CapSys) -> None:
-    """Raise fields must include the exception type."""
+    """When a C{raise} field is missing the exception type, a warning is logged
+    and the HTML will list the exception type as unknown.
+    """
     mod = fromText('''
     def f(x):
         """

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -356,7 +356,21 @@ def test_constructor_param_on_class(capsys: CapSys) -> None:
     assert captured == '<test>:5: Documented parameter "q" does not exist\n'
 
 
-def test_func_missing_exception_type(capsys: CapSys) -> None:
+def test_func_raise_linked() -> None:
+    """Raise fields are formatted by linking the exception type."""
+    mod = fromText('''
+    class SpanishInquisition(Exception):
+        pass
+    def f():
+        """
+        @raise SpanishInquisition: If something unexpected happens.
+        """
+    ''', modname='test')
+    html = docstring2html(mod.contents['f']).split('\n')
+    assert '<a href="test.SpanishInquisition.html">SpanishInquisition</a>' in html
+
+
+def test_func_raise_missing_exception_type(capsys: CapSys) -> None:
     """Raise fields must include the exception type."""
     mod = fromText('''
     def f(x):
@@ -365,9 +379,12 @@ def test_func_missing_exception_type(capsys: CapSys) -> None:
         @raise: On a blue moon.
         """
     ''')
-    epydoc2stan.format_docstring(mod.contents['f'])
+    func = mod.contents['f']
+    epydoc2stan.format_docstring(func)
     captured = capsys.readouterr().out
     assert captured == '<test>:5: Exception type missing\n'
+    html = docstring2html(func).split('\n')
+    assert '<span class="undocumented">Unknown exception</span>' in html
 
 
 def test_unexpected_field_args(capsys: CapSys) -> None:


### PR DESCRIPTION
Before this feature could be implemented, some refactoring on `FieldDesc` and related code had to be performed.

[Example](https://pydoctor--354.org.readthedocs.build/en/354/api/pydoctor.sphinx.html?private=1) contains two linked exception types: `ValueError` from the standard library (linked via Intersphinx) and `InvalidMaxAge` as a custom class (internal link).

Closes #324.