### PR TITLE
Documentable.setDocstring now accepts a string type.

### DIFF
--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -146,23 +146,27 @@ class Documentable:
         #       requires a boatload of changes.
         self.contents: Dict[str, Any] = {}
 
-    def setDocstring(self, node: ast.Str) -> None:
-        doc = node.s
-        lineno = node.lineno
-        if _string_lineno_is_end:
-            # In older CPython versions, the AST only tells us the end line
-            # number and we must approximate the start line number.
-            # This approximation is correct if the docstring does not contain
-            # explicit newlines ('\n') or joined lines ('\' at end of line).
-            lineno -= doc.count('\n')
+    def setDocstring(self, node: Union[ast.Str, str]) -> None:
+        if isinstance(node, ast.Str):
+            doc = node.s
+            lineno = node.lineno
+            if _string_lineno_is_end:
+                # In older CPython versions, the AST only tells us the end line
+                # number and we must approximate the start line number.
+                # This approximation is correct if the docstring does not contain
+                # explicit newlines ('\n') or joined lines ('\' at end of line).
+                lineno -= doc.count('\n')
 
-        # Leading blank lines are stripped by cleandoc(), so we must
-        # return the line number of the first non-blank line.
-        for ch in doc:
-            if ch == '\n':
-                lineno += 1
-            elif not ch.isspace():
-                break
+            # Leading blank lines are stripped by cleandoc(), so we must
+            # return the line number of the first non-blank line.
+            for ch in doc:
+                if ch == '\n':
+                    lineno += 1
+                elif not ch.isspace():
+                    break
+        else:
+            doc = node
+            lineno = self.linenumber
 
         self.docstring = inspect.cleandoc(doc)
         self.docstring_lineno = lineno


### PR DESCRIPTION
When passing a `str`: the `Documentable.docstring_lineno` attribute is set to the same values as `Documentable. linenumber` , instead of calculating the real line number. 
This is needed in order to load the documentable data from JSON, where the raw docstring is stored as astring. 

See #93.