### PR TITLE
Annotate templatewriter

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -14,12 +14,6 @@ warn_unused_ignores=True
 
 plugins=mypy_zope:plugin
 
-# The following modules use twisted.web.template, hasn't received many
-# annotations yet:
-
-[mypy-pydoctor.epydoc.doctest]
-warn_return_any=False
-
 # The following modules are currently only partially annotated:
 
 [mypy-pydoctor.templatewriter.summary]

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,14 +14,6 @@ warn_unused_ignores=True
 
 plugins=mypy_zope:plugin
 
-# The following modules are currently only partially annotated:
-
-[mypy-pydoctor.templatewriter.summary]
-disallow_untyped_defs=False
-
-[mypy-pydoctor.templatewriter.pages.*]
-disallow_untyped_defs=False
-
 # The following external libraries don't support annotations (yet):
 
 [mypy-appdirs.*]

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -33,11 +33,15 @@ each error.
 """
 __docformat__ = 'epytext en'
 
-from typing import List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 import re
 
 from twisted.python.failure import Failure
-from twisted.web.template import Flattenable, Tag, XMLString, flattenString
+from twisted.web.template import Tag, XMLString, flattenString
+
+if TYPE_CHECKING:
+    from twisted.web.template import Flattenable
+
 
 ##################################################
 ## Contents
@@ -115,7 +119,7 @@ def html2stan(html: Union[bytes, str]) -> Tag:
     stan.tagName = ''
     return stan
 
-def flatten(stan: Flattenable) -> str:
+def flatten(stan: "Flattenable") -> str:
     """
     Convert a document fragment from a Stan tree to HTML.
 

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -37,7 +37,7 @@ from typing import List, Optional, Sequence, Union
 import re
 
 from twisted.python.failure import Failure
-from twisted.web.template import Tag, XMLString, flattenString
+from twisted.web.template import Flattenable, Tag, XMLString, flattenString
 
 ##################################################
 ## Contents
@@ -109,12 +109,13 @@ def html2stan(html: Union[bytes, str]) -> Tag:
         html = html.encode('utf8')
 
     html = _RE_CONTROL.sub(lambda m:b'\\x%02x' % ord(m.group()), html)
-    stan: Tag = XMLString(b'<div>%s</div>' % html).load()[0]
+    stan = XMLString(b'<div>%s</div>' % html).load()[0]
+    assert isinstance(stan, Tag)
     assert stan.tagName == 'div'
     stan.tagName = ''
     return stan
 
-def flatten(stan: Tag) -> str:
+def flatten(stan: Flattenable) -> str:
     """
     Convert a document fragment from a Stan tree to HTML.
 

--- a/pydoctor/epydoc/markup/plaintext.py
+++ b/pydoctor/epydoc/markup/plaintext.py
@@ -40,4 +40,4 @@ class ParsedPlaintextDocstring(ParsedDocstring):
         return bool(self._text)
 
     def to_stan(self, docstring_linker: DocstringLinker) -> Tag:
-        return tags.p(self._text, class_='pre')  # type: ignore[no-any-return]
+        return tags.p(self._text, class_='pre')

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -5,8 +5,8 @@ Convert L{pydoctor.epydoc} parsed markup into renderable content.
 from collections import defaultdict
 from importlib import import_module
 from typing import (
-    Callable, ClassVar, DefaultDict, Dict, Generator, Iterable, Iterator, List,
-    Mapping, Optional, Sequence, Tuple, Union
+    TYPE_CHECKING, Callable, ClassVar, DefaultDict, Dict, Generator, Iterable,
+    Iterator, List, Mapping, Optional, Sequence, Tuple, Union
 )
 import ast
 import itertools
@@ -16,9 +16,12 @@ import attr
 
 from pydoctor import model
 from pydoctor.epydoc.markup import Field as EpydocField, ParseError
-from twisted.web.template import Flattenable, Tag, tags
+from twisted.web.template import Tag, tags
 from pydoctor.epydoc.markup import DocstringLinker, ParsedDocstring
 import pydoctor.epydoc.markup.plaintext
+
+if TYPE_CHECKING:
+    from twisted.web.template import Flattenable
 
 
 def get_parser(obj: model.Documentable) -> Callable[[str, List[ParseError]], ParsedDocstring]:
@@ -712,7 +715,7 @@ def format_summary(obj: model.Documentable) -> Tag:
         # so don't spam the log.
         return tags.span(class_='undocumented')("Broken description")
 
-    content: Sequence[Flattenable] = [stan] if stan.tagName else stan.children
+    content: Sequence["Flattenable"] = [stan] if stan.tagName else stan.children
     if content and isinstance(content[0], Tag) and content[0].tagName == 'p':
         content = content[0].children
     return tags.span(*content)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -109,9 +109,9 @@ class _EpydocLinker(DocstringLinker):
 
         url = self.look_for_intersphinx(fullID)
         if url is not None:
-            return tags.a(label, href=url)  # type: ignore[no-any-return]
+            return tags.a(label, href=url)
 
-        return tags.transparent(label)  # type: ignore[no-any-return]
+        return tags.transparent(label)
 
     def link_xref(self, target: str, label: str, lineno: int) -> Tag:
         xref: Union[Tag, str]
@@ -574,9 +574,9 @@ class FieldHandler:
             r += format_desc_list(f"Unknown Field: {kind}", fieldlist)
 
         if any(r):
-            return tags.table(class_='fieldTable')(r) # type: ignore[no-any-return]
+            return tags.table(class_='fieldTable')(r)
         else:
-            return tags.transparent # type: ignore[no-any-return]
+            return tags.transparent
 
 
 def _is_none_literal(node: ast.expr) -> bool:
@@ -701,7 +701,7 @@ def format_summary(obj: model.Documentable) -> Tag:
                 )
             ]
         if len(lines) > 3:
-            return tags.span(class_='undocumented')("No summary") # type: ignore[no-any-return]
+            return tags.span(class_='undocumented')("No summary")
         pdoc = parse_docstring(obj, ' '.join(lines), source)
 
     try:
@@ -709,12 +709,12 @@ def format_summary(obj: model.Documentable) -> Tag:
     except Exception:
         # This problem will likely be reported by the full docstring as well,
         # so don't spam the log.
-        return tags.span(class_='undocumented')("Broken description") # type: ignore[no-any-return]
+        return tags.span(class_='undocumented')("Broken description")
 
     content = [stan] if stan.tagName else stan.children
     if content and isinstance(content[0], Tag) and content[0].tagName == 'p':
         content = content[0].children
-    return tags.span(*content) # type: ignore[no-any-return]
+    return tags.span(*content)
 
 
 def format_undocumented(obj: model.Documentable) -> Tag:

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -5,8 +5,8 @@ Convert L{pydoctor.epydoc} parsed markup into renderable content.
 from collections import defaultdict
 from importlib import import_module
 from typing import (
-    Callable, ClassVar, DefaultDict, Dict, Iterable, Iterator, List, Mapping,
-    Optional, Sequence, Tuple, Union
+    Callable, ClassVar, DefaultDict, Dict, Generator, Iterable, Iterator, List,
+    Mapping, Optional, Sequence, Tuple, Union
 )
 import ast
 import itertools
@@ -16,7 +16,7 @@ import attr
 
 from pydoctor import model
 from pydoctor.epydoc.markup import Field as EpydocField, ParseError
-from twisted.web.template import Tag, tags
+from twisted.web.template import Flattenable, Tag, tags
 from pydoctor.epydoc.markup import DocstringLinker, ParsedDocstring
 import pydoctor.epydoc.markup.plaintext
 
@@ -232,7 +232,7 @@ class FieldDesc:
     type: Optional[Tag] = None
     body: Optional[Tag] = None
 
-    def format(self) -> Iterator[Tag]:
+    def format(self) -> Generator[Tag, None, None]:
         """
         @return: Iterator that yields one or two C{tags.td}.
         """
@@ -256,7 +256,8 @@ class FieldDesc:
 class RaisesDesc(FieldDesc):
     """Description of an exception that can be raised by function/method."""
 
-    def format(self) -> Iterator[Tag]:
+    def format(self) -> Generator[Tag, None, None]:
+        assert self.type is not None  # TODO: Why can't it be None?
         yield tags.td(tags.code(self.type), class_="fieldArgContainer")
         yield tags.td(self.body or self._UNDOCUMENTED)
 
@@ -711,7 +712,7 @@ def format_summary(obj: model.Documentable) -> Tag:
         # so don't spam the log.
         return tags.span(class_='undocumented')("Broken description")
 
-    content = [stan] if stan.tagName else stan.children
+    content: Sequence[Flattenable] = [stan] if stan.tagName else stan.children
     if content and isinstance(content[0], Tag) and content[0].tagName == 'p':
         content = content[0].children
     return tags.span(*content)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -775,9 +775,7 @@ class AnnotationDocstring(ParsedDocstring):
         self.annotation = annotation
 
     def to_stan(self, docstring_linker: DocstringLinker) -> Tag:
-        tag: Tag = tags.code
-        tag(_AnnotationFormatter(docstring_linker).visit(self.annotation))
-        return tag
+        return tags.code(_AnnotationFormatter(docstring_linker).visit(self.annotation))
 
 
 class _AnnotationFormatter(ast.NodeVisitor):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -28,6 +28,7 @@ from pydoctor.sphinx import CacheT, SphinxInventory
 
 if TYPE_CHECKING:
     from typing_extensions import Literal
+    from twisted.web.template import Flattenable
     from pydoctor.astbuilder import ASTBuilder
 else:
     Literal = {True: bool, False: bool}
@@ -133,6 +134,7 @@ class Documentable:
         self.parent = parent
         self.parentMod: Optional[Module] = None
         self.source_path: Optional[Path] = source_path
+        self._deprecated_info: Optional["Flattenable"] = None
         self.setup()
 
     @property

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -1,17 +1,25 @@
 """The classes that turn  L{Documentable} instances into objects we can render."""
 
-from typing import Any, Dict, Iterator, List, Optional, Mapping, Sequence, Tuple, Union, Type
+from typing import (
+    TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Mapping, Sequence,
+    Tuple, Type, Union
+)
 import ast
 import abc
 
-from twisted.web.template import Element, Flattenable, Tag, renderer, tags
 import astor
-
 from twisted.web.iweb import IRenderable, ITemplateLoader, IRequest
+from twisted.web.template import Element, Flattenable, Tag, renderer, tags
+
 from pydoctor import epydoc2stan, model, zopeinterface, __version__
 from pydoctor.astbuilder import node2fullname
 from pydoctor.templatewriter import util, TemplateLookup, TemplateElement
 from pydoctor.templatewriter.pages.table import ChildTable
+
+if TYPE_CHECKING:
+    from pydoctor.templatewriter.pages.attributechild import AttributeChild
+    from pydoctor.templatewriter.pages.functionchild import FunctionChild
+
 
 def objects_order(o: model.Documentable) -> Tuple[int, int, str]: 
     """
