### PR TITLE
Fix `InMemoryWriter` to match `IWriter` interface and remove unnecessary warning

### DIFF
--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -463,15 +463,9 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
 
             build_directory = Path(options.htmloutput)
 
-            try:
-                # mypy error: Cannot instantiate abstract class 'IWriter'
-                writer = writerclass(build_directory, # type: ignore[abstract]
-                    template_lookup=template_lookup)
-            except TypeError:
-                # Custom class does not accept 'template_lookup' argument.
-                writer = writerclass(build_directory) # type: ignore[abstract]
-                warnings.warn(f"Writer '{writerclass.__name__}' does not support "
-                    "HTML template customization with --template-dir.")
+            # mypy error: Cannot instantiate abstract class 'IWriter'
+            writer = writerclass(build_directory, # type: ignore[abstract]
+                template_lookup=template_lookup)
 
             writer.prepOutputDirectory()
 

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -6,7 +6,6 @@ from typing import Iterator, TYPE_CHECKING, List, Sequence, Tuple, Type, TypeVar
 import datetime
 import os
 import sys
-import warnings
 from inspect import getmodulename
 
 from pydoctor.themes import get_themes

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -432,7 +432,8 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
             from pydoctor import templatewriter
             if options.htmlwriter:
                 writerclass = findClassFromDottedName(
-                    options.htmlwriter, '--html-writer', IWriter)
+                    # ignore mypy error: Only concrete class can be given where "Type[IWriter]" is expected
+                    options.htmlwriter, '--html-writer', IWriter) # type: ignore[misc]
             else:
                 writerclass = templatewriter.TemplateWriter
 
@@ -462,9 +463,7 @@ def main(args: Sequence[str] = sys.argv[1:]) -> int:
 
             build_directory = Path(options.htmloutput)
 
-            # mypy error: Cannot instantiate abstract class 'IWriter'
-            writer = writerclass(build_directory, # type: ignore[abstract]
-                template_lookup=template_lookup)
+            writer = writerclass(build_directory, template_lookup=template_lookup)
 
             writer.prepOutputDirectory()
 

--- a/pydoctor/templatewriter/__init__.py
+++ b/pydoctor/templatewriter/__init__.py
@@ -62,9 +62,6 @@ class IWriter(Protocol):
     Interface class for pydoctor output writer.
     """
 
-    @overload
-    def __init__(self, build_directory: Path) -> None: ...
-    @overload
     def __init__(self, build_directory: Path, template_lookup: 'TemplateLookup') -> None: ...
 
     def prepOutputDirectory(self) -> None:

--- a/pydoctor/templatewriter/__init__.py
+++ b/pydoctor/templatewriter/__init__.py
@@ -1,5 +1,5 @@
 """Render pydoctor data as HTML."""
-from typing import Iterable, Iterator, Optional, Union, cast, overload, TYPE_CHECKING
+from typing import Iterable, Iterator, Optional, Union, cast, TYPE_CHECKING
 if TYPE_CHECKING:
     from typing_extensions import Protocol, runtime_checkable
 else:

--- a/pydoctor/test/__init__.py
+++ b/pydoctor/test/__init__.py
@@ -4,11 +4,12 @@ from logging import LogRecord
 from typing import Iterable, TYPE_CHECKING, Optional, Sequence
 import sys
 import pytest
+from pathlib import Path
 
 from twisted.web.template import Tag, tags
 
 from pydoctor import epydoc2stan, model
-from pydoctor.templatewriter import IWriter
+from pydoctor.templatewriter import IWriter, TemplateLookup
 from pydoctor.epydoc.markup import DocstringLinker
 
 if TYPE_CHECKING:
@@ -48,8 +49,8 @@ class InMemoryWriter(IWriter):
     trigger the rendering of epydoc for the targeted code.
     """
 
-    def __init__(self, filebase: str) -> None:
-        self._base = filebase
+    def __init__(self, build_directory: Path, template_lookup: 'TemplateLookup') -> None:
+        pass
 
     def prepOutputDirectory(self) -> None:
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,6 @@ doctest_optionflags = ELLIPSIS IGNORE_EXCEPTION_DETAIL
 xfail_strict = true
 filterwarnings =
     error
-    ignore:Writer 'InMemoryWriter' does not support HTML template customization with --template-dir\.:UserWarning:pydoctor.driver
 
 [upload]
 sign = True


### PR DESCRIPTION
Avoids UserWarning to be triggered while testing. 

We should add a test for this code block nevertheless, or completely remove the catch block if we decide that's not worth it to keep. 

This warning come from the fact that we can pass a custom HTML writer with the option `--html-writer`, the thing is that the interface of such writer has changed, we don't pass the build directory as `str` anymore, bu rather as `Path`, so in any case, older customized HTML writer will be broken, If the customization overrides the `__init__` method. 

So I think it's probably OK to remove the `TypeError` catching altogether and remove the `@overload` from the `IWriter.__init__` definition. 
