### PR TITLE
Docutils typeshed are a bit more complete now.

### DIFF
--- a/pydoctor/epydoc/markup/restructuredtext.py
+++ b/pydoctor/epydoc/markup/restructuredtext.py
@@ -392,9 +392,7 @@ class _EpydocHTMLTranslator(HTMLTranslator):
 
         # Set the document's settings.
         if self.settings is None:
-            settings = OptionParser([HTMLWriter()]).get_default_values() #type: ignore[arg-type]
-            # See: https://github.com/python/typeshed/issues/5667
-            
+            settings = OptionParser([HTMLWriter()]).get_default_values()
             self.__class__.settings = settings
         document.settings = self.settings
 


### PR DESCRIPTION
We don't need this type ignore comment anymore. 

Issue https://github.com/python/typeshed/issues/5667 is fixed.