### PR TITLE
Cache summaries in new documenable attribute

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ in development
 * Option ``--docformat=plaintext`` overrides any assignments to ``__docformat__`` 
   module variable in order to focus on potential python code parsing errors.
 * Switch to ``configargparse`` to handle argument and configuration file parsing (`more infos <https://pydoctor.readthedocs.io/en/latest/help.html>`_).
+* Improved performances with caching of docstring summaries.
 
 pydoctor 22.3.0
 ^^^^^^^^^^^^^^^

--- a/docs/tests/test.py
+++ b/docs/tests/test.py
@@ -186,7 +186,7 @@ def test_lunr_index() -> None:
                     'pydoctor.epydoc.markup.plaintext.ParsedPlaintextDocstring.to_stan',
                     'pydoctor.epydoc.markup._types.ParsedTypeDocstring.to_stan',
                     'pydoctor.epydoc.markup._pyval_repr.ColorizedPyvalRepr.to_stan',
-                    'pydoctor.epydoc2stan._ParsedDocFromStan.to_stan'
+                    'pydoctor.epydoc2stan._ParsedStanOnly.to_stan'
                 ]
         test_search('to_stan*', to_stan_results, order_is_important=False)
         test_search('to_stan', to_stan_results, order_is_important=False)
@@ -197,7 +197,7 @@ def test_lunr_index() -> None:
                     'pydoctor.epydoc.markup._types.ParsedTypeDocstring.to_node',
                     'pydoctor.epydoc.markup.restructuredtext.ParsedRstDocstring.to_node',
                     'pydoctor.epydoc.markup.epytext.ParsedEpytextDocstring.to_node',
-                    'pydoctor.epydoc2stan._ParsedDocFromStan.to_node'
+                    'pydoctor.epydoc2stan._ParsedStanOnly.to_node'
                 ]
         test_search('to_node*', to_node_results, order_is_important=False)
         test_search('to_node', to_node_results, order_is_important=False)

--- a/docs/tests/test.py
+++ b/docs/tests/test.py
@@ -186,6 +186,7 @@ def test_lunr_index() -> None:
                     'pydoctor.epydoc.markup.plaintext.ParsedPlaintextDocstring.to_stan',
                     'pydoctor.epydoc.markup._types.ParsedTypeDocstring.to_stan',
                     'pydoctor.epydoc.markup._pyval_repr.ColorizedPyvalRepr.to_stan',
+                    'pydoctor.stanutils._ParsedDocFromStan.to_stan'
                 ]
         test_search('to_stan*', to_stan_results, order_is_important=False)
         test_search('to_stan', to_stan_results, order_is_important=False)
@@ -196,6 +197,7 @@ def test_lunr_index() -> None:
                     'pydoctor.epydoc.markup._types.ParsedTypeDocstring.to_node',
                     'pydoctor.epydoc.markup.restructuredtext.ParsedRstDocstring.to_node',
                     'pydoctor.epydoc.markup.epytext.ParsedEpytextDocstring.to_node',
+                    'pydoctor.stanutils._ParsedDocFromStan.to_node'
                 ]
         test_search('to_node*', to_node_results, order_is_important=False)
         test_search('to_node', to_node_results, order_is_important=False)

--- a/docs/tests/test.py
+++ b/docs/tests/test.py
@@ -186,7 +186,7 @@ def test_lunr_index() -> None:
                     'pydoctor.epydoc.markup.plaintext.ParsedPlaintextDocstring.to_stan',
                     'pydoctor.epydoc.markup._types.ParsedTypeDocstring.to_stan',
                     'pydoctor.epydoc.markup._pyval_repr.ColorizedPyvalRepr.to_stan',
-                    'pydoctor.stanutils._ParsedDocFromStan.to_stan'
+                    'pydoctor.epydoc2stan._ParsedDocFromStan.to_stan'
                 ]
         test_search('to_stan*', to_stan_results, order_is_important=False)
         test_search('to_stan', to_stan_results, order_is_important=False)
@@ -197,7 +197,7 @@ def test_lunr_index() -> None:
                     'pydoctor.epydoc.markup._types.ParsedTypeDocstring.to_node',
                     'pydoctor.epydoc.markup.restructuredtext.ParsedRstDocstring.to_node',
                     'pydoctor.epydoc.markup.epytext.ParsedEpytextDocstring.to_node',
-                    'pydoctor.stanutils._ParsedDocFromStan.to_node'
+                    'pydoctor.epydoc2stan._ParsedDocFromStan.to_node'
                 ]
         test_search('to_node*', to_node_results, order_is_important=False)
         test_search('to_node', to_node_results, order_is_important=False)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -4,7 +4,7 @@ Convert L{pydoctor.epydoc} parsed markup into renderable content.
 
 from collections import defaultdict
 from typing import (
-    TYPE_CHECKING, Callable, ClassVar, DefaultDict, Dict, Generator, Iterable,
+    TYPE_CHECKING, Any, Callable, ClassVar, DefaultDict, Dict, Generator, Iterable,
     Iterator, List, Mapping, Optional, Sequence, Set, Tuple, Union, cast
 )
 import ast
