### PR TITLE
Enable break-word for parameter names and function names

### DIFF
--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -5,7 +5,7 @@ Most part of this documentation is using Python type hinting.
 """
 
 from abc import ABC
-from typing import AnyStr, Generator, Union
+from typing import AnyStr, Dict, Generator, List, Union
 from somelib import SomeInterface
 import zope.interface
 import zope.schema
@@ -39,7 +39,7 @@ def demo_typing_arguments(name: str, size: bytes) -> bool:
 
 def demo_long_function_and_parameter_names__this_indeed_very_long(
         this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: str, 
-        what__another_super_super_long_name__ho_no: Generator[Union[list[AnyStr], dict[str, AnyStr]], None, None]) -> bool:
+        what__another_super_super_long_name__ho_no: Generator[Union[List[AnyStr], Dict[str, AnyStr]], None, None]) -> bool:
     """
     Long names and annotations should display on several lines when they don't fit in a single line. 
     """

--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -38,7 +38,7 @@ def demo_typing_arguments(name: str, size: bytes) -> bool:
     return True
 
 def demo_long_function_and_parameter_names__this_indeed_very_long(
-        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: str, 
+        this_is_a_very_long_parameter_name_aahh: str, 
         what__another_super_super_long_name__ho_no: Generator[Union[List[AnyStr], Dict[str, AnyStr]], None, None]) -> bool:
     """
     Long names and annotations should display on several lines when they don't fit in a single line. 

--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -36,6 +36,13 @@ def demo_typing_arguments(name: str, size: bytes) -> bool:
     """
     return True
 
+def demo_long_function_and_parameter_names__this_indeed_very_long(
+        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: str, 
+        what__another_super_super_long_name__ho_no: bytes) -> bool:
+    """
+    Long names should display on several lines when they don't fit in a single line. 
+    """
+    return True
 
 def demo_cross_reference() -> None:
     """

--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -5,6 +5,7 @@ Most part of this documentation is using Python type hinting.
 """
 
 from abc import ABC
+from typing import AnyStr, Generator, Literal, Union
 from somelib import SomeInterface
 import zope.interface
 import zope.schema
@@ -37,10 +38,10 @@ def demo_typing_arguments(name: str, size: bytes) -> bool:
     return True
 
 def demo_long_function_and_parameter_names__this_indeed_very_long(
-        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: str, 
-        what__another_super_super_long_name__ho_no: bytes) -> bool:
+        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: Literal["one", "two", "three", "four", "five"], 
+        what__another_super_super_long_name__ho_no: Generator[Union[list[AnyStr], dict[str, AnyStr]], None, None]) -> bool:
     """
-    Long names should display on several lines when they don't fit in a single line. 
+    Long names and annotations should display on several lines when they don't fit in a single line. 
     """
     return True
 

--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -5,7 +5,7 @@ Most part of this documentation is using Python type hinting.
 """
 
 from abc import ABC
-from typing import AnyStr, Generator, Literal, Union
+from typing import AnyStr, Generator, Union
 from somelib import SomeInterface
 import zope.interface
 import zope.schema
@@ -38,7 +38,7 @@ def demo_typing_arguments(name: str, size: bytes) -> bool:
     return True
 
 def demo_long_function_and_parameter_names__this_indeed_very_long(
-        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: Literal["one", "two", "three", "four", "five"], 
+        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: str, 
         what__another_super_super_long_name__ho_no: Generator[Union[list[AnyStr], dict[str, AnyStr]], None, None]) -> bool:
     """
     Long names and annotations should display on several lines when they don't fit in a single line. 

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -11,7 +11,7 @@ def demo_fields_docstring_arguments(m, b):  # type: ignore
     """
     Fields are used to describe specific properties of a documented object.
 
-    This function can be used in conjuction with L{demo_typing_arguments} to
+    This function can be used in conjuction with `demo_typing_arguments` to
     find an arbitrary function's zeros.
 
     :type  m: number
@@ -46,7 +46,7 @@ def demo_typing_arguments(name: str, size: bytes) -> bool:
     return True
 
 def demo_long_function_and_parameter_names__this_indeed_very_long(
-        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: str, 
+        this_is_a_very_long_parameter_name_aahh: str, 
         what__another_super_super_long_name__ho_no: Generator[Union[List[AnyStr], Dict[str, AnyStr]], None, None]) -> bool:
     """
     Long names and annotations should display on several lines when they don't fit in a single line. 

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -43,10 +43,10 @@ def demo_typing_arguments(name: str, size: bytes) -> bool:
     return True
 
 def demo_long_function_and_parameter_names__this_indeed_very_long(
-        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: str, 
-        what__another_super_super_long_name__ho_no: bytes) -> bool:
+        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: Literal["one", "two", "three", "four", "five"], 
+        what__another_super_super_long_name__ho_no: Generator[Union[list[AnyStr], dict[str, AnyStr]], None, None]) -> bool:
     """