@@ -159,10 +167,10 @@ class CommonPage(Page):
     def page_url(self) -> str:
         return self.ob.page_object.url
 
-    def title(self):
+    def title(self) -> str:
         return self.ob.fullName()
 
-    def heading(self):
+    def heading(self) -> Tag:
         return tags.h1(class_=util.css_class(self.ob))(
             tags.code(self.namespace(self.ob))
             )
@@ -172,7 +180,7 @@ class CommonPage(Page):
         assert kind is not None
         return f"{epydoc2stan.format_kind(kind).lower()} documentation"
 
-    def namespace(self, obj: model.Documentable) -> Sequence[Union[Tag, str]]:
+    def namespace(self, obj: model.Documentable) -> List[Union[Tag, str]]:
         page_url = self.page_url
         parts: List[Union[Tag, str]] = []
         ob: Optional[model.Documentable] = obj
@@ -186,42 +194,43 @@ class CommonPage(Page):
         return parts
 
     @renderer
-    def deprecated(self, request, tag):
-        if hasattr(self.ob, "_deprecated_info"):
-            return (tags.div(self.ob._deprecated_info, role="alert", class_="deprecationNotice alert alert-warning"),)
-        else:
+    def deprecated(self, request: object, tag: Tag) -> Flattenable:
+        msg: Optional[Flattenable] = getattr(self.ob, "_deprecated_info", None)
+        if msg is None:
             return ()
+        else:
+            return tags.div(msg, role="alert", class_="deprecationNotice alert alert-warning")
 
     @renderer
-    def source(self, request, tag):
+    def source(self, request: object, tag: Tag) -> Flattenable:
         sourceHref = util.srclink(self.ob)
         if not sourceHref:
             return ()
         return tag(href=sourceHref)
 
     @renderer
-    def inhierarchy(self, request, tag):
+    def inhierarchy(self, request: object, tag: Tag) -> Flattenable:
         return ()
 
-    def extras(self):
+    def extras(self) -> List[Flattenable]:
         return []
 
-    def docstring(self):
+    def docstring(self) -> Flattenable:
         return self.docgetter.get(self.ob)
 
-    def children(self):
+    def children(self) -> Sequence[model.Documentable]:
         return sorted(
             (o for o in self.ob.contents.values() if o.isVisible),
             key=objects_order)
 
-    def packageInitTable(self):
+    def packageInitTable(self) -> Flattenable:
         return ()
 
     @renderer
-    def baseTables(self, request, tag):
+    def baseTables(self, request: object, tag: Tag) -> Flattenable:
         return ()
 
-    def mainTable(self):
+    def mainTable(self) -> Flattenable:
         children = self.children()
         if children:
             return ChildTable(self.docgetter, self.ob, children,
@@ -229,16 +238,16 @@ class CommonPage(Page):
         else:
             return ()
 
-    def methods(self):
+    def methods(self) -> Sequence[model.Documentable]:
         return sorted((o for o in self.ob.contents.values()
                        if o.documentation_location is model.DocLocation.PARENT_PAGE and o.isVisible), 
                       key=objects_order)
 
-    def childlist(self):
+    def childlist(self) -> List[Union["AttributeChild", "FunctionChild"]]:
         from pydoctor.templatewriter.pages.attributechild import AttributeChild
         from pydoctor.templatewriter.pages.functionchild import FunctionChild
 
-        r = []
+        r: List[Union["AttributeChild", "FunctionChild"]] = []
 
         func_loader = FunctionChild.lookup_loader(self.template_lookup)
         attr_loader = AttributeChild.lookup_loader(self.template_lookup)
@@ -246,14 +255,16 @@ class CommonPage(Page):
         for c in self.methods():
             if isinstance(c, model.Function):
                 r.append(FunctionChild(self.docgetter, c, self.functionExtras(c), func_loader))
-            else:
+            elif isinstance(c, model.Attribute):
                 r.append(AttributeChild(self.docgetter, c, self.functionExtras(c), attr_loader))
+            else:
+                assert False, type(c)
         return r
 
-    def functionExtras(self, data):
+    def functionExtras(self, data: model.Documentable) -> List[Flattenable]:
         return []
 
-    def functionBody(self, data):
+    def functionBody(self, data: model.Documentable) -> Flattenable:
         return self.docgetter.get(data)
 
     @property
@@ -272,7 +283,7 @@ class CommonPage(Page):
 
 
 class ModulePage(CommonPage):
-    def extras(self):
+    def extras(self) -> List[Flattenable]:
         r = super().extras()
 
         sourceHref = util.srclink(self.ob)
@@ -283,13 +294,13 @@ class ModulePage(CommonPage):
 
 
 class PackagePage(ModulePage):
-    def children(self):
+    def children(self) -> Sequence[model.Documentable]:
         return sorted(
             (o for o in self.ob.contents.values()
              if isinstance(o, model.Module) and o.isVisible),
             key=objects_order)
 
-    def packageInitTable(self):
+    def packageInitTable(self) -> Flattenable:
         children = sorted(
             (o for o in self.ob.contents.values()
              if not isinstance(o, model.Module) and o.isVisible),
@@ -303,13 +314,17 @@ class PackagePage(ModulePage):
         else:
             return ()
 
-    def methods(self):
+    def methods(self) -> Sequence[model.Documentable]:
         return [o for o in self.ob.contents.values()
                 if o.documentation_location is model.DocLocation.PARENT_PAGE
                 and o.isVisible]
 
 
-def overriding_subclasses(c, name, firstcall=True):
+def overriding_subclasses(
+        c: model.Class,
+        name: str,
+        firstcall: bool = True
+        ) -> Iterator[model.Class]:
     if not firstcall and name in c.contents:
         yield c
     else:
@@ -317,8 +332,8 @@ def overriding_subclasses(c, name, firstcall=True):
             if sc.isVisible:
                 yield from overriding_subclasses(sc, name, False)
 
-def nested_bases(b):
-    r = [(b,)]
+def nested_bases(b: model.Class) -> Sequence[Tuple[model.Class, ...]]:
+    r: List[Tuple[model.Class, ...]] = [(b,)]
     for b2 in b.baseobjects:
         if b2 is None:
             continue
@@ -326,7 +341,7 @@ def nested_bases(b):
             r.append(n + (b,))
     return r
 
-def unmasked_attrs(baselist):
+def unmasked_attrs(baselist: Sequence[model.Documentable]) -> Sequence[model.Documentable]:
     maybe_masking = {
         o.name
         for b in baselist[1:]
@@ -335,8 +350,13 @@ def unmasked_attrs(baselist):
     return [o for o in baselist[0].contents.values()
             if o.isVisible and o.name not in maybe_masking]
 
-
-def assembleList(system, label, lst, idbase, page_url):
+def assembleList(
+        system: model.System,
+        label: str,
+        lst: Sequence[str],
+        idbase: str,
+        page_url: str
+        ) -> Optional[Flattenable]:
     lst2 = []
     for name in lst:
         o = system.allobjects.get(name)
@@ -345,19 +365,19 @@ def assembleList(system, label, lst, idbase, page_url):
     lst = lst2
     if not lst:
         return None
-    def one(item):
+    def one(item: str) -> Flattenable:
         if item in system.allobjects:
             return tags.code(epydoc2stan.taglink(system.allobjects[item], page_url))
         else:
             return item
-    def commasep(items):
+    def commasep(items: Sequence[str]) -> List[Flattenable]:
         r = []
         for item in items:
             r.append(one(item))
             r.append(', ')
         del r[-1]
         return r
-    p = [label]
+    p: List[Flattenable] = [label]
     p.extend(commasep(lst))
     return p
 
@@ -366,8 +386,11 @@ class ClassPage(CommonPage):
 
     ob: model.Class
 
-    def __init__(self, ob:model.Documentable, template_lookup:TemplateLookup,
-                 docgetter:Optional[DocGetter] = None):
+    def __init__(self,
+            ob: model.Documentable,
+            template_lookup: TemplateLookup,
+            docgetter: Optional[DocGetter] = None
+            ):
         super().__init__(ob, template_lookup, docgetter)
         self.baselists = []
         for baselist in nested_bases(self.ob):
@@ -376,10 +399,11 @@ class ClassPage(CommonPage):
                 self.baselists.append((baselist, attrs))
         self.overridenInCount = 0
 
-    def extras(self):
+    def extras(self) -> List[Flattenable]:
         r = super().extras()
 
         sourceHref = util.srclink(self.ob)
+        source: Flattenable
         if sourceHref:
             source = (" ", tags.a("(source)", href=sourceHref, class_="sourceLink"))
         else:
@@ -424,11 +448,11 @@ class ClassPage(CommonPage):
         return r
 
     @renderer
-    def inhierarchy(self, request, tag):
+    def inhierarchy(self, request: object, tag: Tag) -> Tag:
         return tag(href="classIndex.html#"+self.ob.fullName())
 
     @renderer
-    def baseTables(self, request, item):
+    def baseTables(self, request: object, item: Tag) -> Flattenable:
         baselists = self.baselists[:]
         if not baselists:
             return []
@@ -442,14 +466,14 @@ class ClassPage(CommonPage):
                                                loader))
                 for b, attrs in baselists]
 
