### PR TITLE
Package is a module

### DIFF
--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -397,6 +397,8 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
                         error(f"Source path lies outside base directory: {ex}")
                 if path.is_dir():
                     system.msg('addPackage', f"adding directory {path}")
+                    if not (path / '__init__.py').is_file():
+                        error(f"Source directory lacks __init__.py: {path}")
                     system.addPackage(path, prependedpackage)
                 elif path.is_file():
                     system.msg('addModuleFromPath', f"adding module {path}")

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -397,10 +397,10 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
                         error(f"Source path lies outside base directory: {ex}")
                 if path.is_dir():
                     system.msg('addPackage', f"adding directory {path}")
-                    system.addPackage(str(path), prependedpackage)
+                    system.addPackage(path, prependedpackage)
                 elif path.is_file():
                     system.msg('addModuleFromPath', f"adding module {path}")
-                    system.addModuleFromPath(prependedpackage, str(path))
+                    system.addModuleFromPath(prependedpackage, path)
                 elif path.exists():
                     error(f"Source path is neither file nor directory: {path}")
                 else:

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -414,7 +414,7 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
         # step 3: move the system to the desired state
 
         if system.options.projectname is None:
-            name = '/'.join(ro.name for ro in system.rootobjects)
+            name = '/'.join(system.root_names)
             system.msg('warning', f"Guessing '{name}' for project name.", thresh=0)
             system.projectname = name
         else:
@@ -462,14 +462,13 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
 
             writer.prepOutputDirectory()
 
-            subjects: List[model.Documentable] = []
+            subjects: Sequence[model.Documentable] = ()
             if options.htmlsubjects:
-                for fn in options.htmlsubjects:
-                    subjects.append(system.allobjects[fn])
+                subjects = [system.allobjects[fn] for fn in options.htmlsubjects]
             else:
                 writer.writeSummaryPages(system)
                 if not options.htmlsummarypages:
-                    subjects.extend(system.rootobjects)
+                    subjects = system.rootobjects
             writer.writeIndividualFiles(subjects)
             if system.docstring_syntax_errors:
                 def p(msg: str) -> None:

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -400,7 +400,7 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
                     system.addPackage(path, prependedpackage)
                 elif path.is_file():
                     system.msg('addModuleFromPath', f"adding module {path}")
-                    system.addModuleFromPath(prependedpackage, path)
+                    system.addModuleFromPath(path, prependedpackage)
                 elif path.exists():
                     error(f"Source path is neither file nor directory: {path}")
                 else:

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -200,10 +200,8 @@ class _EpydocLinker(DocstringLinker):
         # Examine every module and package in the system and see if 'identifier'
         # names an object in each one.  Again, if more than one object is
         # found, complain.
-        target = self.look_for_name(identifier, itertools.chain(
-            self.obj.system.objectsOfType(model.Module),
-            self.obj.system.objectsOfType(model.Package)),
-            lineno)
+        target = self.look_for_name(
+            identifier, self.obj.system.objectsOfType(model.Module), lineno)
         if target is not None:
             return target
 
@@ -729,8 +727,6 @@ def format_undocumented(obj: model.Documentable) -> Tag:
         sub_objects_total_count[k] += 1
         if sub_ob.docstring is not None:
             sub_objects_with_docstring_count[k] += 1
-    if isinstance(obj, model.Package):
-        sub_objects_total_count[model.DocumentableKind.MODULE] -= 1
 
     tag: Tag = tags.span(class_='undocumented')
     if sub_objects_with_docstring_count:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -845,8 +845,6 @@ class System:
         self._introspectThing(py_mod, module, module)
 
     def addPackage(self, package_path: Path, parentPackage: Optional[_PackageT] = None) -> None:
-        if not package_path.exists():
-            raise Exception(f'package path "{package_path}" does not exist!')
         if not (package_path / '__init__.py').exists():
             raise Exception("you must pass a package directory to addPackage")
         if parentPackage:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -117,6 +117,9 @@ class Documentable:
     sourceHref: Optional[str] = None
     kind: Optional[DocumentableKind] = None
 