-    Long names should display on several lines when they don't fit in a single line. 
+    Long names and annotations should display on several lines when they don't fit in a single line. 
     """
     return True
 

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -47,7 +47,7 @@ def demo_typing_arguments(name: str, size: bytes) -> bool:
 
 def demo_long_function_and_parameter_names__this_indeed_very_long(
         this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: str, 
-        what__another_super_super_long_name__ho_no: Generator[Union[list[AnyStr], dict[str, AnyStr]], None, None]) -> bool:
+        what__another_super_super_long_name__ho_no: Generator[Union[List[AnyStr], Dict[str, AnyStr]], None, None]) -> bool:
     """
     Long names and annotations should display on several lines when they don't fit in a single line. 
     """

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -42,6 +42,13 @@ def demo_typing_arguments(name: str, size: bytes) -> bool:
     """
     return True
 
+def demo_long_function_and_parameter_names__this_indeed_very_long(
+        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: str, 
+        what__another_super_super_long_name__ho_no: bytes) -> bool:
+    """
+    Long names should display on several lines when they don't fit in a single line. 
+    """
+    return True
 
 def demo_cross_reference() -> None:
     r"""

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -4,6 +4,9 @@ This is a module demonstrating reST code documentation features.
 Most part of this documentation is using Python type hinting.
 """
 
+from typing import AnyStr, Generator, Union
+
+
 def demo_fields_docstring_arguments(m, b):  # type: ignore
     """
     Fields are used to describe specific properties of a documented object.
@@ -43,7 +46,7 @@ def demo_typing_arguments(name: str, size: bytes) -> bool:
     return True
 
 def demo_long_function_and_parameter_names__this_indeed_very_long(
-        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: Literal["one", "two", "three", "four", "five"], 
+        this_is_a_very_long_parameter_name_don_t_do_that_at_home_kids: str, 
         what__another_super_super_long_name__ho_no: Generator[Union[list[AnyStr], dict[str, AnyStr]], None, None]) -> bool:
     """
     Long names and annotations should display on several lines when they don't fit in a single line. 

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -4,7 +4,7 @@ This is a module demonstrating reST code documentation features.
 Most part of this documentation is using Python type hinting.
 """
 
-from typing import AnyStr, Generator, Union
+from typing import AnyStr, Generator, Union, List, Dict
 
 
 def demo_fields_docstring_arguments(m, b):  # type: ignore

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -804,13 +804,16 @@ class _AnnotationFormatter(ast.NodeVisitor):
         else:
             return self.generic_visit(node)
 
-    def _handle_sequence(self, tag: Tag, sequence: Iterable[ast.expr]) -> None:
+    def _handle_sequence(self, tag: Tag, sequence: List[ast.expr]) -> None:
         first = True
-        for elem in sequence:
+        for i, elem in enumerate(sequence):
             if first:
                 first = False
             else:
-                tag(', ', tags.wbr) # Add an potential line break for long types
+                # Add an potential line break for long types, not when it's the last bracket, though.
+                tag(', ')
+                if i < len(sequence)-1:
+                    tag(tags.wbr)
             tag(self.visit(elem))
 
     def visit_Name(self, node: ast.Name) -> Tag:

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -3,7 +3,6 @@ body {
     flex-direction: column;
     min-height: 100vh;
     overflow-y: scroll;
-    word-break: break-word;
 }
 
 nav.navbar {
@@ -223,6 +222,7 @@ ul ul ul ul ul ul ul {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+    word-break: break-word;
 }
 
 /* Argument description column or return value desc, etc */
@@ -239,6 +239,7 @@ ul ul ul ul ul ul ul {
 /* Attr name column table  */
 #splitTables > table tr td:nth-child(2) {
     width: 200px;
+    word-break: break-word;
 }
 
 /* For smaller displays, i.e. half screen or mobile phone */

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -204,7 +204,7 @@ ul ul ul ul ul ul ul {
 }
 
 .fieldTable tr:not(.fieldStart) td:first-child{
-    padding-left: 10px;
+    padding: 3px 4px 3px 10px;
 }
 
 .fieldTable tr td {
@@ -219,10 +219,20 @@ ul ul ul ul ul ul ul {
 /* Argument name + type column table  */
 .fieldTable tr td.fieldArgContainer {
     width: 250px;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
     word-break: break-word;
+}
+
+/* parameters names in parameters table */
+.fieldTable tr td.fieldArgContainer > .fieldArg {
+    display: inline;
+}
+
+/* parameters types (in parameters table) */
+.fieldTable tr td.fieldArgContainer > code {
+    /* we don't want word break for the types because we already add <wbr> tags inside the type HTML, and that should suffice. */
+    word-break: normal;
+    display: inline-flex;
+    flex-wrap: wrap;
 }
 
 /* Argument description column or return value desc, etc */

--- a/pydoctor/templates/apidocs.css
+++ b/pydoctor/templates/apidocs.css
@@ -3,6 +3,7 @@ body {
     flex-direction: column;
     min-height: 100vh;
     overflow-y: scroll;
+    word-break: break-word;
 }
 
 nav.navbar {


### PR DESCRIPTION
This small adjustment to the CSS makes long words (namely long parameter names or function names) take multiple lines (without hyphen) when there is no space left. 
The current behaviour is annoying because long names overlaps with documentation.

Example of annoyance: [configargparse.ArgumentParser](https://tristanlatr.github.io/ConfigArgParse/configargparse.ArgumentParser.html#__init__)