-    def baseName(self, data: Tuple[model.Class, ...]) -> List[str]:
+    def baseName(self, data: Sequence[model.Class]) -> Flattenable:
         page_url = self.page_url
-        r = []
+        r: List[Flattenable] = []
         source_base = data[0]
         r.append(tags.code(epydoc2stan.taglink(source_base, page_url, source_base.name)))
         bases_to_mention = data[1:-1]
         if bases_to_mention:
-            tail = []
+            tail: List[Flattenable] = []
             for b in reversed(bases_to_mention):
                 tail.append(tags.code(epydoc2stan.taglink(b, page_url, b.name)))
                 tail.append(', ')
@@ -457,17 +481,18 @@ class ClassPage(CommonPage):
             r.extend([' (via ', tail, ')'])
         return r
 
-    def functionExtras(self, ob):
+    def functionExtras(self, data: model.Documentable) -> List[Flattenable]:
         page_url = self.page_url
-        r = []
+        name = data.name
+        r: List[Flattenable] = []
         for b in self.ob.allbases(include_self=False):
-            if ob.name not in b.contents:
+            if name not in b.contents:
                 continue
-            overridden = b.contents[ob.name]
+            overridden = b.contents[name]
             r.append(tags.div(class_="interfaceinfo")(
                 'overrides ', tags.code(epydoc2stan.taglink(overridden, page_url))))
             break
-        ocs = sorted(overriding_subclasses(self.ob, ob.name), key=objects_order)
+        ocs = sorted(overriding_subclasses(self.ob, name), key=objects_order)
         if ocs:
             self.overridenInCount += 1
             idbase = 'overridenIn' + str(self.overridenInCount)
@@ -480,9 +505,9 @@ class ClassPage(CommonPage):
 
 class ZopeInterfaceClassPage(ClassPage):
     ob: zopeinterface.ZopeInterfaceClass
-    
-    def extras(self):
-        r = [super().extras()]
+
+    def extras(self) -> List[Flattenable]:
+        r = super().extras()
         if self.ob.isinterface:
             namelist = [o.fullName() for o in 
                         sorted(self.ob.implementedby_directly, key=objects_order)]
@@ -497,22 +522,26 @@ class ZopeInterfaceClassPage(ClassPage):
                 r.append(tags.p(l))
         return r
 
-    def interfaceMeth(self, methname):
+    def interfaceMeth(self, methname: str) -> Optional[model.Documentable]:
         system = self.ob.system
         for interface in self.ob.allImplementedInterfaces:
             if interface in system.allobjects:
                 io = system.allobjects[interface]
+                assert isinstance(io, zopeinterface.ZopeInterfaceClass)
                 for io2 in io.allbases(include_self=True):
-                    if methname in io2.contents:
-                        return io2.contents[methname]
+                    method: Optional[model.Documentable] = io2.contents.get(methname)
+                    if method is not None:
+                        return method
         return None
 
-    def functionExtras(self, data):
+    def functionExtras(self, data: model.Documentable) -> List[Flattenable]:
         imeth = self.interfaceMeth(data.name)
-        r = []
+        r: List[Flattenable] = []
         if imeth:
+            iface = imeth.parent
+            assert iface is not None
             r.append(tags.div(class_="interfaceinfo")('from ', tags.code(
-                epydoc2stan.taglink(imeth, self.page_url, imeth.parent.fullName())
+                epydoc2stan.taglink(imeth, self.page_url, iface.fullName())
                 )))
         r.extend(super().functionExtras(data))
         return r

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -196,7 +196,7 @@ class CommonPage(Page):
 
     @renderer
     def deprecated(self, request: object, tag: Tag) -> "Flattenable":
-        msg: Optional["Flattenable"] = getattr(self.ob, "_deprecated_info", None)
+        msg = self.ob._deprecated_info
         if msg is None:
             return ()
         else:

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -9,7 +9,7 @@ import abc
 
 import astor
 from twisted.web.iweb import IRenderable, ITemplateLoader, IRequest
-from twisted.web.template import Element, Flattenable, Tag, renderer, tags
+from twisted.web.template import Element, Tag, renderer, tags
 
 from pydoctor import epydoc2stan, model, zopeinterface, __version__
 from pydoctor.astbuilder import node2fullname
@@ -17,6 +17,7 @@ from pydoctor.templatewriter import util, TemplateLookup, TemplateElement
 from pydoctor.templatewriter.pages.table import ChildTable
 
 if TYPE_CHECKING:
+    from twisted.web.template import Flattenable
     from pydoctor.templatewriter.pages.attributechild import AttributeChild
     from pydoctor.templatewriter.pages.functionchild import FunctionChild
 
@@ -111,7 +112,7 @@ class Page(TemplateElement):
         return tags.transparent(super().render(request)).fillSlots(**self.slot_map)
 
     @property
-    def slot_map(self) -> Dict[str, Flattenable]:
+    def slot_map(self) -> Dict[str, "Flattenable"]:
         system = self.system
 
         if system.options.projecturl:
@@ -194,28 +195,28 @@ class CommonPage(Page):
         return parts
 
     @renderer
-    def deprecated(self, request: object, tag: Tag) -> Flattenable:
-        msg: Optional[Flattenable] = getattr(self.ob, "_deprecated_info", None)
+    def deprecated(self, request: object, tag: Tag) -> "Flattenable":
+        msg: Optional["Flattenable"] = getattr(self.ob, "_deprecated_info", None)
         if msg is None:
             return ()
         else:
             return tags.div(msg, role="alert", class_="deprecationNotice alert alert-warning")
 
     @renderer
-    def source(self, request: object, tag: Tag) -> Flattenable:
+    def source(self, request: object, tag: Tag) -> "Flattenable":
         sourceHref = util.srclink(self.ob)
         if not sourceHref:
             return ()
         return tag(href=sourceHref)
 
     @renderer
-    def inhierarchy(self, request: object, tag: Tag) -> Flattenable:
+    def inhierarchy(self, request: object, tag: Tag) -> "Flattenable":
         return ()
 
-    def extras(self) -> List[Flattenable]:
+    def extras(self) -> List["Flattenable"]:
         return []
 
-    def docstring(self) -> Flattenable:
+    def docstring(self) -> "Flattenable":
         return self.docgetter.get(self.ob)
 
     def children(self) -> Sequence[model.Documentable]:
@@ -223,14 +224,14 @@ class CommonPage(Page):
             (o for o in self.ob.contents.values() if o.isVisible),
             key=objects_order)
 
-    def packageInitTable(self) -> Flattenable:
+    def packageInitTable(self) -> "Flattenable":
         return ()
 
     @renderer
