### PR TITLE
Use Dict[str, Documentable] as annotation for Documentable.contents.

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -366,6 +366,8 @@ class ModuleVistor(ast.NodeVisitor):
                             "astbuilder",
                             "moving %r into %r" % (ob.fullName(), current.fullName())
                             )
+                        # Must be a Module since the exports is set to an empty list if it's not.
+                        assert isinstance(current, model.Module)
                         ob.reparent(current, asname)
                         continue
 
@@ -470,7 +472,8 @@ class ModuleVistor(ast.NodeVisitor):
         assert isinstance(cls, model.Class)
         if not _maybeAttribute(cls, name):
             return
-        obj: Optional[model.Attribute] = cls.contents.get(name)
+        # Class variables can only be Attribute, so it's OK to cast
+        obj = cast(Optional[model.Attribute], cls.contents.get(name))
         if obj is None:
             obj = self.builder.addAttribute(name=name, kind=None, parent=cls)
         if obj.kind is None:
@@ -504,8 +507,9 @@ class ModuleVistor(ast.NodeVisitor):
             return
         if not _maybeAttribute(cls, name):
             return
-        obj = cls.contents.get(name)
-        if obj is None:
+        # Class variables can only be Attribute, so it's OK to cast
+        obj = cast(Optional[model.Attribute], cls.contents.get(name))
+        if not obj:
             obj = self.builder.addAttribute(name=name, kind=None, parent=cls)
         obj.kind = model.DocumentableKind.INSTANCE_VARIABLE
         if annotation is None and expr is not None:

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -731,10 +731,11 @@ def format_undocumented(obj: model.Documentable) -> Tag:
     sub_objects_with_docstring_count: DefaultDict[model.DocumentableKind, int] = defaultdict(int)
     sub_objects_total_count: DefaultDict[model.DocumentableKind, int]  = defaultdict(int)
     for sub_ob in obj.contents.values():
-        k = sub_ob.kind
-        sub_objects_total_count[k] += 1
-        if sub_ob.docstring is not None:
-            sub_objects_with_docstring_count[k] += 1
+        kind = sub_ob.kind
+        if kind is not None:
+            sub_objects_total_count[kind] += 1
+            if sub_ob.docstring is not None:
+                sub_objects_with_docstring_count[kind] += 1
 
     tag: Tag = tags.span(class_='undocumented')
     if sub_objects_with_docstring_count:
@@ -744,10 +745,10 @@ def format_undocumented(obj: model.Documentable) -> Tag:
         tag(
             "No ", format_kind(kind).lower(), " docstring; ",
             ', '.join(
-                f"{sub_objects_with_docstring_count[k]}/{sub_objects_total_count[k]} "
-                f"{format_kind(k, plural=sub_objects_with_docstring_count[k]>=2).lower()}"
+                f"{sub_objects_with_docstring_count[kind]}/{sub_objects_total_count[kind]} "
+                f"{format_kind(kind, plural=sub_objects_with_docstring_count[kind]>=2).lower()}"
                 
-                for k in sorted(sub_objects_total_count, key=(lambda x:x.value))
+                for kind in sorted(sub_objects_total_count, key=(lambda x:x.value))
                 ),
             " documented"
             )

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -18,7 +18,7 @@ from inspect import Signature
 from optparse import Values
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING, Any, Collection, Dict, Iterable, Iterator, List, Mapping,
+    TYPE_CHECKING, Collection, Dict, Iterable, Iterator, List, Mapping,
     Optional, Sequence, Set, Tuple, Type, TypeVar, Union, overload
 )
 from urllib.parse import quote
@@ -142,9 +142,7 @@ class Documentable:
         return self
 
     def setup(self) -> None:
-        # TODO: The actual value type is Documentable, but using that
-        #       requires a boatload of changes.
-        self.contents: Dict[str, Any] = {}
+        self.contents: Dict[str, Documentable] = {}
 
     def setDocstring(self, node: ast.Str) -> None:
         doc = node.s

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Type, overload
+from typing import Optional, Tuple, Type, overload, cast
 import ast
 import textwrap
 