+    documentation_location = DocLocation.OWN_PAGE
+    """Page location where we are documented."""
+
     def __init__(
             self, system: 'System', name: str,
             parent: Optional['Documentable'] = None,
@@ -130,13 +133,6 @@ class Documentable:
         self.parentMod: Optional[Module] = None
         self.source_path: Optional[Path] = source_path
         self.setup()
-
-    @property
-    def documentation_location(self) -> DocLocation:
-        """Page location where we are documented.
-        The default implementation returns L{DocLocation.OWN_PAGE}.
-        """
-        return DocLocation.OWN_PAGE
 
     @property
     def doctarget(self) -> 'Documentable':
@@ -372,10 +368,6 @@ class Module(CanContainImportsDocumentable):
     state = ProcessingState.UNPROCESSED
 
     @property
-    def documentation_location(self) -> DocLocation:
-        return DocLocation.OWN_PAGE
-
-    @property
     def privacyClass(self) -> PrivacyClass:
         if self.name == '__main__':
             return PrivacyClass.PRIVATE
@@ -478,12 +470,9 @@ class Class(CanContainImportsDocumentable):
 
 
 class Inheritable(Documentable):
+    documentation_location = DocLocation.PARENT_PAGE
 
     parent: CanContainImportsDocumentable
-
-    @property
-    def documentation_location(self) -> DocLocation:
-        return DocLocation.PARENT_PAGE
 
     def docsources(self) -> Iterator[Documentable]:
         yield self

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -21,15 +21,16 @@ from typing import (
     TYPE_CHECKING, Any, Collection, Dict, Iterable, Iterator, List, Mapping,
     Optional, Sequence, Set, Tuple, Type, TypeVar, Union, overload
 )
-from typing_extensions import Literal
 from urllib.parse import quote
 
 from pydoctor.epydoc.markup import ParsedDocstring
 from pydoctor.sphinx import CacheT, SphinxInventory
 
 if TYPE_CHECKING:
+    from typing_extensions import Literal
     from pydoctor.astbuilder import ASTBuilder
 else:
+    Literal = {True: bool, False: bool}
     ASTBuilder = object
 
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -122,12 +122,12 @@ class Documentable:
             ):
         if not isinstance(self, Package):
             if source_path is None and parent is not None:
-                source_path = parent.source_path # type: ignore[has-type]
+                source_path = parent.source_path
         self.system = system
         self.name = name
         self.parent = parent
         self.parentMod: Optional[Module] = None
-        self.source_path = source_path
+        self.source_path: Optional[Path] = source_path
         self.setup()
 
     @property

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -718,7 +718,7 @@ class System:
             mod.sourceHref = f'{self.sourcebase}/{relative}'
 
     @overload