-    def baseTables(self, request: object, tag: Tag) -> Flattenable:
+    def baseTables(self, request: object, tag: Tag) -> "Flattenable":
         return ()
 
-    def mainTable(self) -> Flattenable:
+    def mainTable(self) -> "Flattenable":
         children = self.children()
         if children:
             return ChildTable(self.docgetter, self.ob, children,
@@ -261,14 +262,14 @@ class CommonPage(Page):
                 assert False, type(c)
         return r
 
-    def functionExtras(self, data: model.Documentable) -> List[Flattenable]:
+    def functionExtras(self, data: model.Documentable) -> List["Flattenable"]:
         return []
 
-    def functionBody(self, data: model.Documentable) -> Flattenable:
+    def functionBody(self, data: model.Documentable) -> "Flattenable":
         return self.docgetter.get(data)
 
     @property
-    def slot_map(self) -> Dict[str, Flattenable]:
+    def slot_map(self) -> Dict[str, "Flattenable"]:
         slot_map = super().slot_map
         slot_map.update(
             heading=self.heading(),
@@ -283,7 +284,7 @@ class CommonPage(Page):
 
 
 class ModulePage(CommonPage):
-    def extras(self) -> List[Flattenable]:
+    def extras(self) -> List["Flattenable"]:
         r = super().extras()
 
         sourceHref = util.srclink(self.ob)
@@ -300,7 +301,7 @@ class PackagePage(ModulePage):
              if isinstance(o, model.Module) and o.isVisible),
             key=objects_order)
 
-    def packageInitTable(self) -> Flattenable:
+    def packageInitTable(self) -> "Flattenable":
         children = sorted(
             (o for o in self.ob.contents.values()
              if not isinstance(o, model.Module) and o.isVisible),
@@ -356,7 +357,7 @@ def assembleList(
         lst: Sequence[str],
         idbase: str,
         page_url: str
-        ) -> Optional[Flattenable]:
+        ) -> Optional["Flattenable"]:
     lst2 = []
     for name in lst:
         o = system.allobjects.get(name)
@@ -365,19 +366,19 @@ def assembleList(
     lst = lst2
     if not lst:
         return None
-    def one(item: str) -> Flattenable:
+    def one(item: str) -> "Flattenable":
         if item in system.allobjects:
             return tags.code(epydoc2stan.taglink(system.allobjects[item], page_url))
         else:
             return item
-    def commasep(items: Sequence[str]) -> List[Flattenable]:
+    def commasep(items: Sequence[str]) -> List["Flattenable"]:
         r = []
         for item in items:
             r.append(one(item))
             r.append(', ')
         del r[-1]
         return r
-    p: List[Flattenable] = [label]
+    p: List["Flattenable"] = [label]
     p.extend(commasep(lst))
     return p
 
@@ -399,11 +400,11 @@ class ClassPage(CommonPage):
                 self.baselists.append((baselist, attrs))
         self.overridenInCount = 0
 
-    def extras(self) -> List[Flattenable]:
+    def extras(self) -> List["Flattenable"]:
         r = super().extras()
 
         sourceHref = util.srclink(self.ob)
-        source: Flattenable
+        source: "Flattenable"
         if sourceHref:
             source = (" ", tags.a("(source)", href=sourceHref, class_="sourceLink"))
         else:
@@ -423,8 +424,8 @@ class ClassPage(CommonPage):
             r.append(tags.p(p))
         return r
 
-    def classSignature(self) -> Flattenable:
-        r: List[Flattenable] = []
+    def classSignature(self) -> "Flattenable":
+        r: List["Flattenable"] = []
         zipped = list(zip(self.ob.rawbases, self.ob.bases, self.ob.baseobjects))
         if zipped:
             r.append('(')
@@ -452,7 +453,7 @@ class ClassPage(CommonPage):
         return tag(href="classIndex.html#"+self.ob.fullName())
 
     @renderer
-    def baseTables(self, request: object, item: Tag) -> Flattenable:
+    def baseTables(self, request: object, item: Tag) -> "Flattenable":
         baselists = self.baselists[:]
         if not baselists:
             return []
@@ -466,14 +467,14 @@ class ClassPage(CommonPage):
                                                loader))
                 for b, attrs in baselists]
 
-    def baseName(self, data: Sequence[model.Class]) -> Flattenable:
+    def baseName(self, data: Sequence[model.Class]) -> "Flattenable":
         page_url = self.page_url
-        r: List[Flattenable] = []
+        r: List["Flattenable"] = []
         source_base = data[0]
         r.append(tags.code(epydoc2stan.taglink(source_base, page_url, source_base.name)))
         bases_to_mention = data[1:-1]
         if bases_to_mention:
-            tail: List[Flattenable] = []
+            tail: List["Flattenable"] = []
             for b in reversed(bases_to_mention):
                 tail.append(tags.code(epydoc2stan.taglink(b, page_url, b.name)))
                 tail.append(', ')
@@ -481,10 +482,10 @@ class ClassPage(CommonPage):
             r.extend([' (via ', tail, ')'])
         return r
 
-    def functionExtras(self, data: model.Documentable) -> List[Flattenable]:
+    def functionExtras(self, data: model.Documentable) -> List["Flattenable"]:
         page_url = self.page_url
         name = data.name
-        r: List[Flattenable] = []
+        r: List["Flattenable"] = []
         for b in self.ob.allbases(include_self=False):
             if name not in b.contents:
                 continue
@@ -506,7 +507,7 @@ class ClassPage(CommonPage):
 class ZopeInterfaceClassPage(ClassPage):
     ob: zopeinterface.ZopeInterfaceClass
 
-    def extras(self) -> List[Flattenable]:
+    def extras(self) -> List["Flattenable"]:
         r = super().extras()
         if self.ob.isinterface:
             namelist = [o.fullName() for o in 
@@ -534,9 +535,9 @@ class ZopeInterfaceClassPage(ClassPage):
                         return method
         return None
 
-    def functionExtras(self, data: model.Documentable) -> List[Flattenable]:
+    def functionExtras(self, data: model.Documentable) -> List["Flattenable"]:
         imeth = self.interfaceMeth(data.name)
-        r: List[Flattenable] = []
+        r: List["Flattenable"] = []
         if imeth:
             iface = imeth.parent
             assert iface is not None

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -262,11 +262,11 @@ class CommonPage(Page):
                 assert False, type(c)
         return r
 
-    def functionExtras(self, data: model.Documentable) -> List["Flattenable"]:
+    def functionExtras(self, ob: model.Documentable) -> List["Flattenable"]:
         return []
 
-    def functionBody(self, data: model.Documentable) -> "Flattenable":
-        return self.docgetter.get(data)
+    def functionBody(self, ob: model.Documentable) -> "Flattenable":
+        return self.docgetter.get(ob)
 
     @property
     def slot_map(self) -> Dict[str, "Flattenable"]:
@@ -467,12 +467,12 @@ class ClassPage(CommonPage):
                                                loader))
                 for b, attrs in baselists]
 
-    def baseName(self, data: Sequence[model.Class]) -> "Flattenable":
+    def baseName(self, bases: Sequence[model.Class]) -> "Flattenable":
         page_url = self.page_url
         r: List["Flattenable"] = []
-        source_base = data[0]
+        source_base = bases[0]
         r.append(tags.code(epydoc2stan.taglink(source_base, page_url, source_base.name)))
-        bases_to_mention = data[1:-1]
+        bases_to_mention = bases[1:-1]
         if bases_to_mention:
             tail: List["Flattenable"] = []
             for b in reversed(bases_to_mention):
@@ -482,9 +482,9 @@ class ClassPage(CommonPage):
             r.extend([' (via ', tail, ')'])
         return r
 
-    def functionExtras(self, data: model.Documentable) -> List["Flattenable"]:
+    def functionExtras(self, ob: model.Documentable) -> List["Flattenable"]:
         page_url = self.page_url
-        name = data.name
+        name = ob.name
         r: List["Flattenable"] = []
         for b in self.ob.allbases(include_self=False):
             if name not in b.contents:
@@ -535,8 +535,8 @@ class ZopeInterfaceClassPage(ClassPage):
                         return method
         return None
 
-    def functionExtras(self, data: model.Documentable) -> List["Flattenable"]:
-        imeth = self.interfaceMeth(data.name)
+    def functionExtras(self, ob: model.Documentable) -> List["Flattenable"]:
+        imeth = self.interfaceMeth(ob.name)
         r: List["Flattenable"] = []
         if imeth:
             iface = imeth.parent
@@ -544,7 +544,7 @@ class ZopeInterfaceClassPage(ClassPage):
             r.append(tags.div(class_="interfaceinfo")('from ', tags.code(
                 epydoc2stan.taglink(imeth, self.page_url, iface.fullName())
                 )))
