### PR TITLE
Always enable pytest verbose

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
 
 commands =
     test: coverage erase
-    test: coverage run -m pytest {posargs:-vv pydoctor}
+    test: coverage run -m pytest -vv {posargs: pydoctor}
     test: coverage report -m
 
     ; Publish coverage data on codecov.io


### PR DESCRIPTION
I'm always editing the `tox.ini` to add the `-vv` flag because it seems it does not work from `tox` CLI. 

<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