@@ -18,7 +18,6 @@ from pydoctor.epydoc.markup import Field as EpydocField, ParseError, get_parser_
 from twisted.web.template import Tag, tags
 from pydoctor.epydoc.markup import DocstringLinker, ParsedDocstring
 import pydoctor.epydoc.markup.plaintext
-from pydoctor.stanutils import parsed_doc_from_stan
 from pydoctor.epydoc.markup._pyval_repr import colorize_pyval, colorize_inline_pyval
 
 if TYPE_CHECKING:
@@ -976,6 +975,20 @@ def ensure_parsed_docstring(obj: model.Documentable) -> Optional[model.Documenta
     else:
         return None
 
+
+class _ParsedDocFromStan(ParsedDocstring):
+    def __init__(self, stan: Tag):
+        super().__init__(fields=[])
+        self._fromstan = stan
+    def has_body(self) -> bool:
+        return True
+    def to_stan(self, docstring_linker: Any) -> Tag:
+        return self._fromstan
+    def to_node(self) -> Any:
+        raise NotImplementedError()
+
+def parsed_doc_from_stan(stan: Tag) -> 'ParsedDocstring':
+    return _ParsedDocFromStan(stan)
 
 def ensure_parsed_summary(obj: model.Documentable) -> Tuple[Optional[model.Documentable], ParsedDocstring]:
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -977,6 +977,11 @@ def ensure_parsed_docstring(obj: model.Documentable) -> Optional[model.Documenta
 
 
 class _ParsedDocFromStan(ParsedDocstring):
+    """
+    A dummy L{ParsedDocstring}. 
+    
+    L{to_stan} method simply returns back what's given to L{_ParsedDocFromStan.__init__}. 
+    """
     def __init__(self, stan: Tag):
         super().__init__(fields=[])
         self._fromstan = stan
@@ -997,6 +1002,8 @@ def ensure_parsed_summary(obj: model.Documentable) -> Tuple[Optional[model.Docum
     """
     Ensures that the C{parsed_summary} attribute of a documentable is set to it's final value. 
     Do not generate summary twice.
+    
+    @returns: Tuple: C{source}, C{parsed docstring}
     """
 
     doc, source = get_docstring(obj)

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -978,7 +978,7 @@ def ensure_parsed_docstring(obj: model.Documentable) -> Optional[model.Documenta
 
 class _ParsedStanOnly(ParsedDocstring):
     """
-    A L{ParsedDocstring} that only contains cached stan. 
+    A L{ParsedDocstring} directly constructed from stan, for caching purposes.
     
     L{to_stan} method simply returns back what's given to L{_ParsedStanOnly.__init__}. 
     """
@@ -991,12 +991,6 @@ class _ParsedStanOnly(ParsedDocstring):
         return self._fromstan
     def to_node(self) -> Any:
         raise NotImplementedError()
-
-def _cache_parsed_stan(stan: Tag) -> 'ParsedDocstring':
-    """
-    Encapsulate the given L{Tag} into a L{ParsedDocstring}.
-    """
-    return _ParsedStanOnly(stan)
 
 def _get_parsed_summary(obj: model.Documentable) -> Tuple[Optional[model.Documentable], ParsedDocstring]:
     """
@@ -1023,7 +1017,7 @@ def _get_parsed_summary(obj: model.Documentable) -> Tuple[Optional[model.Documen
         source = obj.parent
         assert source is not None
     elif doc is None:
-        parsed_doc = _cache_parsed_stan(format_undocumented(obj))
+        parsed_doc = _ParsedStanOnly(format_undocumented(obj))
     else:
         # Tell mypy that if we found a docstring, we also have its source.
         assert source is not None
@@ -1036,7 +1030,7 @@ def _get_parsed_summary(obj: model.Documentable) -> Tuple[Optional[model.Documen
                 )
             ]
         if len(lines) > 3:
-            parsed_doc = _cache_parsed_stan(tags.span(class_='undocumented')("No summary"))
+            parsed_doc = _ParsedStanOnly(tags.span(class_='undocumented')("No summary"))
         else:
             parsed_doc = parse_docstring(obj, ' '.join(lines), source)
     
@@ -1103,7 +1097,7 @@ def format_summary(obj: model.Documentable) -> Tag:
         # This problem will likely be reported by the full docstring as well,
         # so don't spam the log.
         stan = tags.span(class_='undocumented')("Broken description")
-        obj.parsed_summary = _cache_parsed_stan(stan)
+        obj.parsed_summary = _ParsedStanOnly(stan)
 
     return stan
 

--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -1000,7 +1000,7 @@ def parsed_doc_from_stan(stan: Tag) -> 'ParsedDocstring':
 
 def ensure_parsed_summary(obj: model.Documentable) -> Tuple[Optional[model.Documentable], ParsedDocstring]:
     """
-    Ensures that the C{parsed_summary} attribute of a documentable is set to it's final value. 
+    Ensures that the L{model.Documentable.parsed_summary} attribute of a documentable is set to it's final value. 
     Do not generate summary twice.
     
     @returns: Tuple: C{source}, C{parsed docstring}

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -119,6 +119,7 @@ class Documentable:
     """
     docstring: Optional[str] = None
     parsed_docstring: Optional[ParsedDocstring] = None
+    parsed_summary: Optional[ParsedDocstring] = None
     parsed_type: Optional[ParsedDocstring] = None
     docstring_lineno = 0
     linenumber = 0

--- a/pydoctor/stanutils.py
+++ b/pydoctor/stanutils.py
@@ -2,7 +2,7 @@
 Utilities related to Stan tree building and HTML flattening.
 """
 import re
-from typing import Any, Union, List, TYPE_CHECKING
+from typing import Union, List, TYPE_CHECKING
 
 from twisted.web.template import Tag, XMLString, flattenString
 from twisted.python.failure import Failure

--- a/pydoctor/stanutils.py
+++ b/pydoctor/stanutils.py
@@ -2,14 +2,13 @@
 Utilities related to Stan tree building and HTML flattening.
 """
 import re
-from typing import Any, Union, List, TYPE_CHECKING, cast
+from typing import Any, Union, List, TYPE_CHECKING
 
 from twisted.web.template import Tag, XMLString, flattenString
 from twisted.python.failure import Failure
 
 if TYPE_CHECKING:
     from twisted.web.template import Flattenable
-    from pydoctor.epydoc.markup import ParsedDocstring
 
 _RE_CONTROL = re.compile((
     '[' + ''.join(

--- a/pydoctor/stanutils.py
+++ b/pydoctor/stanutils.py
@@ -62,16 +62,3 @@ def flatten_text(stan: Union[Tag, str]) -> str:
             if isinstance(child, (Tag, str)):
                 text += flatten_text(child)
     return text
-
-class _ParsedDocFromStan:
-    def __init__(self, stan: Tag):
-        self.fields: List[Any] = []
-        self._stan = stan
-        self.has_body = True
-    def to_stan(self, docstring_linker: Any) -> Tag:
-        return self._stan
-    def to_node(self) -> Any:
-        raise NotImplementedError()
-
-def parsed_doc_from_stan(stan: Tag) -> 'ParsedDocstring':
-    return cast('ParsedDocstring', _ParsedDocFromStan(stan))

--- a/pydoctor/stanutils.py
+++ b/pydoctor/stanutils.py
@@ -2,13 +2,14 @@
 Utilities related to Stan tree building and HTML flattening.
 """
 import re
-from typing import Union, List, TYPE_CHECKING
+from typing import Any, Union, List, TYPE_CHECKING, cast
 
 from twisted.web.template import Tag, XMLString, flattenString
 from twisted.python.failure import Failure
 
 if TYPE_CHECKING:
     from twisted.web.template import Flattenable
+    from pydoctor.epydoc.markup import ParsedDocstring
 
 _RE_CONTROL = re.compile((
     '[' + ''.join(
@@ -61,3 +62,16 @@ def flatten_text(stan: Union[Tag, str]) -> str:
             if isinstance(child, (Tag, str)):
                 text += flatten_text(child)
     return text
+
+class _ParsedDocFromStan:
+    def __init__(self, stan: Tag):
+        self.fields: List[Any] = []
+        self._stan = stan
+        self.has_body = True
+    def to_stan(self, docstring_linker: Any) -> Tag:
+        return self._stan
+    def to_node(self) -> Any:
+        raise NotImplementedError()
+
+def parsed_doc_from_stan(stan: Tag) -> 'ParsedDocstring':
+    return cast('ParsedDocstring', _ParsedDocFromStan(stan))


### PR DESCRIPTION
Fixes #497

- Create `Documentable.parsed_summary` to cache summaries
- Create `stanutils.parsed_doc_from_stan(stan: Tag) -> 'ParsedDocstring'` to work with the code we have the generated stan, and cache it into a parsed docstring.

The performance benefits are quite big: 
- minus one minute of build time for `tox -e twisted-apidoc` (which includes pulling all Twisted code)
- minus 25 seconds for `tox -e numpy-apidoc`
- same for `tox -e python-igraph-apidocs`
- minus 2m for `tox -e cpython-summary`
- minus 3m for `tox -e cpython-apidocs`