### PR TITLE
Bugfix the colorizer string escape function

### DIFF
--- a/.github/workflows/system.yaml
+++ b/.github/workflows/system.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        tox_target: [twisted-apidoc, cpython-summary, cpython-apidocs]
+        tox_target: [twisted-apidoc, cpython-summary]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/system.yaml
+++ b/.github/workflows/system.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        tox_target: [twisted-apidoc, cpython-summary]
+        tox_target: [twisted-apidoc, cpython-summary, cpython-apidocs]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ in development
 * The Module Index now only shows module names instead of their full name. You can hover over a module link to see the full name.
 * If there is only a single root module, `index.html` now documents that module (previously it only linked the module page).
 * Fix introspection of functions comming from C-extensions.
+* Fix colorizer string escape function crashing with surrogates unicode strings.
 
 pydoctor 21.12.1
 ^^^^^^^^^^^^^^^^

--- a/pydoctor/epydoc/markup/_pyval_repr.py
+++ b/pydoctor/epydoc/markup/_pyval_repr.py
@@ -236,7 +236,19 @@ def _str_escape(s: str) -> str:
         elif c == "\\": 
             c = r'\\'
         return c
-    return ''.join(map(enc, s))
+
+    # Escape it
+    s = ''.join(map(enc, s))
+
+    # Ensures there is no funcky caracters (like surrogate unicode strings)
+    try:
+        s.encode('utf-8')
+    except UnicodeEncodeError:
+        # Otherwise replace them with backslashreplace
+        s = s.encode('utf-8', 'backslashreplace').decode('utf-8')
+    
+    return s
+
 def _bytes_escape(b: bytes) -> str:
     return repr(b)[2:-1]
 

--- a/pydoctor/test/epydoc/test_pyval_repr.py
+++ b/pydoctor/test/epydoc/test_pyval_repr.py
@@ -1438,23 +1438,23 @@ def color2(v: Any) -> str:
     """
     colorizer = PyvalColorizer(linelen=50, maxlines=5)
     colorized = colorizer.colorize(v)
-    text = ''.join(gettext(colorized.to_node()))
-    return text
-
-def color3(v:Any) -> str:
-    """
-    HTML colorize.
-    """
-    colorizer = PyvalColorizer(linelen=50, maxlines=5)
-    colorized = colorizer.colorize(v)
-    return flatten(colorized.to_stan(NotFoundLinker()))
+    text1 = ''.join(gettext(colorized.to_node()))
+    text2 = flatten_text(html2stan(flatten(colorized.to_stan(NotFoundLinker()))))
+    assert text1 == text2
+    return text2
 
 
 def test_crash_surrogates_not_allowed() -> None:
     """
     Test that the colorizer does not make the flatten function crash when passing surrogates unicode strings.
     """
-    assert flatten_text(html2stan(color3('surrogates:\udc80\udcff'))) == "'surrogates:\\udc80\\udcff'"
+    assert color2('surrogates:\udc80\udcff') == "'surrogates:\\udc80\\udcff'"
+
+def test_surrogates_cars_in_re() -> None:
+    """
+    Regex string are escaped their own way. See https://github.com/twisted/pydoctor/pull/493
+    """
+    assert color2(extract_expr(ast.parse("re.compile('surrogates:\\udc80\\udcff')"))) == "re.compile(r'surrogates:\\udc80\\udcff')"
 
 def test_repr_text() -> None:
     """Test a few representations, with a plain text version.

--- a/pydoctor/test/epydoc/test_pyval_repr.py
+++ b/pydoctor/test/epydoc/test_pyval_repr.py
@@ -5,7 +5,7 @@ from typing import Any, Union
 
 from pydoctor.epydoc.markup._pyval_repr import PyvalColorizer
 from pydoctor.test import NotFoundLinker
-from pydoctor.stanutils import flatten
+from pydoctor.stanutils import flatten, flatten_text, html2stan
 from pydoctor.node2stan import gettext
 
 def color(v: Any, linebreakok:bool=True, maxlines:int=5, linelen:int=40) -> str:
@@ -1433,10 +1433,28 @@ def test_line_wrapping() -> None:
         ...\n"""
 
 def color2(v: Any) -> str:
+    """
+    Pain text colorize.
+    """
     colorizer = PyvalColorizer(linelen=50, maxlines=5)
     colorized = colorizer.colorize(v)
     text = ''.join(gettext(colorized.to_node()))
     return text
+
+def color3(v:Any) -> str:
+    """
+    HTML colorize.
+    """
+    colorizer = PyvalColorizer(linelen=50, maxlines=5)
+    colorized = colorizer.colorize(v)
+    return flatten(colorized.to_stan(NotFoundLinker()))
+
+
+def test_crash_surrogates_not_allowed() -> None:
+    """
+    Test that the colorizer does not make the flatten function crash when passing surrogates unicode strings.
+    """
+    assert flatten_text(html2stan(color3('surrogates:\udc80\udcff'))) == "'surrogates:\\udc80\\udcff'"
 
 def test_repr_text() -> None:
     """Test a few representations, with a plain text version.


### PR DESCRIPTION
Pydoctor 21.12.1 crashes when building the python standard library docs because of a `UnicodeEncodeError` :/ 

My bad. Thanks @not-my-profile for the report.  
