### PR TITLE
Resolve name check super class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ What's New?
 
 in development
 ^^^^^^^^^^^^^^
+* Improve the name resolving algo such that it checks in super classes for inherited attributes.
 * C-modules wins over regular modules when there is a name clash.
 * Packages wins over modules when there is a name clash.
 * Fixed that modules were processed in a random order leading to several hard to reproduce bugs.

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -299,10 +299,17 @@ class Documentable:
             full_name = obj._localNameToFullName(p)
             if full_name == p and i != 0:
                 # The local name was not found.
-                # TODO: Instead of returning the input, _localNameToFullName()
-                #       should probably either return None or raise LookupError.
-                full_name = f'{obj.fullName()}.{p}'
-                break
+                # If we're looking at a class, we try our luck with the inherited members
+                if isinstance(obj, Class):
+                    inherited = obj.find(p)
+                    if inherited: 
+                        full_name = inherited.fullName()
+                if full_name == p:
+                    # We don't have a full name
+                    # TODO: Instead of returning the input, _localNameToFullName()
+                    #       should probably either return None or raise LookupError.
+                    full_name = f'{obj.fullName()}.{p}'
+                    break
             nxt = self.system.objForFullName(full_name)
             if nxt is None:
                 break

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -347,3 +347,14 @@ def test_c_module_python_module_name_clash(capsys:CapSys) -> None:
     finally:
         # cleanup
         subprocess.getoutput(f'rm -f {package_path}/*.so')
+
+def test_resolve_name_subclass(capsys:CapSys) -> None:
+    m = fromText(
+        """
+        class B:
+            v=1
+        class C(B):
+            pass
+        """
+    )
+    assert m.resolveName('C.v') == m.contents['B'].contents['v']

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -349,6 +349,9 @@ def test_c_module_python_module_name_clash(capsys:CapSys) -> None:
         subprocess.getoutput(f'rm -f {package_path}/*.so')
 
 def test_resolve_name_subclass(capsys:CapSys) -> None:
+    """
+    C{Model.resolveName} knows about single inheritance.
+    """
     m = fromText(
         """
         class B:


### PR DESCRIPTION
This PR solves the same issue as #380, but it adds the feature inside the `expandName` logic, which is to me, the right place. 