-    def addModule(self,
+    def analyzeModule(self,
             modpath: Path,
             modname: str,
             parentPackage: Optional[_PackageT],
@@ -726,14 +726,14 @@ class System:
             ) -> _ModuleT: ...
 
     @overload
-    def addModule(self,
+    def analyzeModule(self,
             modpath: Path,
             modname: str,
             parentPackage: Optional[_PackageT],
             is_package: Literal[True]
             ) -> _PackageT: ...
 
-    def addModule(self,
+    def analyzeModule(self,
             modpath: Path,
             modname: str,
             parentPackage: Optional[_PackageT] = None,
@@ -743,7 +743,7 @@ class System:
         mod = factory(self, modname, parentPackage, modpath)
         self.addObject(mod)
         self.progress(
-            "addModule", len(self.allobjects),
+            "analyzeModule", len(self.allobjects),
             None, "modules and packages discovered")
         self.unprocessed_modules.add(mod)
         self.module_count += 1
@@ -836,7 +836,7 @@ class System:
         return module
 
     def addPackage(self, package_path: Path, parentPackage: Optional[_PackageT] = None) -> None:
-        package = self.addModule(
+        package = self.analyzeModule(
             package_path / '__init__.py', package_path.name, parentPackage, is_package=True)
 
         for path in sorted(package_path.iterdir()):
@@ -856,7 +856,7 @@ class System:
                 if self.options.introspect_c_modules:
                     self.introspectModule(path, module_name, package)
             elif suffix in importlib.machinery.SOURCE_SUFFIXES:
-                self.addModule(path, module_name, package)
+                self.analyzeModule(path, module_name, package)
             break
 
     def handleDuplicate(self, obj: Documentable) -> None:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -845,8 +845,6 @@ class System:
         self._introspectThing(py_mod, module, module)
 
     def addPackage(self, package_path: Path, parentPackage: Optional[_PackageT] = None) -> None:
-        if not (package_path / '__init__.py').exists():
-            raise Exception("you must pass a package directory to addPackage")
         if parentPackage:
             package_full_name = f'{parentPackage.fullName()}.{package_path.name}'
         else:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -859,9 +859,9 @@ class System:
                 if (path / '__init__.py').exists():
                     self.addPackage(path, package)
             elif not path.name.startswith('.'):
-                self.addModuleFromPath(package, path)
+                self.addModuleFromPath(path, package)
 
-    def addModuleFromPath(self, package: Optional[_PackageT], path: Path) -> None:
+    def addModuleFromPath(self, path: Path, package: Optional[_PackageT]) -> None:
         name = path.name
         for suffix in importlib.machinery.all_suffixes():
             if not name.endswith(suffix):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -571,7 +571,7 @@ class System:
 
     def __init__(self, options: Optional[Values] = None):
         self.allobjects: Dict[str, Documentable] = {}
-        self.rootobjects: List[Documentable] = []
+        self.rootobjects: List[Union[_ModuleT, _PackageT]] = []
 
         self.violations = 0
         """The number of docstring problems found.
@@ -604,11 +604,7 @@ class System:
     @property
     def root_names(self) -> Collection[str]:
         """The top-level package/module names in this system."""
-        return {
-            obj.name
-            for obj in self.rootobjects
-            if isinstance(obj, (Module, Package))
-            }
+        return {obj.name for obj in self.rootobjects}
 
     def verbosity(self, section: Union[str, Iterable[str]]) -> int:
         if isinstance(section, str):
@@ -728,8 +724,10 @@ class System:
 
         if obj.parent:
             obj.parent.contents[obj.name] = obj
-        else:
+        elif isinstance(obj, (_ModuleT, _PackageT)):
             self.rootobjects.append(obj)
+        else:
+            raise ValueError(f'Top-level object is not a module: {obj!r}')
 
         first = self.allobjects.setdefault(obj.fullName(), obj)
         if obj is not first:

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -251,7 +251,7 @@ class SphinxInventoryWriter:
         url = obj.url
 
         display = '-'
-        if isinstance(obj, (model.Package, model.Module)):
+        if isinstance(obj, model.Module):
             domainname = 'module'
         elif isinstance(obj, model.Class):
             domainname = 'class'

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -275,25 +275,26 @@ class ModulePage(CommonPage):
 
 class PackagePage(ModulePage):
     def children(self):
-        return sorted((o for o in self.ob.contents.values()
-                       if o.name != '__init__' and o.isVisible),
-                      key=lambda o2:(-o2.privacyClass.value, o2.fullName()))
+        return sorted(
+            (o for o in self.ob.contents.values()
+             if isinstance(o, model.Module) and o.isVisible),
+            key=lambda o2:(-o2.privacyClass.value, o2.fullName()))
 
     def packageInitTable(self):
-        init = self.ob.contents['__init__']
         children = sorted(
-            [o for o in init.contents.values() if o.isVisible],
+            (o for o in self.ob.contents.values()
+             if not isinstance(o, model.Module) and o.isVisible),
             key=lambda o2:(-o2.privacyClass.value, o2.fullName()))
         if children:
             loader = ChildTable.lookup_loader(self.template_lookup)
             return [tags.p("From the ", tags.code("__init__.py"), " module:",
                            class_="fromInitPy"),
-                    ChildTable(self.docgetter, init, children, loader)]
+                    ChildTable(self.docgetter, self.ob, children, loader)]
         else:
             return ()
 
     def methods(self):
-        return [o for o in self.ob.contents['__init__'].contents.values()
+        return [o for o in self.ob.contents.values()
                 if o.documentation_location is model.DocLocation.PARENT_PAGE
                 and o.isVisible]
 

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -299,9 +299,10 @@ class PackagePage(ModulePage):
             key=objects_order)
         if children:
             loader = ChildTable.lookup_loader(self.template_lookup)
-            return [tags.p("From the ", tags.code("__init__.py"), " module:",
-                           class_="fromInitPy"),
-                    ChildTable(self.docgetter, self.ob, children, loader)]
+            return [
+                tags.p("From ", tags.code("__init__.py"), ":", class_="fromInitPy"),
+                ChildTable(self.docgetter, self.ob, children, loader)
+                ]
         else:
             return ()
 

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -8,23 +8,24 @@ from pydoctor.templatewriter.pages import Page
 from twisted.web.template import Element, Tag, TagLoader, renderer, tags
 
 
-def moduleSummary(modorpack, page_url):
-    r = tags.li(
-        tags.code(epydoc2stan.taglink(modorpack, page_url)), ' - ',
-        epydoc2stan.format_summary(modorpack)
+def moduleSummary(module: model.Module, page_url: str) -> Tag:
+    r: Tag = tags.li(
+        tags.code(epydoc2stan.taglink(module, page_url)), ' - ',
+        epydoc2stan.format_summary(module)
         )
-    if modorpack.isPrivate:
+    if module.isPrivate:
         r(class_='private')
-    if not isinstance(modorpack, model.Package):
+    if not isinstance(module, model.Package):
         return r
-    contents = [m for m in modorpack.contents.values()
-                if m.isVisible and m.name != '__init__']
+    contents = [m for m in module.contents.values()
+                if isinstance(m, model.Module) and m.isVisible]
     if not contents:
         return r
     ul = tags.ul()
     for m in sorted(contents, key=lambda m:m.fullName()):
         ul(moduleSummary(m, page_url))
-    return r(ul)
+    r(ul)
+    return r
 
 def _lckey(x):
     return (x.fullName().lower(), x.fullName())

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -46,14 +46,9 @@ def fromAST(
         # Set containing package as parent.
         builder.current = _system.allobjects[parent_name]
 
-    if is_package:
-        _system.ensurePackage(full_name)
-        builder.current = _system.allobjects[full_name]
-        modname = '__init__'
-        full_name = f'{full_name}.{modname}'
-
-    mod: model.Module = builder._push(_system.Module, modname, 0)
-    builder._pop(_system.Module)
+    factory = _system.Package if is_package else _system.Module
+    mod: model.Module = builder._push(factory, modname, 0)
+    builder._pop(factory)
     builder.processModuleAST(ast, mod)
     assert mod is _system.allobjects[full_name]
     mod.state = model.ProcessingState.PROCESSED

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -315,7 +315,7 @@ def test_relative_import_past_top(
     package.
     """
     system = systemcls()
-    system.ensurePackage('pkg')
+    fromText('', modname='pkg', is_package=True, system=system)
     fromText(f'''
     from {'.' * level + 'X'} import A
     ''', modname='mod', parent_name='pkg', system=system)

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -207,7 +207,7 @@ class Dummy:
 def test_introspection_python() -> None:
     """Find docstrings from this test using introspection on pure Python."""
     system = model.System()
-    system.introspectModule(Path(__file__), __name__)
+    system.introspectModule(Path(__file__), __name__, None)
 
     module = system.objForFullName(__name__)
     assert module is not None
@@ -230,12 +230,20 @@ def test_introspection_extension() -> None:
         pytest.skip("cython_test_exception_raiser not installed")
 
     system = model.System()
-    system.introspectModule(
+    package = system.introspectModule(
+        Path(cython_test_exception_raiser.__file__),
+        'cython_test_exception_raiser',
+        None)
+    assert isinstance(package, model.Package)
+    module = system.introspectModule(
         Path(cython_test_exception_raiser.raiser.__file__),
-        'cython_test_exception_raiser.raiser')
+        'raiser',
+        package)
+    assert not isinstance(module, model.Package)
 
-    module = system.objForFullName('cython_test_exception_raiser.raiser')
-    assert module is not None
+    assert system.objForFullName('cython_test_exception_raiser') is package
+    assert system.objForFullName('cython_test_exception_raiser.raiser') is module
+
     assert module.docstring is not None
     assert module.docstring.strip().split('\n')[0] == "A trivial extension that just raises an exception."
 

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -73,13 +73,9 @@ def test_package_sourceHref() -> None:
     system.sourcebase = "https://git.example.org/proj/main"
     system.options = cast(Values, options)
 
-    mod_init = fromText('''
-    """Docstring."""
-    ''', modname='pkg', is_package=True, system=system)
-    system.setSourceHref(mod_init, project_dir / 'src' / 'pkg' / '__init__.py')
+    package = system.Package(system, 'pkg')
+    system.setSourceHref(package, project_dir / 'src' / 'pkg' / '__init__.py')
 
-    package = system.objForFullName('pkg')
-    assert isinstance(package, model.Package)
     assert package.sourceHref == "https://git.example.org/proj/main/src/pkg/__init__.py"
 
 

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -70,13 +70,12 @@ def test_package_sourceHref() -> None:
     options.projectbasedirectory = project_dir
 
     system = model.System()
-    system.ensurePackage('pkg')
     system.sourcebase = "https://git.example.org/proj/main"
     system.options = cast(Values, options)
 
     mod_init = fromText('''
     """Docstring."""
-    ''', modname='__init__', parent_name='pkg', system=system)
+    ''', modname='pkg', is_package=True, system=system)
     system.setSourceHref(mod_init, project_dir / 'src' / 'pkg' / '__init__.py')
 
     package = system.objForFullName('pkg')

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -59,26 +59,6 @@ def test_setSourceHrefOption(projectBaseDir: Path) -> None:
     assert mod.sourceHref == "http://example.org/trac/browser/trunk/package/module.py"
 
 
-def test_package_sourceHref() -> None:
-    """
-    A package reports its __init__.py location as its source link.
-    """
-
-    project_dir = Path("/foo/bar/ProjectName")
-
-    options = FakeOptions()
-    options.projectbasedirectory = project_dir
-
-    system = model.System()
-    system.sourcebase = "https://git.example.org/proj/main"
-    system.options = cast(Values, options)
-
-    package = system.Package(system, 'pkg')
-    system.setSourceHref(package, project_dir / 'src' / 'pkg' / '__init__.py')
-
-    assert package.sourceHref == "https://git.example.org/proj/main/src/pkg/__init__.py"
-
-
 def test_initialization_default() -> None:
     """
     When initialized without options, will use default options and default

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -1,14 +1,13 @@
+from pathlib import Path
 from typing import Type
-import os
 
 from pydoctor import model
 
-testpackages = os.path.join(os.path.dirname(__file__), 'testpackages')
+testpackages = Path(__file__).parent / 'testpackages'
 
 def processPackage(packname: str, systemcls: Type[model.System] = model.System) -> model.System:
-    testpackage = os.path.join(testpackages, packname)
     system = systemcls()
-    system.addPackage(testpackage)
+    system.addPackage(testpackages / packname)
     system.process()
     return system
 

--- a/pydoctor/test/test_packages.py
+++ b/pydoctor/test/test_packages.py
@@ -19,8 +19,7 @@ def test_relative_import() -> None:
 
 def test_package_docstring() -> None:
     system = processPackage("relativeimporttest")
-    assert (system.allobjects['relativeimporttest.__init__'].docstring ==
-            "DOCSTRING")
+    assert system.allobjects['relativeimporttest'].docstring == "DOCSTRING"
 
 def test_modnamedafterbuiltin() -> None:
     # well, basically the test is that this doesn't explode:


### PR DESCRIPTION
Previously pydoctor had a `Package` object for the namespace and a `Module` object for the code from the `__init__.py` source file. However, in the Python Language Reference, it is explicitly stated that packages are modules.

This PR makes the `Package` class inherit from the `Module` class and simplifies the related code.
