### PR TITLE
Make intersphinx links blue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ What's New?
 
 in development
 ^^^^^^^^^^^^^^
+* Make intersphinx links blue instead of red. Keep red color for internal links only.
 * Smarter line wrapping in summary and parameters tables.
 * Fix introspection of functions comming from C-extensions.
 

--- a/docs/tests/test.py
+++ b/docs/tests/test.py
@@ -104,7 +104,7 @@ def test_index_contains_infos():
               '<a href="moduleIndex.html"',
               '<a href="classIndex.html"',
               '<a href="nameIndex.html"',
-              'Start at <code><a href="pydoctor.html">pydoctor</a></code>, the root package.',
+              'Start at <code><a href="pydoctor.html" class="internal-link">pydoctor</a></code>, the root package.',
               '<a href="https://github.com/twisted/pydoctor/">pydoctor</a>',)
 
     with open(BASE_DIR / 'api' / 'index.html', 'r', encoding='utf-8') as stream:

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -53,6 +53,9 @@ def get_docstring(
 
 
 def taglink(o: model.Documentable, page_url: str, label: Optional["Flattenable"] = None) -> Tag:
+    """
+    Create a link to an object that exists in the system.
+    """
     if not o.isVisible:
         o.system.msg("html", "don't link to %s"%o.fullName())
 
@@ -74,6 +77,13 @@ class _EpydocLinker(DocstringLinker):
 
     def __init__(self, obj: model.Documentable):
         self.obj = obj
+
+    @staticmethod
+    def _create_intersphinx_link(label:str, url:str) -> "Flattenable":
+        """
+        Create a link with the special 'intersphinx-link' CSS class.
+        """
+        return tags.a(label, href=url, class_='intersphinx-link')
 
     def look_for_name(self,
             name: str,
@@ -115,7 +125,7 @@ class _EpydocLinker(DocstringLinker):
 
         url = self.look_for_intersphinx(fullID)
         if url is not None:
-            return tags.a(label, href=url)
+            return self._create_intersphinx_link(label, url=url)
 
         return tags.transparent(label)
 
@@ -129,7 +139,7 @@ class _EpydocLinker(DocstringLinker):
             if isinstance(resolved, model.Documentable):
                 xref = taglink(resolved, self.obj.page_object.url, label)
             else:
-                xref = tags.a(label, href=resolved)
+                xref = self._create_intersphinx_link(label, url=resolved)
         ret: Tag = tags.code(xref)
         return ret
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -79,7 +79,7 @@ class _EpydocLinker(DocstringLinker):
         self.obj = obj
 
     @staticmethod
-    def _create_intersphinx_link(label:str, url:str) -> "Flattenable":
+    def _create_intersphinx_link(label:str, url:str) -> Tag:
         """
         Create a link with the special 'intersphinx-link' CSS class.
         """

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -69,7 +69,7 @@ def taglink(o: model.Documentable, page_url: str, label: Optional["Flattenable"]
         # if the query string is non-empty.
         url = url[len(page_url):]
 
-    ret: Tag = tags.a(label, href=url)
+    ret: Tag = tags.a(label, href=url, class_='internal-link')
     return ret
 
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -79,7 +79,7 @@ class _EpydocLinker(DocstringLinker):
         self.obj = obj
 
     @staticmethod
-    def _create_intersphinx_link(label:str, url:str) -> Tag:
+    def _create_intersphinx_link(label:"Flattenable", url:str) -> Tag:
         """
         Create a link with the special 'intersphinx-link' CSS class.
         """

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -435,25 +435,18 @@ class ClassPage(CommonPage):
 
     def classSignature(self) -> "Flattenable":
         r: List["Flattenable"] = []
-        zipped = list(zip(self.ob.rawbases, self.ob.bases, self.ob.baseobjects))
+        _linker = epydoc2stan._EpydocLinker(self.ob)
+        zipped = list(zip(self.ob.rawbases, self.ob.bases))
         if zipped:
             r.append('(')
-            for idx, (name, full_name, base) in enumerate(zipped):
+            for idx, (name, full_name) in enumerate(zipped):
                 if idx != 0:
                     r.append(', ')
 
-                if base is None:
-                    # External class.
-                    url = self.ob.system.intersphinx.getLink(full_name)
-                else:
-                    # Internal class.
-                    url = base.url
-
-                if url is None:
-                    tag = tags.span
-                else:
-                    tag = tags.a(href=url)
-                r.append(tag(name, title=full_name))
+                # link to external class or internal class
+                tag = _linker.link_to(full_name, name)
+                    
+                r.append(tag(title=full_name))
             r.append(')')
         return r
 

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -390,7 +390,7 @@ def test_func_raise_linked() -> None:
         """
     ''', modname='test')
     html = docstring2html(mod.contents['f']).split('\n')
-    assert '<a href="test.SpanishInquisition.html">SpanishInquisition</a>' in html
+    assert '<a href="test.SpanishInquisition.html" class="internal-link">SpanishInquisition</a>' in html
 
 
 def test_func_raise_missing_exception_type(capsys: CapSys) -> None:
@@ -1175,7 +1175,7 @@ def test_constant_values_rst(capsys: CapSys) -> None:
     expected = ('<table class="valueTable"><tr class="fieldStart">'
                 '<td class="fieldName">Value</td></tr><tr><td>'
                 '<pre class="constant-value"><code>(<wbr></wbr>'
-                '<a href="pack.mod1.html#f">f</a>)</code></pre></td></tr></table>')
+                '<a href="pack.mod1.html#f" class="internal-link">f</a>)</code></pre></td></tr></table>')
     
     attr = mod.contents['CONST']
     assert isinstance(attr, model.Attribute)

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -782,6 +782,23 @@ def test_EpydocLinker_look_for_intersphinx_hit() -> None:
 
     assert 'http://tm.tld/some.html' == result
 
+def test_EpydocLinker_adds_intersphinx_link_css_class() -> None:
+    """
+    The EpydocLinker return a link with the CSS class 'intersphinx-link' when it's using intersphinx.
+    """
+    system = model.System()
+    inventory = SphinxInventory(system.msg)
+    inventory._links['base.module.other'] = ('http://tm.tld', 'some.html')
+    system.intersphinx = inventory
+    target = model.Module(system, 'ignore-name')
+    sut = epydoc2stan._EpydocLinker(target)
+
+    result1 = sut.link_xref('base.module.other', 'base.module.other', 0).children[0] # wrapped in a code tag
+    result2 = sut.link_to('base.module.other', 'base.module.other')
+    
+    res = flatten(result2)
+    assert flatten(result1) == res
+    assert 'class="intersphinx-link"' in res
 
 def test_EpydocLinker_resolve_identifier_xref_intersphinx_absolute_id() -> None:
     """

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -390,7 +390,7 @@ def test_func_raise_linked() -> None:
         """
     ''', modname='test')
     html = docstring2html(mod.contents['f']).split('\n')
-    assert '<a href="test.SpanishInquisition.html" title="test.SpanishInquisition" class="internal-link">SpanishInquisition</a>' in html
+    assert '<a href="test.SpanishInquisition.html" class="internal-link" title="test.SpanishInquisition">SpanishInquisition</a>' in html
 
 
 def test_func_raise_missing_exception_type(capsys: CapSys) -> None:

--- a/pydoctor/themes/base/apidocs.css
+++ b/pydoctor/themes/base/apidocs.css
@@ -355,9 +355,7 @@ tr.private {
 /*
 - Links to class/function/etc names are nested like this:
     <code><a>label</a></code>
-  This applies to inline docstring content marked up as code,
-  for example L{foo} in epytext or `bar` in restructuredtext,
-  but also to links that are present in summary tables.
+  
 - 'functionHeader' is used for lines like `def func():` and `var =`
 */
 code, .literal, .pre, #childList > div .functionHeader,
@@ -367,14 +365,21 @@ code, .literal, .pre, #childList > div .functionHeader,
 code, #childList > div .functionHeader, .fieldArg {
     color: #222222;
 }
-code > a, #childList > div .functionHeader a {
-    color:#c7254e;
-    background-color:#f9f2f4;
-}
 
 /* Intersphinx links are not red, but simply blue */
 a.intersphinx-link {
-    color:#306998!important;
+    color:#23527c;
+    background-color:#f9f2f4;
+}
+
+/* Links to objects within the system use this special css.
+This applies to inline docstring content marked up as code,
+  for example L{foo} in epytext or `bar` in restructuredtext,
+  but also to links that are present in summary tables.
+*/
+a.internal-link {
+    color:#c7254e;
+    background-color:#f9f2f4;
 }
 
 /* top navagation bar */

--- a/pydoctor/themes/base/apidocs.css
+++ b/pydoctor/themes/base/apidocs.css
@@ -371,6 +371,12 @@ code > a, #childList > div .functionHeader a {
     color:#c7254e;
     background-color:#f9f2f4;
 }
+
+/* Intersphinx links are not red, but simply blue */
+a.intersphinx-link {
+    color:#306998!important;
+}
+
 /* top navagation bar */
 .page-header > h1 {
     margin-top: 0;

--- a/pydoctor/themes/base/apidocs.css
+++ b/pydoctor/themes/base/apidocs.css
@@ -368,8 +368,8 @@ code, #childList > div .functionHeader, .fieldArg {
 
 /* Intersphinx links are not red, but simply blue */
 a.intersphinx-link {
-    color:#23527c;
-    background-color:#f9f2f4;
+    color: #03458a;
+    background-color: #f0ebe694;
 }
 
 /* Links to objects within the system use this special css.


### PR DESCRIPTION
Make intersphinx links blue. 

We now have a clear indication on whether the linked object is in the project or not.

Example parameters values and annotations: https://pydoctor--468.org.readthedocs.build/en/468/api/pydoctor.epydoc.markup.html#get_parser_by_name

Example base classes: https://pydoctor--468.org.readthedocs.build/en/468/api/pydoctor.test.test_sphinx.ClosingBytesIO.html

Fixes #464 