### PR TITLE
Fix positioning of anchors using CSS tweaks

### DIFF
--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -31,7 +31,8 @@ body {
 
 a[name] {
     position: relative;
-    bottom: 62px;
+    bottom: 80px;
+    font-size: 0;
 }
 
 ul {
@@ -222,6 +223,9 @@ code > a {
     background-color:#f9f2f4;
 }
 /* top navagation bar */
+.page-header > h1 {
+    margin-top: 0;
+}
 .page-header > h1 > code {
     color: #971c3a;
 }


### PR DESCRIPTION
One problem was introduced between 20.12.x and 21.2.x when I changed the page header to be a flexbox: this somehow makes browsers treat the margin on the `h1` differently.

Another problem was an inconsistency between how Chrome and Firefox render the page: Chrome considered the whitespace-only anchor to have line height 0, while Firefox applied the font's line height. By setting the font size to 0, both browsers use a line height of 0.