### PR TITLE
Release pydoctor 22.3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,8 +70,8 @@ You can select a different format using the ``--docformat`` option or the ``__do
 What's New?
 ~~~~~~~~~~~
 
-in development
-^^^^^^^^^^^^^^
+pydoctor 22.3.0
+^^^^^^^^^^^^^^^
 * Add client side search system based on lunr.js.
 * Fix broken links in docstring summaries.
 * Add cache for the xref linker, reduces the number of identical warnings.

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,9 @@ You can select a different format using the ``--docformat`` option or the ``__do
 What's New?
 ~~~~~~~~~~~
 
+in development
+^^^^^^^^^^^^^^
+
 pydoctor 22.3.0
 ^^^^^^^^^^^^^^^
 * Add client side search system based on lunr.js.

--- a/pydoctor/themes/base/head.html
+++ b/pydoctor/themes/base/head.html
@@ -1,5 +1,5 @@
 <head xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
-    <meta name="pydoctor-template-version" content="1" />
+    <meta name="pydoctor-template-version" content="2" />
     <title><t:transparent t:render="title">
         The title of Something
     </t:transparent></title>

--- a/pydoctor/themes/classic/head.html
+++ b/pydoctor/themes/classic/head.html
@@ -1,5 +1,5 @@
 <head xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
-    <meta name="pydoctor-template-version" content="1" />
+    <meta name="pydoctor-template-version" content="2" />
     <title><t:transparent t:render="title">
         The title of Something
     </t:transparent></title>
@@ -7,7 +7,7 @@
         <t:attr name="content">pydoctor <t:slot name="pydoctor_version" /></t:attr>
     </meta>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=0.75" />
+    <meta name="viewport" content="width=device-width, initial-scale=1 maximum-scale=1" />
     <link rel="stylesheet" type="text/css" href="bootstrap.min.css" />
     <link rel="stylesheet" type="text/css" href="apidocs.css" />
     <link rel="stylesheet" type="text/css" href="extra.css" />

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoctor
-version = 22.3.0
+version = 22.3.0.dev0
 author = Michael Hudson-Doyle
 author_email = micahel@gmail.com
 maintainer = Maarten ter Huurne

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pydoctor
-version = 22.2.2.dev0
+version = 22.3.0
 author = Michael Hudson-Doyle
 author_email = micahel@gmail.com
 maintainer = Maarten ter Huurne


### PR DESCRIPTION
Alongside minor change: Update head.html classic theme template to use the same viewport.