@@ -73,7 +73,12 @@ def fromText(
     ast = astbuilder._parse(textwrap.dedent(text))
     return fromAST(ast, modname, is_package, parent_name, system, buildercls, systemcls)
 
-def unwrap(parsed_docstring: ParsedEpytextDocstring) -> str:
+def unwrap(parsed_docstring: Optional[ParsedDocstring]) -> str:
+    
+    if parsed_docstring is None:
+        raise TypeError("parsed_docstring cannot be None")
+    if not isinstance(parsed_docstring, ParsedEpytextDocstring):
+        raise TypeError(f"parsed_docstring must be a ParsedEpytextDocstring instance, not {parsed_docstring.__class__.__name__}")
     epytext = parsed_docstring._tree
     assert epytext is not None
     assert epytext.tag == 'epytext'
@@ -176,6 +181,7 @@ def test_function_simple(systemcls: Type[model.System]) -> None:
     func, = mod.contents.values()
     assert func.fullName() == '<test>.f'
     assert func.docstring == """This is a docstring."""
+    assert isinstance(func, model.Function)
     assert func.is_async is False
 
 
@@ -191,6 +197,7 @@ def test_function_async(systemcls: Type[model.System]) -> None:
     func, = mod.contents.values()
     assert func.fullName() == '<test>.a'
     assert func.docstring == """This is a docstring."""
+    assert isinstance(func, model.Function)
     assert func.is_async is True
 
 
@@ -288,6 +295,7 @@ def test_class_with_base(systemcls: Type[model.System]) -> None:
     assert clsD.docstring == None
     assert len(clsD.contents) == 1
 
+    assert isinstance(clsD, model.Class)
     assert len(clsD.bases) == 1
     base, = clsD.bases
     assert base == '<test>.C'
@@ -302,6 +310,8 @@ def test_follow_renaming(systemcls: Type[model.System]) -> None:
     mod = fromText(src, systemcls=systemcls)
     C = mod.contents['C']
     E = mod.contents['E']
+    assert isinstance(C, model.Class)
+    assert isinstance(E, model.Class)
     assert E.baseobjects == [C], E.baseobjects
 
 @systemcls_param
@@ -374,6 +384,7 @@ def test_class_with_base_from_module(systemcls: Type[model.System]) -> None:
     assert clsD.docstring == None
     assert len(clsD.contents) == 1
 
+    assert isinstance(clsD, model.Class)
     assert len(clsD.bases) == 2
     base1, base2 = clsD.bases
     assert base1 == 'X.Y.A'
@@ -394,6 +405,7 @@ def test_class_with_base_from_module(systemcls: Type[model.System]) -> None:
     assert clsD.docstring == None
     assert len(clsD.contents) == 1
 
+    assert isinstance(clsD, model.Class)
     assert len(clsD.bases) == 3
     base1, base2, base3 = clsD.bases
     assert base1 == 'X.A', base1
@@ -476,7 +488,9 @@ def test_aliasing_recursion(systemcls: Type[model.System]) -> None:
         pass
     '''
     mod = fromText(src, modname='mod', system=system)
-    assert mod.contents['D'].bases == ['mod.C'], mod.contents['D'].bases
+    D = mod.contents['D']
+    assert isinstance(D, model.Class)
+    assert D.bases == ['mod.C'], D.bases
 
 @systemcls_param
 def test_documented_no_alias(systemcls: Type[model.System]) -> None:
@@ -523,7 +537,9 @@ def test_inherit_names(systemcls: Type[model.System]) -> None:
         pass
     '''
     mod = fromText(src, systemcls=systemcls)
-    assert [b.name for b in mod.contents['A'].allbases()] == ['A 0']
+    A = mod.contents['A']
+    assert isinstance(A, model.Class)
+    assert [b.name for b in A.allbases()] == ['A 0']
 
 @systemcls_param
 def test_nested_class_inheriting_from_same_module(systemcls: Type[model.System]) -> None:
@@ -717,6 +733,7 @@ def test_classdecorator(systemcls: Type[model.System]) -> None:
         pass
     ''', modname='mod', systemcls=systemcls)
     C = mod.contents['C']
+    assert isinstance(C, model.Class)
     assert C.decorators == [('mod.cd', None)]
 
 
@@ -730,9 +747,11 @@ def test_classdecorator_with_args(systemcls: Type[model.System]) -> None:
         pass
     ''', modname='test', systemcls=systemcls)
     C = mod.contents['C']
