### PR TITLE
Fix rendering of project URL

### DIFF
--- a/docs/test.py
+++ b/docs/test.py
@@ -41,7 +41,7 @@ def test_rtd_pydoctor_multiple_call():
     """
     with open(BASE_DIR / 'docformat' / 'epytext' / 'index.html', 'r') as stream:
         page = stream.read()
-        assert 'pydoctor-epytext-demo API Documentation' in page, page
+        assert '<a href="../epytext.html">pydoctor-epytext-demo</a>' in page, page
 
 
 def test_rtd_extension_inventory():

--- a/pydoctor/templates/common.html
+++ b/pydoctor/templates/common.html
@@ -11,10 +11,9 @@
 
     <nav class="navbar navbar-default">
       <div class="container">
-        <div class="navbar-header">
-          <a class="navbar-brand" href="index.html">
-            <t:slot name="project">Some Project</t:slot> API Documentation
-          </a>
+        <div class="navbar-header navbar-brand">
+          <t:transparent t:render="project">Some Project</t:transparent>
+          <a href="index.html">API Documentation</a>
         </div>
       </div>
     </nav>

--- a/pydoctor/templates/index.html
+++ b/pydoctor/templates/index.html
@@ -13,11 +13,9 @@
 
     <nav class="navbar navbar-default">
       <div class="container">
-
-        <div class="navbar-header">
-          <a class="navbar-brand" href="index.html">
-            <t:transparent t:render="project">Some Project</t:transparent> API Documentation
-          </a>
+        <div class="navbar-header navbar-brand">
+          <t:transparent t:render="project">Some Project</t:transparent>
+          <a href="index.html">API Documentation</a>
         </div>
       </div>
     </nav>

--- a/pydoctor/templates/index.html
+++ b/pydoctor/templates/index.html
@@ -1,10 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
   <head>
-    <title>
-      API Documentation for
-      <t:transparent t:render="project">Some Project</t:transparent>
-    </title>
+    <title t:render="title">Something</title>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <link rel="stylesheet" type="text/css" href="bootstrap.min.css" />
     <link rel="stylesheet" type="text/css" href="apidocs.css" />

--- a/pydoctor/templates/nameIndex.html
+++ b/pydoctor/templates/nameIndex.html
@@ -11,11 +11,9 @@
 
     <nav class="navbar navbar-default">
       <div class="container">
-
-        <div class="navbar-header">
-          <a class="navbar-brand" href="index.html">
-            <t:transparent t:render="project">Some Project</t:transparent> API Documentation
-          </a>
+        <div class="navbar-header navbar-brand">
+          <t:transparent t:render="project">Some Project</t:transparent>
+          <a href="index.html">API Documentation</a>
         </div>
       </div>
     </nav>

--- a/pydoctor/templates/summary.html
+++ b/pydoctor/templates/summary.html
@@ -9,11 +9,9 @@
   <body>
     <nav class="navbar navbar-default">
       <div class="container">
-
-        <div class="navbar-header">
-          <a class="navbar-brand" href="index.html">
-            <t:transparent t:render="project">Some Project</t:transparent> API Documentation
-          </a>
+        <div class="navbar-header navbar-brand">
+          <t:transparent t:render="project">Some Project</t:transparent>
+          <a href="index.html">API Documentation</a>
         </div>
       </div>
     </nav>

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -174,7 +174,7 @@ class CommonPage(util.Page):
             childlist=self.childlist(),
             # Note: This slot is not used anymore, but kept for backwards
             #       compatibility until the new template system lands.
-            project=self.project_link,
+            project=self.project_tag,
             version=__version__,
             buildtime=self.ob.system.buildtime.strftime("%Y-%m-%d %H:%M:%S"))
 

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -172,6 +172,8 @@ class CommonPage(util.Page):
             mainTable=self.mainTable(),
             packageInitTable=self.packageInitTable(),
             childlist=self.childlist(),
+            # Note: This slot is not used anymore, but kept for backwards
+            #       compatibility until the new template system lands.
             project=self.project_link,
             version=__version__,
             buildtime=self.ob.system.buildtime.strftime("%Y-%m-%d %H:%M:%S"))

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any, Iterator, List, Optional, Sequence, Union
 import ast
 
-from twisted.web.template import tags, Element, renderer, Tag, XMLFile
+from twisted.web.template import tags, renderer, Tag, XMLFile
 import astor
 
 from pydoctor import epydoc2stan, model, __version__
@@ -41,10 +41,11 @@ class DocGetter:
             else:
                 return [doc, ' (type: ', typ, ')']
 
-class CommonPage(Element):
+class CommonPage(util.Page):
     ob: model.Documentable
 
     def __init__(self, ob, docgetter=None):
+        super().__init__(ob.system)
         self.ob = ob
         if docgetter is None:
             docgetter = DocGetter()
@@ -93,12 +94,6 @@ class CommonPage(Element):
             return 'Part of ', tags.code(self.namespace(parent))
         else:
             return []
-
-    def project(self):
-        if self.ob.system.options.projecturl:
-            return tags.a(href=self.ob.system.options.projecturl)(self.ob.system.projectname)
-        else:
-            return self.ob.system.projectname
 
     @renderer
     def deprecated(self, request, tag):
@@ -177,7 +172,7 @@ class CommonPage(Element):
             mainTable=self.mainTable(),
             packageInitTable=self.packageInitTable(),
             childlist=self.childlist(),
-            project=self.project(),
+            project=self.project_link,
             version=__version__,
             buildtime=self.ob.system.buildtime.strftime("%Y-%m-%d %H:%M:%S"))
 

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -242,6 +242,10 @@ class IndexPage(util.Page):
     def __init__(self, system):
         self.system = system
 
+    @renderer
+    def title(self, request, tag):
+        return tag.clear()(f"API Documentation for {self.system.projectname}")
+
     # Deprecated: pydoctor's templates no longer use this, but it is kept
     #             for now to not break customized templates like Twisted's.
     @renderer

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -242,6 +242,12 @@ class IndexPage(util.Page):
     def __init__(self, system):
         self.system = system
 
+    # Deprecated: pydoctor's templates no longer use this, but it is kept
+    #             for now to not break customized templates like Twisted's.
+    @renderer
+    def project_link(self, request, tag):
+        return self.project_tag
+
     @renderer
     def recentChanges(self, request, tag):
         return ()

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -29,19 +29,12 @@ def _lckey(x):
     return (x.fullName().lower(), x.fullName())
 
 
-class ModuleIndexPage(Element):
+class ModuleIndexPage(util.Page):
     filename = 'moduleIndex.html'
 
     @property
     def loader(self):
         return XMLFile(util.templatefilepath('summary.html'))
-
-    def __init__(self, system):
-        self.system = system
-
-    @renderer
-    def project(self, request, tag):
-        return self.system.projectname
 
     @renderer
     def title(self, request, tag):
@@ -116,23 +109,16 @@ def subclassesFrom(hostsystem, cls, anchors, page_url):
         r(ul)
     return r
 
-class ClassIndexPage(Element):
+class ClassIndexPage(util.Page):
     filename = 'classIndex.html'
 
     @property
     def loader(self):
         return XMLFile(util.templatefilepath('summary.html'))
 
-    def __init__(self, system):
-        self.system = system
-
     @renderer
     def title(self, request, tag):
         return tag.clear()("Class Hierarchy")
-
-    @renderer
-    def project(self, request, tag):
-        return self.system.projectname
 
     @renderer
     def stuff(self, request, tag):
@@ -216,16 +202,16 @@ class LetterElement(Element):
         return r
 
 
-class NameIndexPage(Element):
+class NameIndexPage(util.Page):
     filename = 'nameIndex.html'
 
     @property
     def loader(self):
         return XMLFile(util.templatefilepath('nameIndex.html'))
 
-    def __init__(self, system):
-        self.system = system
-        self.initials = {}
+    def __init__(self, system: model.System):
+        super().__init__(system)
+        self.initials: Dict[str, List[model.Documentable]] = {}
         for ob in self.system.allobjects.values():
             if ob.isVisible:
                 self.initials.setdefault(ob.name[0].upper(), []).append(ob)
@@ -239,10 +225,6 @@ class NameIndexPage(Element):
         return tag.clear()("Index of Names")
 
     @renderer
-    def project(self, request, tag):
-        return self.system.projectname
-
-    @renderer
     def index(self, request, tag):
         r = []
         for i in sorted(self.initials):
@@ -250,7 +232,7 @@ class NameIndexPage(Element):
         return r
 
 
-class IndexPage(Element):
+class IndexPage(util.Page):
     filename = 'index.html'
 
     @property
@@ -259,18 +241,6 @@ class IndexPage(Element):
 
     def __init__(self, system):
         self.system = system
-
-    @renderer
-    def project_link(self, request, tag):
-        if self.system.options.projecturl:
-            return tags.a(href=self.system.options.projecturl)(
-                self.system.projectname)
-        else:
-            return self.system.projectname
-
-    @renderer
-    def project(self, request, tag):
-        return self.system.projectname
 
     @renderer
     def recentChanges(self, request, tag):
@@ -328,7 +298,7 @@ def hasdocstring(ob):
             return True
     return False
 
-class UndocumentedSummaryPage(Element):
+class UndocumentedSummaryPage(util.Page):
     filename = 'undoccedSummary.html'
 
     @property
@@ -345,10 +315,6 @@ class UndocumentedSummaryPage(Element):
     @renderer
     def heading(self, request, tag):
         return tag.clear()("Summary of Undocumented Objects")
-
-    @renderer
-    def project(self, request, tag):
-        return self.system.projectname
 
     @renderer
     def stuff(self, request, tag):

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -27,7 +27,7 @@ class Page(Element):
         self.system = system
 
     @property
-    def project_link(self) -> Tag:
+    def project_tag(self) -> Tag:
         system = self.system
         projecturl: Optional[str] = system.options.projecturl
         tag: Tag = tags.a(href=projecturl) if projecturl else tags.transparent
@@ -36,4 +36,4 @@ class Page(Element):
 
     @renderer
     def project(self, request, tag):
-        return self.project_link
+        return self.project_tag

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -5,6 +5,7 @@ import os
 
 from pydoctor import model
 from twisted.python.filepath import FilePath
+from twisted.web.template import Element, Tag, renderer, tags
 
 
 def srclink(o: model.Documentable) -> Optional[str]:
@@ -17,3 +18,22 @@ def templatefile(filename):
 
 def templatefilepath(filename):
     return FilePath(templatefile(filename))
+
+
+class Page(Element):
+
+    def __init__(self, system: model.System):
+        super().__init__()
+        self.system = system
+
+    @property
+    def project_link(self) -> Tag:
+        system = self.system
+        projecturl: Optional[str] = system.options.projecturl
+        tag: Tag = tags.a(href=projecturl) if projecturl else tags.transparent
+        tag(system.projectname)
+        return tag
+
+    @renderer
+    def project(self, request, tag):
+        return self.project_link


### PR DESCRIPTION
The navigation bar rendering was inconsistent due to duplicate code that hadn't been kept in sync. I removed the duplication by introducing a base class for all pages.

This is intended for a 21.2.1 bug fix release, so we can generate Twisted's API docs. The solution for the next major release will be to merge #299.