### PR TITLE
 Use tags.wbr instead of zero-width spaces in epydoc2stan.insert_break_points 

### DIFF
--- a/pydoctor/epydoc2stan.py
+++ b/pydoctor/epydoc2stan.py
@@ -1279,15 +1279,27 @@ def _split_indentifier_parts_on_case(indentifier:str) -> List[str]:
 
     return text_parts
 
-# TODO: Use tags.wbr instead of zero-width spaces
-# zero-width spaces can interfer in subtle ways when copy/pasting a name.
 def insert_break_points(text: str) -> 'Flattenable':
     """
     Browsers aren't smart enough to recognize word breaking opportunities in
     snake_case or camelCase, so this function helps them out by inserting
-    zero-width spaces.
+    word break opportunities.
+
+    :note: It support full dotted names and will add a wbr tag after each dot.
     """
-    return '\u200b.'.join(
-                '\u200b'.join(
-                    _split_indentifier_parts_on_case(t)) 
-                        for t in text.split('.'))
+
+    # We use tags.wbr instead of zero-width spaces because
+    # zero-width spaces can interfer in subtle ways when copy/pasting a name.
+    
+    r: List['Flattenable'] = []
+    parts = text.split('.')
+    for i,t in enumerate(parts):
+        _parts = _split_indentifier_parts_on_case(t)
+        for i_,p in enumerate(_parts):
+            r += [p]
+            if i_ != len(_parts)-1:
+                r += [tags.wbr()]
+        if i != len(parts)-1:
+            r += [tags.wbr(), '.']
+    return tags.transparent(*r)
+

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -1468,29 +1468,32 @@ def test_yields_field(capsys: CapSys) -> None:
     captured = capsys.readouterr().out
     assert captured == ''
 
+def insert_break_points(t:str) -> str:
+    return flatten(epydoc2stan.insert_break_points(t))
+
 def test_insert_break_points_identity() -> None:
-    assert epydoc2stan.insert_break_points('test') == 'test'
-    assert epydoc2stan.insert_break_points('_test') == '_test'
-    assert epydoc2stan.insert_break_points('_test_') == '_test_'
-    assert epydoc2stan.insert_break_points('') == ''
-    assert epydoc2stan.insert_break_points('____') == '____'
-    assert epydoc2stan.insert_break_points('__test__') == '__test__'
-    assert epydoc2stan.insert_break_points('__someverylongname__') == '__someverylongname__'
-    assert epydoc2stan.insert_break_points('__SOMEVERYLONGNAME__') == '__SOMEVERYLONGNAME__'
+    assert insert_break_points('test') == 'test'
+    assert insert_break_points('_test') == '_test'
+    assert insert_break_points('_test_') == '_test_'
+    assert insert_break_points('') == ''
+    assert insert_break_points('____') == '____'
+    assert insert_break_points('__test__') == '__test__'
+    assert insert_break_points('__someverylongname__') == '__someverylongname__'
+    assert insert_break_points('__SOMEVERYLONGNAME__') == '__SOMEVERYLONGNAME__'
 
 def test_insert_break_points_snake_case() -> None:
-    assert epydoc2stan.insert_break_points('__some_very_long_name__') == '__some\u200b_very\u200b_long\u200b_name__'
-    assert epydoc2stan.insert_break_points('__SOME_VERY_LONG_NAME__') == '__SOME\u200b_VERY\u200b_LONG\u200b_NAME__'
+    assert insert_break_points('__some_very_long_name__') == '__some<wbr></wbr>_very<wbr></wbr>_long<wbr></wbr>_name__'
+    assert insert_break_points('__SOME_VERY_LONG_NAME__') == '__SOME<wbr></wbr>_VERY<wbr></wbr>_LONG<wbr></wbr>_NAME__'
 
 def test_insert_break_points_camel_case() -> None:
-    assert epydoc2stan.insert_break_points('__someVeryLongName__') == '__some\u200bVery\u200bLong\u200bName__'
-    assert epydoc2stan.insert_break_points('__einÜberlangerName__') == '__ein\u200bÜberlanger\u200bName__'
+    assert insert_break_points('__someVeryLongName__') == '__some<wbr></wbr>Very<wbr></wbr>Long<wbr></wbr>Name__'
+    assert insert_break_points('__einÜberlangerName__') == '__ein<wbr></wbr>Überlanger<wbr></wbr>Name__'
 
 def test_insert_break_points_dotted_name() -> None:
-    assert epydoc2stan.insert_break_points('mod.__some_very_long_name__') == 'mod\u200b.__some\u200b_very\u200b_long\u200b_name__'
-    assert epydoc2stan.insert_break_points('_mod.__SOME_VERY_LONG_NAME__') == '_mod\u200b.__SOME\u200b_VERY\u200b_LONG\u200b_NAME__'
-    assert epydoc2stan.insert_break_points('pack.mod.__someVeryLongName__') == 'pack\u200b.mod\u200b.__some\u200bVery\u200bLong\u200bName__'
-    assert epydoc2stan.insert_break_points('pack._mod_.__einÜberlangerName__') == 'pack\u200b._mod_\u200b.__ein\u200bÜberlanger\u200bName__'
+    assert insert_break_points('mod.__some_very_long_name__') == 'mod<wbr></wbr>.__some<wbr></wbr>_very<wbr></wbr>_long<wbr></wbr>_name__'
+    assert insert_break_points('_mod.__SOME_VERY_LONG_NAME__') == '_mod<wbr></wbr>.__SOME<wbr></wbr>_VERY<wbr></wbr>_LONG<wbr></wbr>_NAME__'
+    assert insert_break_points('pack.mod.__someVeryLongName__') == 'pack<wbr></wbr>.mod<wbr></wbr>.__some<wbr></wbr>Very<wbr></wbr>Long<wbr></wbr>Name__'
+    assert insert_break_points('pack._mod_.__einÜberlangerName__') == 'pack<wbr></wbr>._mod_<wbr></wbr>.__ein<wbr></wbr>Überlanger<wbr></wbr>Name__'
 
 def test_stem_identifier() -> None:
     assert list(stem_identifier('__some_very_long_name__')) == [

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -1472,6 +1472,9 @@ def insert_break_points(t:str) -> str:
     return flatten(epydoc2stan.insert_break_points(t))
 
 def test_insert_break_points_identity() -> None:
+    """
+    No break points are introduced for values containing a single world.
+    """
     assert insert_break_points('test') == 'test'
     assert insert_break_points('_test') == '_test'
     assert insert_break_points('_test_') == '_test_'


### PR DESCRIPTION
Fixes #510

<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