+    assert isinstance(C, model.Class)
     assert len(C.decorators) == 1
     (name, args), = C.decorators
     assert name == 'test.cd'
+    assert args is not None
     assert len(args) == 1
     arg, = args
     assert astbuilder.node2fullname(arg, mod) == 'test.A'
@@ -1339,10 +1358,10 @@ def test_type_comment(systemcls: Type[model.System], capsys: CapSys) -> None:
     d = {} # type: dict[str, int]
     i = [] # type: ignore[misc]
     ''', systemcls=systemcls)
-    assert type2str(mod.contents['d'].annotation) == 'dict[str, int]'
+    assert type2str(cast(model.Attribute, mod.contents['d']).annotation) == 'dict[str, int]'
     # We don't use ignore comments for anything at the moment,
     # but do verify that their presence doesn't break things.
-    assert type2str(mod.contents['i'].annotation) == 'list'
+    assert type2str(cast(model.Attribute, mod.contents['i']).annotation) == 'list'
     assert not capsys.readouterr().out
 
 @systemcls_param
@@ -1368,7 +1387,7 @@ def test_bad_string_annotation(
     mod = fromText(f'''
     x: "{annotation}"
     ''', modname='test', systemcls=systemcls)
-    assert isinstance(mod.contents['x'].annotation, ast.expr)
+    assert isinstance(cast(model.Attribute, mod.contents['x']).annotation, ast.expr)
     assert "syntax error in annotation" in capsys.readouterr().out
 
 @pytest.mark.parametrize('annotation,expected', (
@@ -1421,11 +1440,11 @@ def test_inferred_variable_types(systemcls: Type[model.System]) -> None:
     assert ann_str_and_line(C.contents['j']) == ('tuple', 12)
     # It is unlikely that a variable actually will contain only None,
     # so we should treat this as not be able to infer the type.
-    assert C.contents['n'].annotation is None
+    assert cast(model.Attribute, C.contents['n']).annotation is None
     # These expressions are considered too complex for pydoctor.
     # Maybe we can use an external type inferrer at some point.
-    assert C.contents['x'].annotation is None
-    assert C.contents['y'].annotation is None
+    assert cast(model.Attribute, C.contents['x']).annotation is None
+    assert cast(model.Attribute, C.contents['y']).annotation is None
     # Type inference isn't different for module and instance variables,
     # so we don't need to re-test everything.
     assert ann_str_and_line(C.contents['s']) == ('list[str]', 17)
@@ -1450,11 +1469,24 @@ def test_attrs_attrib_type(systemcls: Type[model.System]) -> None:
         e = attr.ib(123)
     ''', modname='test', systemcls=systemcls)
     C = mod.contents['C']
