### PR TITLE
Fix field overriding attribute docstring

### DIFF
--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -613,17 +613,19 @@ def format_summary(obj: model.Documentable) -> Tag:
     """Generate an shortened HTML representation of a docstring."""
 
     doc, source = get_docstring(obj)
-    if doc is None:
+
+    if (doc is None or source is not obj) and isinstance(obj, model.Attribute):
         # Attributes can be documented as fields in their parent's docstring.
-        if isinstance(obj, model.Attribute):
-            pdoc = obj.parsed_docstring
-        else:
-            pdoc = None
-        if pdoc is None:
-            return format_undocumented(obj)
+        pdoc = obj.parsed_docstring
+    else:
+        pdoc = None
+
+    if pdoc is not None:
+        # The docstring was split off from the Attribute's parent docstring.
         source = obj.parent
-        # Since obj is an Attribute, it has a parent.
         assert source is not None
+    elif doc is None:
+        return format_undocumented(obj)
     else:
         # Tell mypy that if we found a docstring, we also have its source.
         assert source is not None


### PR DESCRIPTION
I noticed the problem on `twisted.web._newclient.Request`, where for `method` and `headers` the inherited docstring was used as the summary instead of the docstring set using `@ivar`.

The Twisted 20.3.0 docs don't have this problem, while docs I generated locally with pydoctor 20.7.1 do have the problem, so it looks like this is a regression introduced in pydoctor 20.7.0. As we're dealing with a regression, I think it would be good to do a bug fix release (20.12.2) after this PR passes review.
