### PR TITLE
Update codedoc.rst

### DIFF
--- a/docs/source/codedoc.rst
+++ b/docs/source/codedoc.rst
@@ -314,4 +314,4 @@ The content of ``my_project/__init__.py`` includes::
 
     from .core._impl import MyClass
 
-    __all__ = ["MyClass"]
+    __all__ = ("MyClass",)


### PR DESCRIPTION
`__all__` should be unmutable, so a tuple is better than a list here. Stumbled upon this while improving docs for `python-igraph`...