### PR TITLE
Fix random module processing order

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ in development
 ^^^^^^^^^^^^^^
 * Smarter line wrapping in summary and parameters tables.
 * Any code inside of ``if __name__ == '__main__'`` is now excluded from the documentation.
+* Fixed that modules were processed in a random order leading to several hard to reproduce bugs.
 * Fix introspection of functions comming from C-extensions.
 
 pydoctor 21.12.1

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -596,7 +596,7 @@ class System:
         self.verboselevel = 0
         self.needsnl = False
         self.once_msgs: Set[Tuple[str, str]] = set()
-        self.unprocessed_modules: Set[Module] = set()
+        self.unprocessed_modules: List[Module] = []
         self.module_count = 0
         self.processing_modules: List[str] = []
         self.buildtime = datetime.datetime.now()
@@ -789,7 +789,7 @@ class System:
         self.progress(
             "analyzeModule", len(self.allobjects),
             None, "modules and packages discovered")
-        self.unprocessed_modules.add(mod)
+        self.unprocessed_modules.append(mod)
         self.module_count += 1
         self.setSourceHref(mod, modpath)
         return mod

--- a/pydoctor/test/test_cyclic_imports_base_classes.py
+++ b/pydoctor/test/test_cyclic_imports_base_classes.py
@@ -1,0 +1,39 @@
+"""
+This test case is in its own file because it requires the
+PYTHONHASHSEED=0 environment variable. See issue #482.
+"""
+
+import os
+import subprocess
+import sys
+
+def test_cyclic_imports_base_classes() -> None:
+    if sys.platform == 'win32':
+        # Running this script with the following subprocess call fails on Windows
+        # with an ImportError that isn't actually related to what we want to test.
+        # So we just skip for Windows.
+        return
+
+    process = subprocess.Popen(
+        [sys.executable, os.path.basename(__file__)],
+        env={'PYTHONHASHSEED': '0'},
+        cwd=os.path.dirname(__file__),
+    )
+    assert process.wait() == 0
+
+
+if __name__ == '__main__':
+    from test_packages import processPackage, model # type: ignore
+
+    assert os.environ['PYTHONHASHSEED'] == '0'
+
+    def consistent_hash(self: model.Module) -> int:
+        return hash(self.name)
+
+    if model.Module.__hash__ == object.__hash__:
+        model.Module.__hash__ = consistent_hash
+
+    system = processPackage('cyclic_imports_base_classes')
+    b_cls = system.allobjects['cyclic_imports_base_classes.b.B']
+    assert isinstance(b_cls, model.Class)
+    assert b_cls.baseobjects == [system.allobjects['cyclic_imports_base_classes.a.A']]

--- a/pydoctor/test/testpackages/cyclic_imports_base_classes/__init__.py
+++ b/pydoctor/test/testpackages/cyclic_imports_base_classes/__init__.py
@@ -1,0 +1,1 @@
+from . import b

--- a/pydoctor/test/testpackages/cyclic_imports_base_classes/a.py
+++ b/pydoctor/test/testpackages/cyclic_imports_base_classes/a.py
@@ -1,0 +1,4 @@
+from . import x
+
+class A(object):
+    pass

--- a/pydoctor/test/testpackages/cyclic_imports_base_classes/b.py
+++ b/pydoctor/test/testpackages/cyclic_imports_base_classes/b.py
@@ -1,0 +1,4 @@
+from . import a
+
+class B(a.A):
+    pass


### PR DESCRIPTION
Previously modules to be processed were stored in a set.
A set however is an unordered collection (and adding items
can completely change the order depending on the object hash).

Since the Module class did not implement `__hash__` every time
there was more than one module to be processed the order
in which they were processed was effectively random leading
to very hard to reproduce bugs.

Fixes #482 and fixes #429.