### PR TITLE
Display name instead of full name in Module Index

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ in development
 ^^^^^^^^^^^^^^
 * Smarter line wrapping in summary and parameters tables.
 * Any code inside of ``if __name__ == '__main__'`` is now excluded from the documentation.
+* The Module Index now only shows module names instead of their full name.
 * Fix introspection of functions comming from C-extensions.
 
 pydoctor 21.12.1

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ in development
 ^^^^^^^^^^^^^^
 * Smarter line wrapping in summary and parameters tables.
 * Any code inside of ``if __name__ == '__main__'`` is now excluded from the documentation.
-* The Module Index now only shows module names instead of their full name.
+* The Module Index now only shows module names instead of their full name. You can hover over a module link to see the full name.
 * Fix introspection of functions comming from C-extensions.
 
 pydoctor 21.12.1

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -66,7 +66,9 @@ def taglink(o: model.Documentable, page_url: str, label: Optional["Flattenable"]
         # if the query string is non-empty.
         url = url[len(page_url):]
 
-    ret: Tag = tags.a(label, href=url)
+    ret = tags.a(label, href=url)
+    if label != o.fullName():
+        ret(title=o.fullName())
     return ret
 
 

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 def moduleSummary(module: model.Module, page_url: str) -> Tag:
     r: Tag = tags.li(
-        tags.code(epydoc2stan.taglink(module, page_url)), ' - ',
+        tags.code(epydoc2stan.taglink(module, page_url, label=module.name)), ' - ',
         epydoc2stan.format_summary(module)
         )
     if module.isPrivate:

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -390,7 +390,7 @@ def test_func_raise_linked() -> None:
         """
     ''', modname='test')
     html = docstring2html(mod.contents['f']).split('\n')
-    assert '<a href="test.SpanishInquisition.html">SpanishInquisition</a>' in html
+    assert '<a href="test.SpanishInquisition.html" title="test.SpanishInquisition">SpanishInquisition</a>' in html
 
 
 def test_func_raise_missing_exception_type(capsys: CapSys) -> None:
@@ -1158,7 +1158,7 @@ def test_constant_values_rst(capsys: CapSys) -> None:
     expected = ('<table class="valueTable"><tr class="fieldStart">'
                 '<td class="fieldName">Value</td></tr><tr><td>'
                 '<pre class="constant-value"><code>(<wbr></wbr>'
-                '<a href="pack.mod1.html#f">f</a>)</code></pre></td></tr></table>')
+                '<a href="pack.mod1.html#f" title="pack.mod1.f">f</a>)</code></pre></td></tr></table>')
     
     attr = mod.contents['CONST']
     assert isinstance(attr, model.Attribute)


### PR DESCRIPTION
| before | after |
|--|--|
|![image](https://user-images.githubusercontent.com/73739153/152670995-d9c46638-b1fe-49bb-885e-819e5bef89df.png) | ![image](https://user-images.githubusercontent.com/73739153/152671002-7a79cf9d-66c9-4c75-9725-dbe99970949e.png)

I think it makes the index more readable (especially for modules deeper down the hierarchy).