-        r.extend(super().functionExtras(data))
+        r.extend(super().functionExtras(ob))
         return r
 
 commonpages: Mapping[str, Type[CommonPage]] = {

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -1,64 +1,74 @@
-from twisted.web.template import renderer, tags
+from typing import List, Optional
 
+from twisted.web.iweb import ITemplateLoader
+from twisted.web.template import Flattenable, Tag, renderer, tags
+
+from pydoctor.model import Attribute
 from pydoctor.templatewriter import TemplateElement, util
-from pydoctor.templatewriter.pages import format_decorators
+from pydoctor.templatewriter.pages import DocGetter, format_decorators
 
 
 class AttributeChild(TemplateElement):
 
     filename = 'attribute-child.html'
 
-    def __init__(self, docgetter, ob, extras, loader):
+    def __init__(self,
+            docgetter: DocGetter,
+            ob: Attribute,
+            extras: Flattenable,
+            loader: ITemplateLoader
+            ):
         super().__init__(loader)
         self.docgetter = docgetter
         self.ob = ob
         self._functionExtras = extras
 
     @renderer
-    def class_(self, request, tag):
+    def class_(self, request: object, tag: Tag) -> Flattenable:
         class_ = util.css_class(self.ob)
         if self.ob.parent is not self.ob:
             class_ = 'base' + class_
         return class_
 
     @renderer
-    def functionAnchor(self, request, tag):
+    def functionAnchor(self, request: object, tag: Tag) -> Flattenable:
         return self.ob.fullName()
 
     @renderer
-    def shortFunctionAnchor(self, request, tag):
+    def shortFunctionAnchor(self, request: object, tag: Tag) -> Flattenable:
         return self.ob.name
 
     @renderer
-    def decorator(self, request, tag):
+    def decorator(self, request: object, tag: Tag) -> Flattenable:
         return list(format_decorators(self.ob))
 
     @renderer
-    def attribute(self, request, tag):
-        attr = [tags.span(self.ob.name, class_='py-defname')]
+    def attribute(self, request: object, tag: Tag) -> Flattenable:
+        attr: List[Flattenable] = [tags.span(self.ob.name, class_='py-defname')]
         _type = self.docgetter.get_type(self.ob)
         if _type:
             attr.extend([': ', _type])
         return attr
 
     @renderer
-    def sourceLink(self, request, tag):
+    def sourceLink(self, request: object, tag: Tag) -> Flattenable:
         if self.ob.sourceHref:
             return tag.fillSlots(sourceHref=self.ob.sourceHref)
         else:
             return ()
 
     @renderer
-    def functionExtras(self, request, tag):
+    def functionExtras(self, request: object, tag: Tag) -> Flattenable:
         return self._functionExtras
 
     @renderer
-    def functionBody(self, request, tag):
+    def functionBody(self, request: object, tag: Tag) -> Flattenable:
         return self.docgetter.get(self.ob)
 
     @renderer
-    def functionDeprecated(self, request, tag):
-        if hasattr(self.ob, "_deprecated_info"):
-            return (tags.div(self.ob._deprecated_info, role="alert", class_="deprecationNotice alert alert-warning"),)
-        else:
+    def functionDeprecated(self, request: object, tag: Tag) -> Flattenable:
+        msg: Optional[Flattenable] = getattr(self.ob, "_deprecated_info", None)
+        if msg is None:
             return ()
+        else:
+            return tags.div(msg, role="alert", class_="deprecationNotice alert alert-warning")

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -70,7 +70,7 @@ class AttributeChild(TemplateElement):
 
     @renderer
     def functionDeprecated(self, request: object, tag: Tag) -> "Flattenable":
-        msg: Optional["Flattenable"] = getattr(self.ob, "_deprecated_info", None)
+        msg = self.ob._deprecated_info
         if msg is None:
             return ()
         else:

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List
 
 from twisted.web.iweb import ITemplateLoader
 from twisted.web.template import Tag, renderer, tags

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -1,11 +1,14 @@
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from twisted.web.iweb import ITemplateLoader
-from twisted.web.template import Flattenable, Tag, renderer, tags
+from twisted.web.template import Tag, renderer, tags
 
 from pydoctor.model import Attribute
 from pydoctor.templatewriter import TemplateElement, util
 from pydoctor.templatewriter.pages import DocGetter, format_decorators
+
+if TYPE_CHECKING:
+    from twisted.web.template import Flattenable
 
 
 class AttributeChild(TemplateElement):
@@ -15,7 +18,7 @@ class AttributeChild(TemplateElement):
     def __init__(self,
             docgetter: DocGetter,
             ob: Attribute,
-            extras: Flattenable,
+            extras: "Flattenable",
             loader: ITemplateLoader
             ):
         super().__init__(loader)
@@ -24,50 +27,50 @@ class AttributeChild(TemplateElement):
         self._functionExtras = extras
 
     @renderer
-    def class_(self, request: object, tag: Tag) -> Flattenable:
+    def class_(self, request: object, tag: Tag) -> "Flattenable":
         class_ = util.css_class(self.ob)
         if self.ob.parent is not self.ob:
             class_ = 'base' + class_
         return class_
 
     @renderer
-    def functionAnchor(self, request: object, tag: Tag) -> Flattenable:
+    def functionAnchor(self, request: object, tag: Tag) -> "Flattenable":
         return self.ob.fullName()
 
     @renderer
-    def shortFunctionAnchor(self, request: object, tag: Tag) -> Flattenable:
+    def shortFunctionAnchor(self, request: object, tag: Tag) -> "Flattenable":
         return self.ob.name
 
     @renderer
-    def decorator(self, request: object, tag: Tag) -> Flattenable:
+    def decorator(self, request: object, tag: Tag) -> "Flattenable":
         return list(format_decorators(self.ob))
 
     @renderer
-    def attribute(self, request: object, tag: Tag) -> Flattenable:
-        attr: List[Flattenable] = [tags.span(self.ob.name, class_='py-defname')]
+    def attribute(self, request: object, tag: Tag) -> "Flattenable":
+        attr: List["Flattenable"] = [tags.span(self.ob.name, class_='py-defname')]
         _type = self.docgetter.get_type(self.ob)
         if _type:
             attr.extend([': ', _type])
         return attr
 
     @renderer
-    def sourceLink(self, request: object, tag: Tag) -> Flattenable:
+    def sourceLink(self, request: object, tag: Tag) -> "Flattenable":
         if self.ob.sourceHref:
             return tag.fillSlots(sourceHref=self.ob.sourceHref)
         else:
             return ()
 
     @renderer
-    def functionExtras(self, request: object, tag: Tag) -> Flattenable:
+    def functionExtras(self, request: object, tag: Tag) -> "Flattenable":
         return self._functionExtras
 
     @renderer
-    def functionBody(self, request: object, tag: Tag) -> Flattenable:
+    def functionBody(self, request: object, tag: Tag) -> "Flattenable":
         return self.docgetter.get(self.ob)
 
     @renderer
-    def functionDeprecated(self, request: object, tag: Tag) -> Flattenable:
-        msg: Optional[Flattenable] = getattr(self.ob, "_deprecated_info", None)
+    def functionDeprecated(self, request: object, tag: Tag) -> "Flattenable":
+        msg: Optional["Flattenable"] = getattr(self.ob, "_deprecated_info", None)
         if msg is None:
             return ()
         else:

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -1,39 +1,48 @@
-from twisted.web.template import renderer, tags
+from typing import Optional
 
-from pydoctor.templatewriter.pages import format_decorators, signature
+from twisted.web.iweb import ITemplateLoader
+from twisted.web.template import Flattenable, Tag, renderer, tags
+
+from pydoctor.model import Function
 from pydoctor.templatewriter import TemplateElement, util
+from pydoctor.templatewriter.pages import DocGetter, format_decorators, signature
 
 class FunctionChild(TemplateElement):
 
     filename = 'function-child.html'
 
-    def __init__(self, docgetter, ob, extras, loader):
+    def __init__(self,
+            docgetter: DocGetter,
+            ob: Function,
+            extras: Flattenable,
+            loader: ITemplateLoader
+            ):
         super().__init__(loader)
         self.docgetter = docgetter
         self.ob = ob
         self._functionExtras = extras
 
     @renderer
-    def class_(self, request, tag):
+    def class_(self, request: object, tag: Tag) -> Flattenable:
         class_ = util.css_class(self.ob)
         if self.ob.parent is not self.ob:
             class_ = 'base' + class_
         return class_
 
     @renderer
-    def functionAnchor(self, request, tag):
+    def functionAnchor(self, request: object, tag: Tag) -> Flattenable:
         return self.ob.fullName()
 
     @renderer
-    def shortFunctionAnchor(self, request, tag):
+    def shortFunctionAnchor(self, request: object, tag: Tag) -> Flattenable:
         return self.ob.name
 
     @renderer
-    def decorator(self, request, tag):
+    def decorator(self, request: object, tag: Tag) -> Flattenable:
         return list(format_decorators(self.ob))
 
     @renderer
-    def functionDef(self, request, tag):
+    def functionDef(self, request: object, tag: Tag) -> Flattenable:
         def_stmt = 'async def' if self.ob.is_async else 'def'
         name = self.ob.name
         if name.endswith('.setter') or name.endswith('.deleter'):
@@ -44,23 +53,24 @@ class FunctionChild(TemplateElement):
             ]
 
     @renderer
