### PR TITLE
If there is just a single root module, document it in index.html

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,7 @@ in development
 * Any code inside of ``if __name__ == '__main__'`` is now excluded from the documentation.
 * Fix variables named like the current module not being documented.
 * The Module Index now only shows module names instead of their full name. You can hover over a module link to see the full name.
+* If there is only a single root module, `index.html` now documents that module (previously it only linked the module page).
 * Fix introspection of functions comming from C-extensions.
 
 pydoctor 21.12.1

--- a/docs/tests/test.py
+++ b/docs/tests/test.py
@@ -89,29 +89,6 @@ def test_sphinx_object_inventory_version_epytext_demo():
             ), page
 
 
-def test_index_contains_infos():
-    """
-    Test if index.html contains the following informations:
-
-        - meta generator tag
-        - nav and links to modules, classes, names
-        - link to the root package
-        - pydoctor github link in the footer
-    """
-
-    infos = (f'<meta name="generator" content="pydoctor {__version__}"',
-              '<nav class="navbar navbar-default"',
-              '<a href="moduleIndex.html"',
-              '<a href="classIndex.html"',
-              '<a href="nameIndex.html"',
-              'Start at <code><a href="pydoctor.html" class="internal-link">pydoctor</a></code>, the root package.',
-              '<a href="https://github.com/twisted/pydoctor/">pydoctor</a>',)
-
-    with open(BASE_DIR / 'api' / 'index.html', 'r', encoding='utf-8') as stream:
-        page = stream.read()
-        for i in infos:
-            assert i in page, page
-
 def test_page_contains_infos():
     """
     Test if pydoctor.driver.html contains the following informations:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -206,6 +206,10 @@ class Documentable:
     def url(self) -> str:
         """Relative URL at which the documentation for this Documentable
         can be found.
+
+        For page objects this method MUST return an C{.html} filename without a
+        URI fragment (because L{pydoctor.templatewriter.writer.TemplateWriter}
+        uses it directly to determine the output filename).
         """
         page_obj = self.page_object
         if list(self.system.root_names) == [page_obj.fullName()]:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -208,7 +208,10 @@ class Documentable:
         can be found.
         """
         page_obj = self.page_object
-        page_url = f'{quote(page_obj.fullName())}.html'
+        if list(self.system.root_names) == [page_obj.fullName()]:
+            page_url = 'index.html'
+        else:
+            page_url = f'{quote(page_obj.fullName())}.html'
         if page_obj is self:
             return page_url
         else:

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -277,23 +277,6 @@ class IndexPage(Page):
         return f"API Documentation for {self.system.projectname}"
 
     @renderer
-    def onlyIfOneRoot(self, request: object, tag: Tag) -> "Flattenable":
-        if len(self.system.rootobjects) != 1:
-            return []
-        else:
-            root, = self.system.rootobjects
-            return tag.clear()(
-                "Start at ", tags.code(epydoc2stan.taglink(root, self.filename)),
-                ", the root ", epydoc2stan.format_kind(root.kind).lower(), ".")
-
-    @renderer
-    def onlyIfMultipleRoots(self, request: object, tag: Tag) -> "Flattenable":
-        if len(self.system.rootobjects) == 1:
-            return []
-        else:
-            return tag
-
-    @renderer
     def roots(self, request: object, tag: Tag) -> "Flattenable":
         r = []
         for o in self.system.rootobjects:

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -334,8 +334,9 @@ def summaryPages(system: model.System) -> Iterable[Type[Page]]:
     pages = [
         ModuleIndexPage,
         ClassIndexPage,
-        IndexPage,
         NameIndexPage,
         UndocumentedSummaryPage,
     ]
+    if len(system.root_names) > 1:
+        pages.append(IndexPage)
     return pages

--- a/pydoctor/templatewriter/summary.py
+++ b/pydoctor/templatewriter/summary.py
@@ -14,7 +14,6 @@ from pydoctor.templatewriter.pages import Page
 
 if TYPE_CHECKING:
     from twisted.web.template import Flattenable
-    from typing_extensions import Final
 
 
 def moduleSummary(module: model.Module, page_url: str) -> Tag:
@@ -348,10 +347,12 @@ class UndocumentedSummaryPage(Page):
                 ))
         return tag
 
