### PR TITLE
Add -vv flag to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
 
 commands =
     test: coverage erase
-    test: coverage run -m pytest {posargs:pydoctor}
+    test: coverage run -m pytest {posargs:pydoctor} -vv
     test: coverage report -m
 
     ; Publish coverage data on codecov.io

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
 
 commands =
     test: coverage erase
-    test: coverage run -m pytest {posargs:pydoctor} -vv
+    test: coverage run -m pytest {posargs:-vv pydoctor}
     test: coverage report -m
 
     ; Publish coverage data on codecov.io


### PR DESCRIPTION
I'm always adding it locally and it creates conflicts all the time.
I figured it's more simple to just make the goddam tests verbose.