-    assert type2str(C.contents['a'].annotation) == 'int'
-    assert type2str(C.contents['b'].annotation) == 'int'
-    assert type2str(C.contents['c'].annotation) == 'C'
-    assert type2str(C.contents['d'].annotation) == 'bool'
-    assert type2str(C.contents['e'].annotation) == 'int'
+
+    A = C.contents['a']
+    B = C.contents['b']
+    _C = C.contents['c']
+    D = C.contents['d']
+    E = C.contents['e']
+
+    assert isinstance(A, model.Attribute)
+    assert isinstance(B, model.Attribute)
+    assert isinstance(_C, model.Attribute)
+    assert isinstance(D, model.Attribute)
+    assert isinstance(E, model.Attribute)
+
+    assert type2str(A.annotation) == 'int'
+    assert type2str(B.annotation) == 'int'
+    assert type2str(_C.annotation) == 'C'
+    assert type2str(D.annotation) == 'bool'
+    assert type2str(E.annotation) == 'int'
 
 @systemcls_param
 def test_attrs_attrib_instance(systemcls: Type[model.System]) -> None:

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -156,7 +156,9 @@ def test_constructor_params_empty() -> None:
         pass
     '''
     mod = fromText(src)
-    assert mod.contents['C'].constructor_params == {}
+    C = mod.contents['C']
+    assert isinstance(C, model.Class)
+    assert C.constructor_params == {}
 
 
 def test_constructor_params_simple() -> None:
@@ -166,7 +168,9 @@ def test_constructor_params_simple() -> None:
             pass
     '''
     mod = fromText(src)
-    assert mod.contents['C'].constructor_params.keys() == {'self', 'a', 'b'}
+    C = mod.contents['C']
+    assert isinstance(C, model.Class)
+    assert C.constructor_params.keys() == {'self', 'a', 'b'}
 
 
 def test_constructor_params_inherited() -> None:
@@ -181,7 +185,9 @@ def test_constructor_params_inherited() -> None:
         pass
     '''
     mod = fromText(src)
-    assert mod.contents['C'].constructor_params.keys() == {'self', 'a', 'b'}
+    C = mod.contents['C']
+    assert isinstance(C, model.Class)
+    assert C.constructor_params.keys() == {'self', 'a', 'b'}
 
 
 def test_docstring_lineno() -> None:

--- a/pydoctor/test/test_templatewriter.py
+++ b/pydoctor/test/test_templatewriter.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import Callable
+from typing import Callable, cast
 import pytest
 import warnings
 from pathlib import Path
@@ -242,11 +242,11 @@ def test_isPrivate(func: Callable[[model.Class], bool]) -> None:
             pass
     ''')
     public = mod.contents['Public']
-    assert not func(public)
-    assert not func(public.contents['Inner'])
+    assert not func(cast(model.Class, public))
+    assert not func(cast(model.Class, public.contents['Inner']))
     private = mod.contents['_Private']
-    assert func(private)
-    assert func(private.contents['Inner'])
+    assert func(cast(model.Class, private))
+    assert func(cast(model.Class, private.contents['Inner']))
 
 
 def test_isClassNodePrivate() -> None:
@@ -261,7 +261,7 @@ def test_isClassNodePrivate() -> None:
     class _Private(_BaseForPrivate):
         pass
     ''')
-    assert not isClassNodePrivate(mod.contents['Public'])
-    assert isClassNodePrivate(mod.contents['_Private'])
-    assert not isClassNodePrivate(mod.contents['_BaseForPublic'])
-    assert isClassNodePrivate(mod.contents['_BaseForPrivate'])
+    assert not isClassNodePrivate(cast(model.Class, mod.contents['Public']))
+    assert isClassNodePrivate(cast(model.Class, mod.contents['_Private']))
+    assert not isClassNodePrivate(cast(model.Class, mod.contents['_BaseForPublic']))
+    assert isClassNodePrivate(cast(model.Class, mod.contents['_BaseForPrivate']))

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -1,6 +1,9 @@
+from typing import cast
+
 from pydoctor.test.test_astbuilder import fromText, type2html
 from pydoctor.test.test_packages import processPackage
-from pydoctor.zopeinterface import ZopeInterfaceSystem
+from pydoctor.zopeinterface import ZopeInterfaceClass, ZopeInterfaceSystem
+from pydoctor.epydoc.markup import ParsedDocstring
 from pydoctor import model
 
 from . import CapSys, NotFoundLinker
@@ -74,6 +77,12 @@ def implements_test(src: str) -> None:
     foobar = mod.contents['FooBar']
     onlybar = mod.contents['OnlyBar']
 
+    assert isinstance(ifoo, ZopeInterfaceClass)
+    assert isinstance(ibar, ZopeInterfaceClass)
+    assert isinstance(foo, ZopeInterfaceClass)
+    assert isinstance(foobar, ZopeInterfaceClass)
+    assert isinstance(onlybar, ZopeInterfaceClass)
+
     assert ifoo.isinterface and ibar.isinterface
     assert not foo.isinterface and not foobar.isinterface and not foobar.isinterface
 
@@ -111,7 +120,9 @@ def test_multiply_inheriting_interfaces() -> None:
     class Both(One, Two): pass
     '''
     mod = fromText(src, modname='zi', systemcls=ZopeInterfaceSystem)