-summarypages: 'Final[Iterable[Type[Page]]]' = [
-    ModuleIndexPage,
-    ClassIndexPage,
-    IndexPage,
-    NameIndexPage,
-    UndocumentedSummaryPage,
+def summaryPages(system: model.System) -> Iterable[Type[Page]]:
+    pages = [
+        ModuleIndexPage,
+        ClassIndexPage,
+        IndexPage,
+        NameIndexPage,
+        UndocumentedSummaryPage,
     ]
+    return pages

--- a/pydoctor/templatewriter/writer.py
+++ b/pydoctor/templatewriter/writer.py
@@ -90,6 +90,18 @@ class TemplateWriter(IWriter):
                 flattenToFile(fobj, page)
             system.msg('html', "took %fs"%(time.time() - T), wantsnl=False)
 
+        if len(system.root_names) == 1:
+            # If there is just a single root module it is written to index.html to produce nicer URLs.
+            # To not break old links we also create a symlink from the full module name to the index.html
+            # file. This is also good for consistency: every module is accessible by <full module name>.html
+            root_module_path = (self.build_directory / (list(system.root_names)[0] + '.html'))
+            try:
+                root_module_path.unlink()
+                # not using missing_ok=True because that was only added in Python 3.8 and we still support Python 3.6
+            except FileNotFoundError:
+                pass
+            root_module_path.symlink_to('index.html')
+
     def _writeDocsFor(self, ob: model.Documentable) -> None:
         if not ob.isVisible:
             return
@@ -97,7 +109,7 @@ class TemplateWriter(IWriter):
             if self.dry_run:
                 self.total_pages += 1
             else:
-                with self.build_directory.joinpath(f'{ob.fullName()}.html').open('wb') as fobj:
+                with self.build_directory.joinpath(ob.url.split('#')[0]).open('wb') as fobj:
                     self._writeDocsForOne(ob, fobj)
         for o in ob.contents.values():
             self._writeDocsFor(o)

--- a/pydoctor/templatewriter/writer.py
+++ b/pydoctor/templatewriter/writer.py
@@ -109,7 +109,7 @@ class TemplateWriter(IWriter):
             if self.dry_run:
                 self.total_pages += 1
             else:
-                with self.build_directory.joinpath(ob.url.split('#')[0]).open('wb') as fobj:
+                with self.build_directory.joinpath(ob.url).open('wb') as fobj:
                     self._writeDocsForOne(ob, fobj)
         for o in ob.contents.values():
             self._writeDocsFor(o)

--- a/pydoctor/templatewriter/writer.py
+++ b/pydoctor/templatewriter/writer.py
@@ -82,7 +82,7 @@ class TemplateWriter(IWriter):
 
     def writeSummaryPages(self, system: model.System) -> None:
         import time
-        for pclass in summary.summarypages:
+        for pclass in summary.summaryPages(system):
             system.msg('html', 'starting ' + pclass.__name__ + ' ...', nonl=True)
             T = time.time()
             page = pclass(system=system, template_lookup=self.template_lookup)

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -88,8 +88,10 @@ def inv_writer_nolog() -> sphinx.SphinxInventoryWriter:
         project_version='2.3.0',
         )
 
+class IgnoreSystem:
+    root_names = ()
 
-IGNORE_SYSTEM = cast(model.System, 'ignore-system')
+IGNORE_SYSTEM = cast(model.System, IgnoreSystem())
 """Passed as a System when we don't want the system to be accessed."""
 
 

--- a/pydoctor/themes/base/index.html
+++ b/pydoctor/themes/base/index.html
@@ -29,20 +29,15 @@
           A listing of <a href="nameIndex.html">all functions, classes,
           modules and packages</a>, ordered by name.
         </li>
-        <li t:render="onlyIfOneRoot">
-          Start at <a href="root.html">root</a>, the root package.
+        <li>
+          Or start at one of the root <t:transparent t:render="rootkind">
+          packages</t:transparent>:
+          <ul>
+            <li t:render="roots">
+              <t:slot name="root"/>
+            </li>
+          </ul>
         </li>
-        <t:transparent t:render="onlyIfMultipleRoots">
-          <li>
-            Or start at one of the root <t:transparent t:render="rootkind">
-            packages</t:transparent>:
-            <ul>
-              <li t:render="roots">
-                <t:slot name="root"/>
-              </li>
-            </ul>
-          </li>
-        </t:transparent>
       </ul>
     </div>
 


### PR DESCRIPTION
I think most of the time `pydoctor` is just invoked with a single module. In that case it's nicer if `index.html` immediately shows the module documentation instead of just a page linking the module.