### PR TITLE
Release pydoctor 22.2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,8 +70,8 @@ You can select a different format using the ``--docformat`` option or the ``__do
 What's New?
 ~~~~~~~~~~~
 
-in development
-^^^^^^^^^^^^^^
+pydoctor 22.2.0
+^^^^^^^^^^^^^^^
 * Improve the name resolving algo such that it checks in super classes for inherited attributes.
 * C-modules wins over regular modules when there is a name clash.
 * Packages wins over modules when there is a name clash.

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,9 @@ You can select a different format using the ``--docformat`` option or the ``__do
 What's New?
 ~~~~~~~~~~~
 
+in development
+^^^^^^^^^^^^^^ 
+
 pydoctor 22.2.0
 ^^^^^^^^^^^^^^^
 * Improve the name resolving algo such that it checks in super classes for inherited attributes.

--- a/pydoctor/themes/base/index.html
+++ b/pydoctor/themes/base/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
-  <meta name="pydoctor-template-version" content="1" />
+  <meta name="pydoctor-template-version" content="2" />
 
   <t:transparent t:render="head">Head</t:transparent>
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoctor
-version = 22.2.0
+version = 22.2.0.dev0
 author = Michael Hudson-Doyle
 author_email = micahel@gmail.com
 maintainer = Maarten ter Huurne

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoctor
-version = 21.12.1.dev0
+version = 22.2.0
 author = Michael Hudson-Doyle
 author_email = micahel@gmail.com
 maintainer = Maarten ter Huurne


### PR DESCRIPTION
I think it's time for a new release. 

Now, we can safely advertise that we support introspection of c-extensions. 