-    assert len(mod.contents['Both'].allImplementedInterfaces) == 2
+    B = mod.contents['Both']
+    assert isinstance(B, ZopeInterfaceClass)
+    assert len(list(B.allImplementedInterfaces)) == 2
 
 def test_attribute(capsys: CapSys) -> None:
     src = '''
@@ -136,9 +147,14 @@ def test_attribute(capsys: CapSys) -> None:
 def test_interfaceclass() -> None:
     system = processPackage('interfaceclass', systemcls=ZopeInterfaceSystem)
     mod = system.allobjects['interfaceclass.mod']
-    assert mod.contents['MyInterface'].isinterface
-    assert mod.contents['MyInterface'].docstring == "This is my interface."
-    assert mod.contents['AnInterface'].isinterface
+    I = mod.contents['MyInterface']
+    assert isinstance(I, ZopeInterfaceClass)
+    assert I.isinterface
+    assert I.docstring == "This is my interface."
+
+    J = mod.contents['AnInterface']
+    assert isinstance(J, ZopeInterfaceClass)
+    assert J.isinterface
 
 def test_warnerproofing() -> None:
     src = '''
@@ -148,7 +164,9 @@ def test_warnerproofing() -> None:
         pass
     '''
     mod = fromText(src, systemcls=ZopeInterfaceSystem)
-    assert mod.contents['IMyInterface'].isinterface
+    I = mod.contents['IMyInterface']
+    assert isinstance(I, ZopeInterfaceClass)
+    assert I.isinterface
 
 def test_zopeschema(capsys: CapSys) -> None:
     src = '''
@@ -202,14 +220,14 @@ def test_zopeschema_inheritance() -> None:
     mod = fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
     mytext = mod.contents['IMyInterface'].contents['mytext']
     assert mytext.docstring == 'fun in a bun'
-    assert str(mytext.parsed_type.to_stan(NotFoundLinker())) == "Tag('code', children=[Tag('', children=['MyTextLine'])])"
+    assert str(cast(ParsedDocstring, mytext.parsed_type).to_stan(NotFoundLinker())) == "Tag('code', children=[Tag('', children=['MyTextLine'])])"
     assert mytext.kind is model.DocumentableKind.SCHEMA_FIELD
     myothertext = mod.contents['IMyInterface'].contents['myothertext']
     assert myothertext.docstring == 'fun in another bun'
-    assert str(myothertext.parsed_type.to_stan(NotFoundLinker())) == "Tag('code', children=[Tag('', children=['MyOtherTextLine'])])"
+    assert str(cast(ParsedDocstring, myothertext.parsed_type).to_stan(NotFoundLinker())) == "Tag('code', children=[Tag('', children=['MyOtherTextLine'])])"
     assert myothertext.kind is model.DocumentableKind.SCHEMA_FIELD
     myint = mod.contents['IMyInterface'].contents['myint']
-    assert str(myint.parsed_type.to_stan(NotFoundLinker())) == "Tag('code', children=[Tag('', children=['INTEGERSCHMEMAFIELD'])])"
+    assert str(cast(ParsedDocstring, myint.parsed_type).to_stan(NotFoundLinker())) == "Tag('code', children=[Tag('', children=['INTEGERSCHMEMAFIELD'])])"
     assert myint.kind is model.DocumentableKind.SCHEMA_FIELD
 
 def test_docsources_includes_interface() -> None:
