### PR TITLE
Look up identifiers in parent classes as well when parsing Epydoc markup

### DIFF
--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -184,6 +184,11 @@ class _EpydocLinker(DocstringLinker):
             target = src.resolveName(identifier)
             if target is not None:
                 return target
+            if isinstance(src, model.Class):
+                for base in src.allbases():
+                    target = base.resolveName(identifier)
+                    if target is not None:
+                        return target
             src = src.parent
 
         # Walk up the object tree again and see if 'identifier' refers to an


### PR DESCRIPTION
This PR changes the Eypdoc markup parser to look up identifiers in parent classes as well when trying to resolve a link target in a class context. The proposed changes in this PR were necessary to build the documentation of `python-igraph` using PyDoctor (see the results [here](https://igraph.org/python/doc/api/index.html)).

I could not find any formal description of how the method lookup should proceed with the Epydoc markup; all that I know is that we've been using Epydoc in the past with `python-igraph` and references to methods in superclasses worked fine with Epydoc. We needed to switch to PyDoctor because we dropped support for Python 2.x and Epydoc could not parse Python 3.x markup any more. This PR essentially ensures that all the internal method links that used to work with Epydoc keep on working with PyDoctor as well.