### PR TITLE
Pass filename to ast.parse() for more useful warnings

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -20,7 +20,7 @@ def parseFile(path: Path) -> ast.Module:
     """Parse the contents of a Python source file."""
     with open(path, 'rb') as f:
         src = f.read() + b'\n'
-    return _parse(src)
+    return _parse(src, filename=str(path))
 
 if sys.version_info >= (3,8):
     _parse = partial(ast.parse, type_comments=True)


### PR DESCRIPTION
If any warnings are issued by `ast.parse()`, we'll now see the file path instead of `<unknown>` being printed.

To see parse warnings being logged, `export PYTHONWARNINGS=always` prior to running pydoctor. To trigger a warning, you can use for example `\s` or `\]` in a string literal without the `r` (raw) prefix.

I encountered this problem when investigating #376, but to reproduce it on `nltk` you might have to merge #360 first to avoid the assert failing.
