### PR TITLE
Add .gitattributes to classify bootstrap.min.css as binary

### DIFF
--- a/pydoctor/themes/classic/.gitattributes
+++ b/pydoctor/themes/classic/.gitattributes
@@ -1,0 +1,1 @@
+bootstrap.min.css binary


### PR DESCRIPTION
Stops bootstrap.min.css from polluting git grep results.

E.g. `git grep table`.