-    def sourceLink(self, request, tag):
+    def sourceLink(self, request: object, tag: Tag) -> Flattenable:
         if self.ob.sourceHref:
             return tag.fillSlots(sourceHref=self.ob.sourceHref)
         else:
             return ()
 
     @renderer
-    def functionExtras(self, request, tag):
+    def functionExtras(self, request: object, tag: Tag) -> Flattenable:
         return self._functionExtras
 
     @renderer
-    def functionBody(self, request, tag):
+    def functionBody(self, request: object, tag: Tag) -> Flattenable:
         return self.docgetter.get(self.ob)
 
     @renderer
-    def functionDeprecated(self, request, tag):
-        if hasattr(self.ob, "_deprecated_info"):
-            return (tags.div(self.ob._deprecated_info, role="alert", class_="deprecationNotice alert alert-warning"),)
-        else:
+    def functionDeprecated(self, request: object, tag: Tag) -> Flattenable:
+        msg: Optional[Flattenable] = getattr(self.ob, "_deprecated_info", None)
+        if msg is None:
             return ()
+        else:
+            return tags.div(msg, role="alert", class_="deprecationNotice alert alert-warning")

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from twisted.web.iweb import ITemplateLoader
 from twisted.web.template import Tag, renderer, tags

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -73,7 +73,7 @@ class FunctionChild(TemplateElement):
 
     @renderer
     def functionDeprecated(self, request: object, tag: Tag) -> "Flattenable":
-        msg: Optional["Flattenable"] = getattr(self.ob, "_deprecated_info", None)
+        msg = self.ob._deprecated_info
         if msg is None:
             return ()
         else:

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -1,11 +1,15 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from twisted.web.iweb import ITemplateLoader
-from twisted.web.template import Flattenable, Tag, renderer, tags
+from twisted.web.template import Tag, renderer, tags
 
 from pydoctor.model import Function
 from pydoctor.templatewriter import TemplateElement, util
 from pydoctor.templatewriter.pages import DocGetter, format_decorators, signature
+
+if TYPE_CHECKING:
+    from twisted.web.template import Flattenable
+
 
 class FunctionChild(TemplateElement):
 
@@ -14,7 +18,7 @@ class FunctionChild(TemplateElement):
     def __init__(self,
             docgetter: DocGetter,
             ob: Function,
-            extras: Flattenable,
+            extras: "Flattenable",
             loader: ITemplateLoader
             ):
         super().__init__(loader)
@@ -23,26 +27,26 @@ class FunctionChild(TemplateElement):
         self._functionExtras = extras
 
     @renderer
-    def class_(self, request: object, tag: Tag) -> Flattenable:
+    def class_(self, request: object, tag: Tag) -> "Flattenable":
         class_ = util.css_class(self.ob)
         if self.ob.parent is not self.ob:
             class_ = 'base' + class_
         return class_
 
     @renderer
-    def functionAnchor(self, request: object, tag: Tag) -> Flattenable:
+    def functionAnchor(self, request: object, tag: Tag) -> "Flattenable":
         return self.ob.fullName()
 
     @renderer
-    def shortFunctionAnchor(self, request: object, tag: Tag) -> Flattenable:
+    def shortFunctionAnchor(self, request: object, tag: Tag) -> "Flattenable":
         return self.ob.name
 
     @renderer
-    def decorator(self, request: object, tag: Tag) -> Flattenable:
+    def decorator(self, request: object, tag: Tag) -> "Flattenable":
         return list(format_decorators(self.ob))
 
     @renderer
-    def functionDef(self, request: object, tag: Tag) -> Flattenable:
+    def functionDef(self, request: object, tag: Tag) -> "Flattenable":
         def_stmt = 'async def' if self.ob.is_async else 'def'
         name = self.ob.name
         if name.endswith('.setter') or name.endswith('.deleter'):
@@ -53,23 +57,23 @@ class FunctionChild(TemplateElement):
             ]
 
     @renderer
-    def sourceLink(self, request: object, tag: Tag) -> Flattenable:
+    def sourceLink(self, request: object, tag: Tag) -> "Flattenable":
         if self.ob.sourceHref:
             return tag.fillSlots(sourceHref=self.ob.sourceHref)
         else:
             return ()
 
     @renderer
-    def functionExtras(self, request: object, tag: Tag) -> Flattenable:
+    def functionExtras(self, request: object, tag: Tag) -> "Flattenable":
         return self._functionExtras
 
     @renderer
-    def functionBody(self, request: object, tag: Tag) -> Flattenable:
+    def functionBody(self, request: object, tag: Tag) -> "Flattenable":
         return self.docgetter.get(self.ob)
 
     @renderer
-    def functionDeprecated(self, request: object, tag: Tag) -> Flattenable:
-        msg: Optional[Flattenable] = getattr(self.ob, "_deprecated_info", None)
+    def functionDeprecated(self, request: object, tag: Tag) -> "Flattenable":
+        msg: Optional["Flattenable"] = getattr(self.ob, "_deprecated_info", None)
         if msg is None:
             return ()
         else:

--- a/pydoctor/templatewriter/pages/table.py
+++ b/pydoctor/templatewriter/pages/table.py
@@ -1,4 +1,4 @@
-from typing import Collection
+from typing import TYPE_CHECKING, Collection
 
 from twisted.web.iweb import ITemplateLoader
 from twisted.web.template import (
@@ -7,15 +7,17 @@ from twisted.web.template import (
 
 from pydoctor import epydoc2stan
 from pydoctor.model import Documentable, Function
-from pydoctor.templatewriter import util
-from pydoctor.templatewriter.pages import DocGetter, TemplateElement
+from pydoctor.templatewriter import TemplateElement, util
+
+if TYPE_CHECKING:
+    from pydoctor.templatewriter.pages import DocGetter
 
 
 class TableRow(Element):
 
     def __init__(self,
             loader: ITemplateLoader,
-            docgetter: DocGetter,
+            docgetter: "DocGetter",
             ob: Documentable,
             child: Documentable,
             ):
@@ -60,7 +62,7 @@ class ChildTable(TemplateElement):
     filename = 'table.html'
 
     def __init__(self,
-            docgetter: DocGetter,
+            docgetter: "DocGetter",
             ob: Documentable,
             children: Collection[Documentable],
             loader: ITemplateLoader,

--- a/pydoctor/templatewriter/pages/table.py
+++ b/pydoctor/templatewriter/pages/table.py
@@ -24,7 +24,9 @@ class TableRow(Element):
     @renderer
     def kind(self, request, tag):
         child = self.child
-        kind_name = epydoc2stan.format_kind(child.kind)
+        kind = child.kind
+        assert kind is not None  # 'kind is None' makes the object invisible
+        kind_name = epydoc2stan.format_kind(kind)
         if isinstance(child, Function) and child.is_async:
             # The official name is "coroutine function", but that is both
             # a bit long and not as widely recognized.
@@ -67,4 +69,6 @@ class ChildTable(TemplateElement):
                 self.docgetter,
                 self.ob,
                 child)
-            for child in self.children]
+            for child in self.children
+            if child.isVisible
+            ]

--- a/pydoctor/templatewriter/pages/table.py
+++ b/pydoctor/templatewriter/pages/table.py
@@ -1,15 +1,14 @@
 from typing import TYPE_CHECKING, Collection
 
 from twisted.web.iweb import ITemplateLoader
-from twisted.web.template import (
-    Element, Flattenable, Tag, TagLoader, renderer, tags
-)
+from twisted.web.template import Element, Tag, TagLoader, renderer, tags
 
 from pydoctor import epydoc2stan
 from pydoctor.model import Documentable, Function
 from pydoctor.templatewriter import TemplateElement, util
 
 if TYPE_CHECKING:
+    from twisted.web.template import Flattenable
     from pydoctor.templatewriter.pages import DocGetter
 
 
@@ -27,7 +26,7 @@ class TableRow(Element):
         self.child = child
 
     @renderer
-    def class_(self, request: object, tag: Tag) -> Flattenable:
+    def class_(self, request: object, tag: Tag) -> "Flattenable":
         class_ = util.css_class(self.child)
         if self.child.parent is not self.ob:
             class_ = 'base' + class_
@@ -79,7 +78,7 @@ class ChildTable(TemplateElement):
         return f'id{self._id}'
 
     @renderer
