### PR TITLE
21.9.1

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.6]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, pypy-3.6]
         os: [ubuntu-20.04]
         include:
           - os: windows-latest

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, pypy-3.6]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc.2, pypy-3.6]
         os: [ubuntu-20.04]
         include:
           - os: windows-latest

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,7 @@ pydoctor 21.9.1
 ^^^^^^^^^^^^^^^
 
 * Fix deprecation warning and officially support Python 3.10.
+* Fix the literals style (use same style as before).
 
 pydoctor 21.9.0
 ^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,9 @@ You can select a different format using the ``--docformat`` option or the ``__do
 What's New?
 ~~~~~~~~~~~
 
+in development
+^^^^^^^^^^^^^^
+
 pydoctor 21.9.1
 ^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ What's New?
 pydoctor 21.9.1
 ^^^^^^^^^^^^^^^
 
-* Support Python 3.10.
+* Fix deprecation warning and officially support Python 3.10.
 
 pydoctor 21.9.0
 ^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,11 @@ You can select a different format using the ``--docformat`` option or the ``__do
 What's New?
 ~~~~~~~~~~~
 
+pydoctor 21.9.1
+^^^^^^^^^^^^^^^
+
+* Support Python 3.10.
+
 pydoctor 21.9.0
 ^^^^^^^^^^^^^^^
 

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -31,6 +31,7 @@ def templatefile(filename: str) -> None:
 
 _VT = TypeVar('_VT')
 
+# Credits: psf/requests see https://github.com/psf/requests/blob/main/AUTHORS.rst
 class CaseInsensitiveDict(MutableMapping[str, _VT], Generic[_VT]):
     """A case-insensitive ``dict``-like object.
     Implements all methods and operations of

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -2,6 +2,7 @@
 
 import warnings
 import collections
+import collections.abc
 from typing import Any, Dict, Generic, Iterable, Iterator, Mapping, Optional, MutableMapping, Tuple, TypeVar, Union
 from pydoctor import model
 from pydoctor.epydoc2stan import format_kind
@@ -84,7 +85,7 @@ class CaseInsensitiveDict(MutableMapping[str, _VT], Generic[_VT]):
         )
 
     def __eq__(self, other: Any) -> bool:
-        if isinstance(other, collections.Mapping):
+        if isinstance(other, collections.abc.Mapping):
             other = CaseInsensitiveDict(other)
             # Compare insensitively
             return dict(self.lower_items()) == dict(other.lower_items())

--- a/pydoctor/templatewriter/util.py
+++ b/pydoctor/templatewriter/util.py
@@ -1,7 +1,6 @@
 """Miscellaneous utilities for the HTML writer."""
 
 import warnings
-import collections
 import collections.abc
 from typing import Any, Dict, Generic, Iterable, Iterator, Mapping, Optional, MutableMapping, Tuple, TypeVar, Union
 from pydoctor import model

--- a/pydoctor/themes/base/apidocs.css
+++ b/pydoctor/themes/base/apidocs.css
@@ -363,7 +363,7 @@ tr.private {
   but also to links that are present in summary tables.
 - 'functionHeader' is used for lines like `def func():` and `var =`
 */
-code, .pre, #childList > div .functionHeader,
+code, .literal, .pre, #childList > div .functionHeader,
 #splitTables > table tr td:nth-child(2), .fieldArg {
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }
@@ -387,7 +387,7 @@ code > a {
 This defines the code style, it's black on light gray.
 It also overwrite the default values inherited from bootstrap min
 */
-code {
+code, .literal {
     padding:2px 4px;
     background-color: #f4f4f4;
     border-radius:4px

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoctor
-version = 21.9.0.dev0
+version = 21.9.1
 author = Michael Hudson-Doyle
 author_email = micahel@gmail.com
 maintainer = Maarten ter Huurne

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoctor
-version = 21.9.1
+version = 21.9.1.dev0
 author = Michael Hudson-Doyle
 author_email = micahel@gmail.com
 maintainer = Maarten ter Huurne


### PR DESCRIPTION
Fixes #435. 

We now officially support python 3.10.

It also fixes a minor - not wanted - change in the style of literals.