### PR TITLE
Insert zero-width spaces for better line wrapping

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ What's New?
 
 in development
 ^^^^^^^^^^^^^^
+* Smarter line wrapping in summary and parameters tables.
 * Fix introspection of functions comming from C-extensions.
 
 pydoctor 21.12.1

--- a/pydoctor/templatewriter/pages/table.py
+++ b/pydoctor/templatewriter/pages/table.py
@@ -47,7 +47,7 @@ class TableRow(Element):
     @renderer
     def name(self, request: object, tag: Tag) -> Tag:
         return tag.clear()(tags.code(
-            epydoc2stan.taglink(self.child, self.ob.url, self.child.name)
+            epydoc2stan.taglink(self.child, self.ob.url, epydoc2stan.insert_break_points(self.child.name))
             ))
 
     @renderer

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -1218,3 +1218,16 @@ def test_yields_field(capsys: CapSys) -> None:
     captured = capsys.readouterr().out
     assert captured == ''
 
+def test_insert_break_points_identity() -> None:
+    assert epydoc2stan.insert_break_points('test') == 'test'
+    assert epydoc2stan.insert_break_points('__test__') == '__test__'
+    assert epydoc2stan.insert_break_points('__someverylongname__') == '__someverylongname__'
+    assert epydoc2stan.insert_break_points('__SOMEVERYLONGNAME__') == '__SOMEVERYLONGNAME__'
+
+def test_insert_break_points_snake_case() -> None:
+    assert epydoc2stan.insert_break_points('__some_very_long_name__') == '__some\u200b_very\u200b_long\u200b_name__'
+    assert epydoc2stan.insert_break_points('__SOME_VERY_LONG_NAME__') == '__SOME\u200b_VERY\u200b_LONG\u200b_NAME__'
+
+def test_insert_break_points_camel_case() -> None:
+    assert epydoc2stan.insert_break_points('__someVeryLongName__') == '__some\u200bVery\u200bLong\u200bName__'
+    assert epydoc2stan.insert_break_points('__einÜberlangerName__') == '__ein\u200bÜberlanger\u200bName__'


### PR DESCRIPTION
For the following code:

    class Foo:
        def some_methods_have_longer_names_that_break(self):
            pass

        def someMethodsHaveLongerNamesThatBreak(self):
            pass

Pydoctor previously generated a class page with a table
that Firefox ended up rendering as:

    Method   some_methods_have_longe    Undocumented
             r_names_that_break

    Method   someMethodsHaveLongerNa    Undocumented
             mesThatBreak

This commit makes Pydoctor detect snake_case and camelCase and insert
zero-width spaces accordingly so that the table becomes:

    Method   some_methods_have          Undocumented
             _longer_names_that_break

    Method   someMethodsHaveLonger      Undocumented
             NamesThatBreak

Fixes #466.