### PR TITLE
Fix tests and refactor tox.ini

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -46,7 +46,7 @@ jobs:
         tox -e test
 
     - name: Run unit tests with latest Twisted version
-      if: matrix.python-version != '3.6'
+      if: matrix.python-version != '3.6' && matrix.python-version != 'pypy-3.6'
       run: |
         tox -e test-latest-twisted
 

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -45,6 +45,11 @@ jobs:
       run: |
         tox -e test
 
+    - name: Run unit tests with latest Twisted version
+      if: matrix.python-version != '3.6'
+      run: |
+        tox -e test-latest-twisted
+
     - name: Publish code coverage
       continue-on-error: true
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,14 @@ docs =
 rst =
     docutils
 
+test = 
+    coverage
+    pytest
+    hypothesis
+    cython-test-exception-raiser==1.0.0
+    bs4
+    Sphinx>=3.5
+
 [options.entry_points]
 console_scripts =
     pydoctor = pydoctor.driver:main

--- a/tox.ini
+++ b/tox.ini
@@ -19,39 +19,43 @@ allowlist_externals =
     touch
 passenv = *
 
+[testenv:test-{py36,py37,py38,py39,py310,pypy3}]
+description = Run tests
+extras =
+    test
+commands = 
+    coverage erase
+    coverage run -m pytest -vv {posargs: pydoctor}
+    coverage report -m
 
+[testenv:test-latest-twisted]
+description = Run tests with latest Twisted version
+deps = 
+    git+https://github.com/twisted/twisted.git
+extras =
+    test
+commands = 
+    pytest -vv {posargs: pydoctor}
+
+[testenv:codecov]
+description = Publish code coverage
 deps =
-    test,test-{py36,py37,py38,py39,pypy3},twisted-apidoc: git+https://github.com/twisted/twisted.git
-
-    test: coverage
-    test: pytest
-    test: docutils
-    test: hypothesis
-    test: cython-test-exception-raiser==1.0.0
-    test: bs4
-    test: Sphinx>=3.5
-
-    codecov: codecov
-
-    twisted-apidoc: pytest
-
-
-commands =
-    test: coverage erase
-    test: coverage run -m pytest -vv {posargs: pydoctor}
-    test: coverage report -m
-
+    codecov
+commands = 
     ; Publish coverage data on codecov.io
-    codecov: coverage xml -o coverage.xml -i
-    codecov: codecov
+    coverage xml -o coverage.xml -i
+    codecov
 
+[testenv:twisted-apidoc]
+deps =
+    pytest
+commands =
     ; Run current version against twisted trunk
-    twisted-apidoc: rm -rf {toxworkdir}/twisted-trunk
-    twisted-apidoc: git clone --depth 1 --branch trunk https://github.com/twisted/twisted.git {toxworkdir}/twisted-trunk
-    twisted-apidoc: /bin/sh -c "{toxworkdir}/twisted-trunk/bin/admin/build-apidocs {toxworkdir}/twisted-trunk/src {toxworkdir}/twisted-apidocs-build > {toxworkdir}/twisted-apidocs.log"
-    twisted-apidoc: /bin/cat {toxworkdir}/twisted-apidocs.log
-    twisted-apidoc: pytest -vv docs/tests/test_twisted_docs.py
-
+    rm -rf {toxworkdir}/twisted-trunk
+    git clone --depth 1 --branch trunk https://github.com/twisted/twisted.git {toxworkdir}/twisted-trunk
+    /bin/sh -c "{toxworkdir}/twisted-trunk/bin/admin/build-apidocs {toxworkdir}/twisted-trunk/src {toxworkdir}/twisted-apidocs-build > {toxworkdir}/twisted-apidocs.log"
+    /bin/cat {toxworkdir}/twisted-apidocs.log
+    pytest -vv docs/tests/test_twisted_docs.py
 
 [testenv:pyflakes]
 description = Run pyflakes over the pydoctor code

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,8 @@ allowlist_externals =
     touch
 passenv = *
 
-[testenv:test-{py36,py37,py38,py39,py310,pypy3}]
-description = Run tests
+[testenv:test]
+description = Run tests and coverage report
 extras =
     test
 commands = 


### PR DESCRIPTION
Refactor ``tox.ini`` to split commands ``test``, ``coverage`` and ``twisted-apidoc`` in 3 sections.

Do not install latest twisted package for testing pydoctor.

This fixes #552 

Place testing requirements inside `setup.cfg` to avoid duplicating data in `tox.ini`.

Test with latest Twisted version in the CI, if we're not running with python3.6.

<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
