### PR TITLE
Add support for signatures of functions and methods in extensions

### DIFF
--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -550,14 +550,13 @@ T = TypeVar('T')
 
 # Declare the types that we consider as functions (also when they are coming
 # from a C extension)
-func_types = [types.BuiltinFunctionType, types.FunctionType]
+func_types: Tuple[Type[Any], ...] = (types.BuiltinFunctionType, types.FunctionType)
 if hasattr(types, "MethodDescriptorType"):
     # This is Python >= 3.7 only
-    func_types.append(types.MethodDescriptorType)
+    func_types += (types.MethodDescriptorType, )
 if hasattr(types, "ClassMethodDescriptorType"):
     # This is Python >= 3.7 only
-    func_types.append(types.ClassMethodDescriptorType)
-func_types = tuple(func_types)
+    func_types += (types.ClassMethodDescriptorType, )
 
 
 class System:
@@ -822,7 +821,6 @@ class System:
 
     def _introspectThing(self, thing: object, parent: Documentable, parentMod: _ModuleT) -> None:
         for k, v in thing.__dict__.items():
-            # TODO(ntamas): MethodDescriptorType and ClassMethodDescriptorType are Python 3.7 only.
             if (isinstance(v, func_types)
                     # In PyPy 7.3.1, functions from extensions are not
                     # instances of the abstract types in func_types

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -553,9 +553,13 @@ func_types: Tuple[Type[Any], ...] = (types.BuiltinFunctionType, types.FunctionTy
 if hasattr(types, "MethodDescriptorType"):
     # This is Python >= 3.7 only
     func_types += (types.MethodDescriptorType, )
+else:
+    func_types += (type(str.join), )
 if hasattr(types, "ClassMethodDescriptorType"):
     # This is Python >= 3.7 only
     func_types += (types.ClassMethodDescriptorType, )
+else:
+    func_types += (type(dict.__dict__["fromkeys"]), )
 
 
 class System:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -528,7 +528,6 @@ class Function(Inheritable):
     annotations: Mapping[str, Optional[ast.expr]]
     decorators: Optional[Sequence[ast.expr]]
     signature: Optional[Signature]
-    text_signature: str = ""
 
     def setup(self) -> None:
         super().setup()
@@ -831,8 +830,12 @@ class System:
                 f.decorators = None
                 try:
                     f.signature = signature(v)
-                except Exception:
-                    f.text_signature = (getattr(v, "__text_signature__") or "") + " (invalid)"
+                except ValueError:
+                    # function either has an invalid text signature or no signature
+                    # at all. We distinguish between the two by looking at the
+                    # __text_signature__ attribute
+                    if getattr(v, "__text_signature__", None) is not None:
+                        parent.report("Cannot parse signature of {0.name}.{1}".format(parent, k))
                     f.signature = None
                         
                 f.is_async = False

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -27,7 +27,7 @@ def format_decorators(obj: Union[model.Function, model.Attribute]) -> Iterator[A
 
 def signature(function: model.Function) -> str:
     """Return a nicely-formatted source-like function signature."""
-    return str(function.signature)
+    return str(function.signature) if function.signature else function.text_signature or "(...)"
 
 class DocGetter:
     def get(self, ob, summary=False):

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -27,7 +27,7 @@ def format_decorators(obj: Union[model.Function, model.Attribute]) -> Iterator[A
 
 def signature(function: model.Function) -> str:
     """Return a nicely-formatted source-like function signature."""
-    return str(function.signature) if function.signature else function.text_signature or "(...)"
+    return str(function.signature) if function.signature else "(...)"
 
 class DocGetter:
     def get(self, ob, summary=False):

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -2,6 +2,7 @@
 Unit tests for model.
 """
 
+from inspect import signature
 from optparse import Values
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import cast
@@ -245,14 +246,14 @@ def test_introspection_python() -> None:
 
     func = module.contents['test_introspection_python']
     assert func.docstring == "Find docstrings from this test using introspection on pure Python."
-    assert str(func.signature) == "() -> None"
+    assert func.signature == signature(test_introspection_python)
 
     method = system.objForFullName(__name__ + '.Dummy.crash')
     assert method is not None
     assert method.docstring == "Mmm"
 
     func = module.contents['dummy_function_with_complex_signature']
-    assert str(func.signature) == "(foo: int, bar: float) -> str"
+    assert func.signature == signature(dummy_function_with_complex_signature)
 
 
 def test_introspection_extension() -> None:

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -229,6 +229,11 @@ class Dummy:
     def crash(self) -> None:
         """Mmm"""
 
+
+def dummy_function_with_complex_signature(foo: int, bar: float) -> str:
+    return "foo"
+
+
 def test_introspection_python() -> None:
     """Find docstrings from this test using introspection on pure Python."""
     system = model.System()
@@ -240,10 +245,14 @@ def test_introspection_python() -> None:
 
     func = module.contents['test_introspection_python']
     assert func.docstring == "Find docstrings from this test using introspection on pure Python."
+    assert str(func.signature) == "() -> None"
 
     method = system.objForFullName(__name__ + '.Dummy.crash')
     assert method is not None
     assert method.docstring == "Mmm"
+
+    func = module.contents['dummy_function_with_complex_signature']
+    assert str(func.signature) == "(foo: int, bar: float) -> str"
 
 
 def test_introspection_extension() -> None:


### PR DESCRIPTION
This PR adds support for handling the signatures of functions and methods of classes declared in C extensions. The proposed changes in this PR were necessary to build the documentation of `python-igraph` using PyDoctor (see the results [here](https://igraph.org/python/doc/api/index.html)).

*Summary of changes:*

* `_introspectThing()` now handles additional types that are used when a method comes from a class declared in a C extension
* the function model was extended to provide support for Python's `__text_signature__` property
* the base template writer was extended to make use of the extended function model

*Detailed explanation of the changes:*

In particular, the function model was extended with a `text_signature` string member and the `signature` member was made optional. When introspecting a function (i.e. anything that is an instance of `BuiltinFunctionType`, `FunctionType`, `MethodDescriptorType` or `ClassMethodDescriptorType` -- the latter two are responsible for handling methods of classes and class instances in C extensions), the `signature()` function of the `inspect` module is used first to extract the function signature. Should it fail, we fall back to the `__text_signature__` property, which is filled by Python itself automatically if the docstring starts with `objectname(...)\n--\n\n`. Note that this should happen only if the text signature is mistyped -- if it is a valid Python signature, the `inspect` module should have already parsed it to provide the signature (see [here](https://github.com/python/cpython/blob/9f220e4968cf73fa60440120ee46881e7974e47d/Lib/inspect.py#L1958-L2093)).

The base template writer was also extended to use `text_signature` as a fallback if the signature is missing.
