### PR TITLE
Fixes #385

### DIFF
--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -9,6 +9,11 @@ from somelib import SomeInterface
 import zope.interface
 import zope.schema
 
+LANG = 'Fr'
+"""
+This is a constant.
+"""
+
 def demo_fields_docstring_arguments(m, b):  # type: ignore
     """
     Fields are used to describe specific properties of a documented object.

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -4,6 +4,11 @@ This is a module demonstrating reST code documentation features.
 Most part of this documentation is using Python type hinting.
 """
 
+LANG = 'Fr'
+"""
+This is a constant.
+"""
+
 def demo_fields_docstring_arguments(m, b):  # type: ignore
     """
     Fields are used to describe specific properties of a documented object.

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -917,6 +917,7 @@ def format_kind(kind: model.DocumentableKind, plural: bool = False) -> str:
         model.DocumentableKind.PROPERTY        : 'Property',
         model.DocumentableKind.VARIABLE        : 'Variable',
         model.DocumentableKind.SCHEMA_FIELD    : 'Attribute',
+        model.DocumentableKind.CONSTANT        : 'Constant',
     }
     plurals = {
         model.DocumentableKind.CLASS           : 'Classes', 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -95,6 +95,7 @@ class DocumentableKind(Enum):
     STATIC_METHOD       = 600
     METHOD              = 500
     FUNCTION            = 400
+    CONSTANT            = 310
     CLASS_VARIABLE      = 300
     SCHEMA_FIELD        = 220
     ATTRIBUTE           = 210
@@ -504,7 +505,7 @@ class Attribute(Inheritable):
     kind: Optional[DocumentableKind] = DocumentableKind.ATTRIBUTE
     annotation: Optional[ast.expr]
     decorators: Optional[Sequence[ast.expr]] = None
-
+    value: Optional[ast.expr] = None
 
 # Work around the attributes of the same name within the System class.
 _ModuleT = Module

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -1612,3 +1612,46 @@ def test_ignore_function_contents(systemcls: Type[model.System]) -> None:
     ''', systemcls=systemcls)
     outer = mod.contents['outer']
     assert not outer.contents
+
+@systemcls_param
+def test_constant_module(systemcls: Type[model.System]) -> None:
+    mod = fromText('''
+    LANG = 'FR'
+    ''', systemcls=systemcls)
+    assert getattr(mod.contents['LANG'], 'kind') == model.DocumentableKind.CONSTANT
+    assert getattr(mod.contents['LANG'], 'value') is not None
+
+@systemcls_param
+def test_constant_module_with_final(systemcls: Type[model.System]) -> None:
+    mod = fromText('''
+    from typing import Final
+    lang: Final = 'fr'
+    ''', systemcls=systemcls)
+    assert getattr(mod.contents['lang'], 'kind') == model.DocumentableKind.CONSTANT
+    assert getattr(mod.contents['lang'], 'value') is not None
+
+@systemcls_param
+def test_constant_class(systemcls: Type[model.System]) -> None:
+    mod = fromText('''
+    from typing import Final
+    from datetime import datetime
+    class Clazz:
+        """Class."""
+        LANG = 'FR'
+    ''', systemcls=systemcls)
+    assert getattr(mod.resolveName('Clazz.LANG'), 'kind') == model.DocumentableKind.CONSTANT
+    assert getattr(mod.resolveName('Clazz.LANG'), 'value') is not None
+
+
+@systemcls_param
+def test_constant_init(systemcls: Type[model.System]) -> None:
+    mod = fromText('''
+    from typing import Final
+    from datetime import datetime
+    class Clazz:
+        """Class."""
+        def __init__(**args):
+            self.LANG = 'FR'
+    ''', systemcls=systemcls)
+    assert getattr(mod.resolveName('Clazz.LANG'), 'kind') == model.DocumentableKind.CONSTANT
+    assert getattr(mod.resolveName('Clazz.LANG'), 'value') is not None


### PR DESCRIPTION
Mark the variables as contants when their names is all caps or if using `typing.Final` annotation.

Introduces a new kind: CONSTANT.

Also new: Attribute.value, this will be used when adding the feature #377 in the near future.