@@ -274,6 +292,7 @@ def test_implementer_decoration() -> None:
     mod = fromText(src, systemcls=ZopeInterfaceSystem)
     iface = mod.contents['IMyInterface']
     impl = mod.contents['Implementation']
+    assert isinstance(impl, ZopeInterfaceClass)
     assert impl.implements_directly == [iface.fullName()]
 
 def test_docsources_from_moduleprovides() -> None:
@@ -298,6 +317,7 @@ def test_interfaceallgames() -> None:
     system = processPackage('interfaceallgames', systemcls=ZopeInterfaceSystem)
     mod = system.allobjects['interfaceallgames.interface']
     iface = mod.contents['IAnInterface']
+    assert isinstance(iface, ZopeInterfaceClass)
     assert [o.fullName() for o in iface.implementedby_directly] == [
         'interfaceallgames.implementation.Implementation'
         ]
@@ -321,6 +341,8 @@ def test_implementer_with_star() -> None:
     mod = fromText(src, systemcls=ZopeInterfaceSystem)
     iface = mod.contents['IMyInterface']
     impl = mod.contents['Implementation']
+    assert isinstance(impl, ZopeInterfaceClass)
+    assert isinstance(iface, ZopeInterfaceClass)
     assert impl.implements_directly == [iface.fullName()]
 
 def test_implementer_nonname(capsys: CapSys) -> None:
@@ -335,6 +357,7 @@ def test_implementer_nonname(capsys: CapSys) -> None:
     '''
     mod = fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
     impl = mod.contents['Implementation']
+    assert isinstance(impl, ZopeInterfaceClass)
     assert impl.implements_directly == []
     captured = capsys.readouterr().out
     assert captured == 'mod:3: Interface argument 1 does not look like a name\n'
@@ -353,6 +376,7 @@ def test_implementer_nonclass(capsys: CapSys) -> None:
     '''
     mod = fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
     impl = mod.contents['Implementation']
+    assert isinstance(impl, ZopeInterfaceClass)
     assert impl.implements_directly == ['mod.var']
     captured = capsys.readouterr().out
     assert captured == 'mod:4: Supposed interface "mod.var" not detected as a class\n'
@@ -373,6 +397,8 @@ def test_implementer_plainclass(capsys: CapSys) -> None:
     mod = fromText(src, modname='mod', systemcls=ZopeInterfaceSystem)
     C = mod.contents['C']
     impl = mod.contents['Implementation']
+    assert isinstance(impl, ZopeInterfaceClass)
+    assert isinstance(C, ZopeInterfaceClass)
     assert not C.isinterface
     assert C.kind is model.DocumentableKind.CLASS
     assert impl.implements_directly == ['mod.C']
@@ -420,11 +446,13 @@ def test_implementer_reparented() -> None:
     ''', modname='app', system=system)
 
     iface = mod_iface.contents['IMyInterface']
+    assert isinstance(iface, ZopeInterfaceClass)
     iface.reparent(mod_export, 'IMyInterface')
     assert iface.fullName() == 'public.IMyInterface'
     assert 'IMyInterface' not in mod_iface.contents
 
     impl = mod_impl.contents['Implementation']
+    assert isinstance(impl, ZopeInterfaceClass)
     assert impl.implements_directly == ['_private.IMyInterface']
     assert iface.implementedby_directly == []
 


### PR DESCRIPTION
Adjust the rest of the annotation in the codebase.

Add assertion when needed, like before reparent() call to assert the parent is a module.

Fix a potentially problematic None value in the Documentable.kind property in format_undocumented().

Change the unwrap() function in the test_astbuilder module to accept Optional[ParsedDocstring] but actually raises if the parsed_docstring is not an ParsedEpytextDocstring. This avoids a lot of extra cast() call or assertions in test_astbuilder.