-    def rows(self, request: object, tag: Tag) -> Flattenable:
+    def rows(self, request: object, tag: Tag) -> "Flattenable":
         return [
             TableRow(
                 TagLoader(tag),

--- a/pydoctor/templatewriter/pages/table.py
+++ b/pydoctor/templatewriter/pages/table.py
@@ -1,28 +1,38 @@
-from twisted.web.template import TagLoader, renderer, tags, Element
+from typing import Collection
+
+from twisted.web.iweb import ITemplateLoader
+from twisted.web.template import (
+    Element, Flattenable, Tag, TagLoader, renderer, tags
+)
 
 from pydoctor import epydoc2stan
-from pydoctor.model import Function
+from pydoctor.model import Documentable, Function
 from pydoctor.templatewriter import util
-from pydoctor.templatewriter.pages import TemplateElement
+from pydoctor.templatewriter.pages import DocGetter, TemplateElement
 
 
 class TableRow(Element):
 
-    def __init__(self, loader, docgetter, ob, child):
+    def __init__(self,
+            loader: ITemplateLoader,
+            docgetter: DocGetter,
+            ob: Documentable,
+            child: Documentable,
+            ):
         super().__init__(loader)
         self.docgetter = docgetter
         self.ob = ob
         self.child = child
 
     @renderer
-    def class_(self, request, tag):
+    def class_(self, request: object, tag: Tag) -> Flattenable:
         class_ = util.css_class(self.child)
         if self.child.parent is not self.ob:
             class_ = 'base' + class_
         return class_
 
     @renderer
-    def kind(self, request, tag):
+    def kind(self, request: object, tag: Tag) -> Tag:
         child = self.child
         kind = child.kind
         assert kind is not None  # 'kind is None' makes the object invisible
@@ -34,13 +44,13 @@ class TableRow(Element):
         return tag.clear()(kind_name)
 
     @renderer
-    def name(self, request, tag):
+    def name(self, request: object, tag: Tag) -> Tag:
         return tag.clear()(tags.code(
             epydoc2stan.taglink(self.child, self.ob.url, self.child.name)
             ))
 
     @renderer
-    def summaryDoc(self, request, tag):
+    def summaryDoc(self, request: object, tag: Tag) -> Tag:
         return tag.clear()(self.docgetter.get(self.child, summary=True))
 
 
@@ -49,7 +59,12 @@ class ChildTable(TemplateElement):
 
     filename = 'table.html'
 
-    def __init__(self, docgetter, ob, children, loader):
+    def __init__(self,
+            docgetter: DocGetter,
+            ob: Documentable,
+            children: Collection[Documentable],
+            loader: ITemplateLoader,
+            ):
         super().__init__(loader)
         self.docgetter = docgetter
         self.children = children
@@ -58,11 +73,11 @@ class ChildTable(TemplateElement):
         self.ob = ob
 
     @renderer
-    def id(self, request, tag):
-        return 'id'+str(self._id)
+    def id(self, request: object, tag: Tag) -> str:
+        return f'id{self._id}'
 
     @renderer
-    def rows(self, request, tag):
+    def rows(self, request: object, tag: Tag) -> Flattenable:
         return [
             TableRow(
                 TagLoader(tag),

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -2,17 +2,18 @@
 
 from collections import defaultdict
 from typing import (
-    DefaultDict, Dict, Iterable, List, Mapping, MutableSet, Sequence, Tuple,
-    Type, Union, cast
+    TYPE_CHECKING, DefaultDict, Dict, Iterable, List, Mapping, MutableSet,
+    Sequence, Tuple, Type, Union, cast
 )
 
-from twisted.web.template import (
-    Element, Flattenable, Tag, TagLoader, renderer, tags
-)
+from twisted.web.template import Element, Tag, TagLoader, renderer, tags
 
 from pydoctor import epydoc2stan, model
 from pydoctor.templatewriter import TemplateLookup
 from pydoctor.templatewriter.pages import Page
+
+if TYPE_CHECKING:
+    from twisted.web.template import Flattenable
 
 
 def moduleSummary(module: model.Module, page_url: str) -> Tag:
@@ -189,7 +190,7 @@ class LetterElement(Element):
 
     @renderer
     def letterlinks(self, request: object, tag: Tag) -> Tag:
-        letterlinks: List[Flattenable] = []
+        letterlinks: List["Flattenable"] = []
         for initial in sorted(self.initials):
             if initial == self.my_letter:
                 letterlinks.append(initial)
@@ -202,7 +203,7 @@ class LetterElement(Element):
         return tag
 
     @renderer
-    def names(self, request: object, tag: Tag) -> Flattenable:
+    def names(self, request: object, tag: Tag) -> "Flattenable":
         def link(obj: model.Documentable) -> Tag:
             # The "data-type" attribute helps doc2dash figure out what
             # category (class, method, etc.) an object belongs to.
@@ -255,7 +256,7 @@ class NameIndexPage(Page):
         return tag.clear()("Index of Names")
 
     @renderer
-    def index(self, request: object, tag: Tag) -> Flattenable:
+    def index(self, request: object, tag: Tag) -> "Flattenable":
         r = []
         for i in sorted(self.initials):
             r.append(LetterElement(TagLoader(tag), self.initials, i))
@@ -270,7 +271,7 @@ class IndexPage(Page):
         return f"API Documentation for {self.system.projectname}"
 
     @renderer
-    def onlyIfOneRoot(self, request: object, tag: Tag) -> Flattenable:
+    def onlyIfOneRoot(self, request: object, tag: Tag) -> "Flattenable":
         if len(self.system.rootobjects) != 1:
             return []
         else:
@@ -280,14 +281,14 @@ class IndexPage(Page):
                 ", the root ", epydoc2stan.format_kind(root.kind).lower(), ".")
 
     @renderer
-    def onlyIfMultipleRoots(self, request: object, tag: Tag) -> Flattenable:
+    def onlyIfMultipleRoots(self, request: object, tag: Tag) -> "Flattenable":
         if len(self.system.rootobjects) == 1:
             return []
         else:
             return tag
 
     @renderer
-    def roots(self, request: object, tag: Tag) -> Flattenable:
+    def roots(self, request: object, tag: Tag) -> "Flattenable":
         r = []
         for o in self.system.rootobjects:
             r.append(tag.clone().fillSlots(root=tags.code(

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -1,11 +1,18 @@
 """Classes that generate the summary pages."""
 
-from typing import Dict, Iterable, List, Sequence, Tuple, Type, Union, cast
+from collections import defaultdict
+from typing import (
+    DefaultDict, Dict, Iterable, List, Mapping, MutableSet, Sequence, Tuple,
+    Type, Union, cast
+)
+
+from twisted.web.template import (
+    Element, Flattenable, Tag, TagLoader, renderer, tags
+)
 
 from pydoctor import epydoc2stan, model
 from pydoctor.templatewriter import TemplateLookup
 from pydoctor.templatewriter.pages import Page
-from twisted.web.template import Element, Tag, TagLoader, renderer, tags
 
 
 def moduleSummary(module: model.Module, page_url: str) -> Tag:
@@ -22,12 +29,14 @@ def moduleSummary(module: model.Module, page_url: str) -> Tag:
     if not contents:
         return r
     ul = tags.ul()
-    for m in sorted(contents, key=lambda m:m.fullName()):
+    def fullName(obj: model.Documentable) -> str:
+        return obj.fullName()
+    for m in sorted(contents, key=fullName):
         ul(moduleSummary(m, page_url))
     r(ul)
     return r
 
-def _lckey(x):
+def _lckey(x: model.Documentable) -> Tuple[str, str]:
     return (x.fullName().lower(), x.fullName())
 
 class ModuleIndexPage(Page):
@@ -41,18 +50,20 @@ class ModuleIndexPage(Page):
         super().__init__(system=system, template_lookup=template_lookup,
             loader=template_lookup.get_template('summary.html').loader )
 
-    def title(self):
+    def title(self) -> str:
         return "Module Index"
 
     @renderer
-    def stuff(self, request, tag):
-        r = []
-        for o in self.system.rootobjects:
-            r.append(moduleSummary(o, self.filename))
-        return tag.clear()(r)
+    def stuff(self, request: object, tag: Tag) -> Tag:
+        tag.clear()
+        tag([moduleSummary(o, self.filename) for o in self.system.rootobjects])
+        return tag
+
     @renderer
-    def heading(self, request, tag):
-        return tag().clear()("Module Index")
+    def heading(self, request: object, tag: Tag) -> Tag:
+        tag().clear()
+        tag("Module Index")
+        return tag
 
 def findRootClasses(
         system: model.System
@@ -94,8 +105,13 @@ def isClassNodePrivate(cls: model.Class) -> bool:
 
     return True
 
-def subclassesFrom(hostsystem, cls, anchors, page_url):
-    r = tags.li()
+def subclassesFrom(
+        hostsystem: model.System,
+        cls: model.Class,
+        anchors: MutableSet[str],
+        page_url: str
+        ) -> Tag:
+    r: Tag = tags.li()
     if isClassNodePrivate(cls):
         r(class_='private')
     name = cls.fullName()
@@ -124,13 +140,13 @@ class ClassIndexPage(Page):
         super().__init__(system=system, template_lookup=template_lookup,
             loader=template_lookup.get_template('summary.html').loader )
 
-    def title(self):
+    def title(self) -> str:
         return "Class Hierarchy"
 
     @renderer
-    def stuff(self, request, tag):
+    def stuff(self, request: object, tag: Tag) -> Tag:
         t = tag
-        anchors = set()
+        anchors: MutableSet[str] = set()
         for b, o in findRootClasses(self.system):
             if isinstance(o, model.Class):
                 t(subclassesFrom(self.system, o, anchors, self.filename))
@@ -149,24 +165,31 @@ class ClassIndexPage(Page):
         return t
 
     @renderer
-    def heading(self, request, tag):
-        return tag.clear()("Class Hierarchy")
+    def heading(self, request: object, tag: Tag) -> Tag:
+        tag.clear()
+        tag("Class Hierarchy")
+        return tag
 
 
 class LetterElement(Element):
 
-    def __init__(self, loader, initials, letter):
+    def __init__(self,
+            loader: TagLoader,
+            initials: Mapping[str, Sequence[model.Documentable]],
+            letter: str
+            ):
         super().__init__(loader=loader)
         self.initials = initials
         self.my_letter = letter
 
     @renderer
-    def letter(self, request, tag):
-        return tag(self.my_letter)
+    def letter(self, request: object, tag: Tag) -> Tag:
+        tag(self.my_letter)
+        return tag
 
     @renderer
-    def letterlinks(self, request, tag):
-        letterlinks = []
+    def letterlinks(self, request: object, tag: Tag) -> Tag:
+        letterlinks: List[Flattenable] = []
         for initial in sorted(self.initials):
             if initial == self.my_letter:
                 letterlinks.append(initial)
@@ -175,10 +198,11 @@ class LetterElement(Element):
             letterlinks.append(' - ')
         if letterlinks:
             del letterlinks[-1]
-        return tag(letterlinks)
+        tag(letterlinks)
+        return tag
 
     @renderer
-    def names(self, request, tag):
+    def names(self, request: object, tag: Tag) -> Flattenable:
         def link(obj: model.Documentable) -> Tag:
             # The "data-type" attribute helps doc2dash figure out what
             # category (class, method, etc.) an object belongs to.
@@ -188,12 +212,12 @@ class LetterElement(Element):
             return tags.code(
                 epydoc2stan.taglink(obj, NameIndexPage.filename), **attributes
                 )
-        name2obs = {}
+        name2obs: DefaultDict[str, List[model.Documentable]] = defaultdict(list)
         for obj in self.initials[self.my_letter]:
-            name2obs.setdefault(obj.name, []).append(obj)
+            name2obs[obj.name].append(obj)
         r = []
         for name in sorted(name2obs, key=lambda x:(x.lower(), x)):
-            item = tag.clone()(name)
+            item: Tag = tag.clone()(name)
             obs = name2obs[name]
             if all(isPrivate(ob) for ob in obs):
                 item(class_='private')
@@ -223,15 +247,15 @@ class NameIndexPage(Page):
                 self.initials.setdefault(ob.name[0].upper(), []).append(ob)
 
 
-    def title(self):
+    def title(self) -> str:
         return "Index of Names"
 
     @renderer
-    def heading(self, request, tag):
+    def heading(self, request: object, tag: Tag) -> Tag:
         return tag.clear()("Index of Names")
 
     @renderer
-    def index(self, request, tag):
+    def index(self, request: object, tag: Tag) -> Flattenable:
         r = []
         for i in sorted(self.initials):
             r.append(LetterElement(TagLoader(tag), self.initials, i))
@@ -242,11 +266,11 @@ class IndexPage(Page):
 
     filename = 'index.html'
 
-    def title(self):
+    def title(self) -> str:
         return f"API Documentation for {self.system.projectname}"
 
     @renderer
-    def onlyIfOneRoot(self, request, tag):
+    def onlyIfOneRoot(self, request: object, tag: Tag) -> Flattenable:
         if len(self.system.rootobjects) != 1:
             return []
         else:
@@ -256,14 +280,14 @@ class IndexPage(Page):
                 ", the root ", epydoc2stan.format_kind(root.kind).lower(), ".")
 
     @renderer
-    def onlyIfMultipleRoots(self, request, tag):
+    def onlyIfMultipleRoots(self, request: object, tag: Tag) -> Flattenable:
         if len(self.system.rootobjects) == 1:
             return []
         else:
             return tag
 
     @renderer
-    def roots(self, request, tag):
+    def roots(self, request: object, tag: Tag) -> Flattenable:
         r = []
         for o in self.system.rootobjects:
             r.append(tag.clone().fillSlots(root=tags.code(
@@ -272,14 +296,14 @@ class IndexPage(Page):
         return r
 
     @renderer
-    def rootkind(self, request, tag):
+    def rootkind(self, request: object, tag: Tag) -> Tag:
         return tag.clear()('/'.join(sorted(
              epydoc2stan.format_kind(o.kind, plural=True).lower()
              for o in self.system.rootobjects
              )))
 
 
-def hasdocstring(ob):
+def hasdocstring(ob: model.Documentable) -> bool:
     for source in ob.docsources():
         if source.docstring is not None:
             return True
@@ -295,15 +319,15 @@ class UndocumentedSummaryPage(Page):
         super().__init__(system=system, template_lookup=template_lookup,
             loader=template_lookup.get_template('summary.html').loader )
 
-    def title(self):
+    def title(self) -> str:
         return "Summary of Undocumented Objects"
 
     @renderer
-    def heading(self, request, tag):
+    def heading(self, request: object, tag: Tag) -> Tag:
         return tag.clear()("Summary of Undocumented Objects")
 
     @renderer
-    def stuff(self, request, tag):
+    def stuff(self, request: object, tag: Tag) -> Tag:
         undoccedpublic = [o for o in self.system.allobjects.values()
                           if o.isVisible and not hasdocstring(o)]
         undoccedpublic.sort(key=lambda o:o.fullName())

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -308,7 +308,12 @@ class UndocumentedSummaryPage(Page):
                           if o.isVisible and not hasdocstring(o)]
         undoccedpublic.sort(key=lambda o:o.fullName())
         for o in undoccedpublic:
-            tag(tags.li(epydoc2stan.format_kind(o.kind), " - ", tags.code(epydoc2stan.taglink(o, self.filename))))
+            kind = o.kind
+            assert kind is not None  # 'kind is None' makes the object invisible
+            tag(tags.li(
+                epydoc2stan.format_kind(kind), " - ",
+                tags.code(epydoc2stan.taglink(o, self.filename))
+                ))
         return tag
 
 summarypages: Iterable[Type[Page]] = [

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -185,9 +185,9 @@ class LetterElement(Element):
             attributes = {}
             if obj.kind:
                 attributes["data-type"] = epydoc2stan.format_kind(obj.kind)
-            tag: Tag = tags.code(
-                epydoc2stan.taglink(obj, NameIndexPage.filename), **attributes)
-            return tag
+            return tags.code(
+                epydoc2stan.taglink(obj, NameIndexPage.filename), **attributes
+                )
         name2obs = {}
         for obj in self.initials[self.my_letter]:
             name2obs.setdefault(obj.name, []).append(obj)

--- a/pydoctor/templatewriter/writer.py
+++ b/pydoctor/templatewriter/writer.py
@@ -18,7 +18,7 @@ from pydoctor.templatewriter import (
 def flattenToFile(fobj: IO[bytes], elem: Element) -> None:
     """
     This method writes a page to a HTML file.
-    @raises Exception: If the L{flatten} call fails.
+    @raises Exception: If the L{twisted.web.template.flatten} call fails.
     """
     fobj.write(DOCTYPE)
     err = None

--- a/pydoctor/test/__init__.py
+++ b/pydoctor/test/__init__.py
@@ -84,10 +84,10 @@ class NotFoundLinker(DocstringLinker):
     """A DocstringLinker implementation that cannot find any links."""
 
     def link_to(self, target: str, label: str) -> Tag:
-        return tags.transparent(label)  # type: ignore[no-any-return]
+        return tags.transparent(label)
 
     def link_xref(self, target: str, label: str, lineno: int) -> Tag:
-        return tags.code(label)  # type: ignore[no-any-return]
+        return tags.code(label)
 
     def resolve_identifier(self, identifier: str) -> Optional[str]:
         return None

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -815,7 +815,7 @@ class RecordingAnnotationLinker(DocstringLinker):
 
     def link_to(self, target: str, label: str) -> Tag:
         self.resolve_identifier(target)
-        return tags.transparent(label)  # type: ignore[no-any-return]
+        return tags.transparent(label)
 
     def link_xref(self, target: str, label: str, lineno: int) -> Tag:
         assert False


### PR DESCRIPTION
Now that `twisted.web.template` has type annotations, we can fully annotate `pydoctor.templatewriter`.