### PR TITLE
Support twisted.python.deprecated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ What's New?
 
 in development
 ^^^^^^^^^^^^^^
-* Add support for `twisted.python.deprecated` (this was orinally part of Twisted customizations).
+* Add support for `twisted.python.deprecated` (this was originally part of Twisted's customizations).
 
 pydoctor 22.5.0
 ^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ What's New?
 
 in development
 ^^^^^^^^^^^^^^
+* Add support for `twisted.python.deprecated` (this was orinally part of Twisted customizations).
 
 pydoctor 22.5.0
 ^^^^^^^^^^^^^^^

--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -28,8 +28,8 @@ This is also a constant, but annotated with typing.Final.
 """
 
 @deprecated(Version("demo", "NEXT", 0, 0), replacement=math.prod)
-def demo_product_deprecated(x, y) -> float:
-    return x * y
+def demo_product_deprecated(x, y) -> float: # type: ignore
+    return float(x * y)
 
 def demo_fields_docstring_arguments(m, b):  # type: ignore
     """

--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -5,11 +5,14 @@ Most part of this documentation is using Python type hinting.
 """
 
 from abc import ABC
+import math
 from typing import AnyStr, Dict, Generator, List, Union, TYPE_CHECKING
 from somelib import SomeInterface
 import zope.interface
 import zope.schema
 from typing import Sequence, Optional
+from incremental import Version
+from twisted.python.deprecate import deprecated
 
 if TYPE_CHECKING:
     from typing_extensions import Final
@@ -23,6 +26,10 @@ lang: 'Final[Sequence[str]]' = ['Fr', 'En']
 """
 This is also a constant, but annotated with typing.Final.
 """
+
+@deprecated(Version("demo", "NEXT", 0, 0), replacement=math.prod)
+def demo_product_deprecated(x, y) -> float:
+    return x * y
 
 def demo_fields_docstring_arguments(m, b):  # type: ignore
     """

--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -12,7 +12,7 @@ import zope.interface
 import zope.schema
 from typing import Sequence, Optional
 from incremental import Version
-from twisted.python.deprecate import deprecated
+from twisted.python.deprecate import deprecated, deprecatedProperty
 
 if TYPE_CHECKING:
     from typing_extensions import Final
@@ -117,6 +117,14 @@ class DemoClass(ABC, SomeInterface, _PrivateClass):
     def read_only(self) -> int:
         """
         This is a read-only property.
+        """
+        return 1
+
+    @deprecatedProperty(Version("demo", 1, 3, 0), replacement=read_only)
+    @property
+    def read_only_deprecated(self) -> int:
+        """
+        This is a deprecated read-only property.
         """
         return 1
 

--- a/docs/epytext_demo/demo_epytext_module.py
+++ b/docs/epytext_demo/demo_epytext_module.py
@@ -121,7 +121,6 @@ class DemoClass(ABC, SomeInterface, _PrivateClass):
         return 1
 
     @deprecatedProperty(Version("demo", 1, 3, 0), replacement=read_only)
-    @property
     def read_only_deprecated(self) -> int:
         """
         This is a deprecated read-only property.

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -137,7 +137,6 @@ class DemoClass(ABC, _PrivateClass):
         return 1
 
     @deprecatedProperty(Version("demo", 1, 3, 0), replacement=read_only)
-    @property
     def read_only_deprecated(self) -> int:
         """
         This is a deprecated read-only property.

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -25,8 +25,8 @@ This is also a constant, but annotated with typing.Final.
 """
 
 @deprecated(Version("demo", "NEXT", 0, 0), replacement=math.prod)
-def demo_product_deprecated(x, y) -> float:
-    return x * y
+def demo_product_deprecated(x, y) -> float: # type: ignore
+    return float(x * y)
 
 def demo_fields_docstring_arguments(m, b = 0):  # type: ignore
     """

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -9,7 +9,7 @@ import zope.interface
 import zope.schema
 from typing import Sequence, Optional, AnyStr, Generator, Union, List, Dict, TYPE_CHECKING
 from incremental import Version
-from twisted.python.deprecate import deprecated
+from twisted.python.deprecate import deprecated, deprecatedProperty
 
 if TYPE_CHECKING:
     from typing_extensions import Final
@@ -133,6 +133,14 @@ class DemoClass(ABC, _PrivateClass):
     def read_only(self) -> int:
         """
         This is a read-only property.
+        """
+        return 1
+
+    @deprecatedProperty(Version("demo", 1, 3, 0), replacement=read_only)
+    @property
+    def read_only_deprecated(self) -> int:
+        """
+        This is a deprecated read-only property.
         """
         return 1
 

--- a/docs/restructuredtext_demo/demo_restructuredtext_module.py
+++ b/docs/restructuredtext_demo/demo_restructuredtext_module.py
@@ -4,9 +4,12 @@ This is a module demonstrating reST code documentation features.
 Most part of this documentation is using Python type hinting.
 """
 from abc import ABC
+import math
 import zope.interface
 import zope.schema
-from typing import Sequence, Optional, TYPE_CHECKING
+from typing import Sequence, Optional, AnyStr, Generator, Union, List, Dict, TYPE_CHECKING
+from incremental import Version
+from twisted.python.deprecate import deprecated
 
 if TYPE_CHECKING:
     from typing_extensions import Final
@@ -21,9 +24,9 @@ lang: 'Final[Sequence[str]]' = ['Fr', 'En']
 This is also a constant, but annotated with typing.Final.
 """
 
-
-from typing import AnyStr, Generator, Union, List, Dict
-
+@deprecated(Version("demo", "NEXT", 0, 0), replacement=math.prod)
+def demo_product_deprecated(x, y) -> float:
+    return x * y
 
 def demo_fields_docstring_arguments(m, b = 0):  # type: ignore
     """

--- a/docs/tests/test.py
+++ b/docs/tests/test.py
@@ -186,7 +186,7 @@ def test_lunr_index() -> None:
                     'pydoctor.epydoc.markup.plaintext.ParsedPlaintextDocstring.to_stan',
                     'pydoctor.epydoc.markup._types.ParsedTypeDocstring.to_stan',
                     'pydoctor.epydoc.markup._pyval_repr.ColorizedPyvalRepr.to_stan',
-                    'pydoctor.epydoc2stan._ParsedStanOnly.to_stan'
+                    'pydoctor.epydoc2stan.ParsedStanOnly.to_stan'
                 ]
         test_search('to_stan*', to_stan_results, order_is_important=False)
         test_search('to_stan', to_stan_results, order_is_important=False)
@@ -197,7 +197,7 @@ def test_lunr_index() -> None:
                     'pydoctor.epydoc.markup._types.ParsedTypeDocstring.to_node',
                     'pydoctor.epydoc.markup.restructuredtext.ParsedRstDocstring.to_node',
                     'pydoctor.epydoc.markup.epytext.ParsedEpytextDocstring.to_node',
-                    'pydoctor.epydoc2stan._ParsedStanOnly.to_node'
+                    'pydoctor.epydoc2stan.ParsedStanOnly.to_node'
                 ]
         test_search('to_node*', to_node_results, order_is_important=False)
         test_search('to_node', to_node_results, order_is_important=False)

--- a/mypy.ini
+++ b/mypy.ini
@@ -42,6 +42,9 @@ ignore_missing_imports=True
 [mypy-cython_test_exception_raiser.*]
 ignore_missing_imports=True
 
+[mypy-incremental.*]
+ignore_missing_imports=True
+
 [mypy-lunr.*]
 ignore_missing_imports=True
 

--- a/pydoctor/astutils.py
+++ b/pydoctor/astutils.py
@@ -3,6 +3,7 @@ Various bits of reusable code related to L{ast.AST} node processing.
 """
 
 import sys
+from numbers import Number
 from typing import Optional, List
 from inspect import BoundArguments, Signature
 import ast
@@ -37,12 +38,29 @@ def bind_args(sig: Signature, call: ast.Call) -> BoundArguments:
     return sig.bind(*call.args, **kwargs)
 
 
+
 if sys.version_info[:2] >= (3, 8):
     # Since Python 3.8 "foo" is parsed as ast.Constant.
+    def get_str_value(expr:ast.expr) -> Optional[str]:
+        if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+            return expr.value
+        return None
+    def get_num_value(expr:ast.expr) -> Optional[Number]:
+        if isinstance(expr, ast.Constant) and isinstance(expr.value, Number):
+            return expr.value
+        return None
     def _is_str_constant(expr: ast.expr, s: str) -> bool:
         return isinstance(expr, ast.Constant) and expr.value == s
 else:
     # Before Python 3.8 "foo" was parsed as ast.Str.
+    def get_str_value(expr:ast.expr) -> Optional[str]:
+        if isinstance(expr, ast.Str):
+            return expr.s
+        return None
+    def get_num_value(expr:ast.expr) -> Optional[Number]:
+        if isinstance(expr, ast.Num):
+            return expr.n
+        return None
     def _is_str_constant(expr: ast.expr, s: str) -> bool:
         return isinstance(expr, ast.Str) and expr.s == s
 

--- a/pydoctor/deprecate.py
+++ b/pydoctor/deprecate.py
@@ -1,0 +1,135 @@
+
+# Copyright (c) Twisted Matrix Laboratories.
+# Adjusted from file twisted/python/_pydoctor.py
+
+"""
+Support for L{twisted.python.deprecate}.
+"""
+
+import ast
+import inspect
+from numbers import Number
+from typing import Optional, Sequence, Union, TYPE_CHECKING, cast
+
+from pydoctor import astbuilder, model, zopeinterface, epydoc2stan, astutils
+
+from twisted.python.deprecate import deprecated, _getDeprecationWarningString
+from incremental import Version
+
+if TYPE_CHECKING:
+    import incremental
+
+def getDeprecated(self:model.Documentable, decorators:Sequence[ast.expr]) -> None:
+    """
+    With a list of decorators, and the object it is running on, set the
+    C{_deprecated_info} flag if any of the decorators are a Twisted deprecation
+    decorator.
+    """
+    for a in decorators:
+        if isinstance(a, ast.Call):
+            fn = astbuilder.node2fullname(a.func, self)
+
+            if fn in (
+                "twisted.python.deprecate.deprecated",
+                "twisted.python.deprecate.deprecatedProperty",
+            ):
+                try:
+                    text = deprecatedToUsefulText(self, self.name, a)
+                except Exception as e:
+                    # It's a reference or something that we can't figure out
+                    # from the AST.
+                    self.report(str(e), section='deprecation text')
+                else:
+                    # Add a warning with reStructuredText .. warning:: directive.
+                    parsed_info = epydoc2stan.parse_docstring(self,
+                        ".. warning:: {}".format(text), self, 
+                        markup='restructuredtext', 
+                        section='deprecation text')
+
+                    self.extra_info.append(parsed_info)
+
+
+class ModuleVisitor(zopeinterface.ZopeInterfaceModuleVisitor):
+    def visit_ClassDef(self, node:ast.ClassDef) -> None:
+        """
+        Called when a class definition is visited.
+        """
+        super().visit_ClassDef(node)
+        try:
+            cls = self.builder.current.contents[node.name]
+        except KeyError:
+            # Classes inside functions are ignored.
+            return
+        assert isinstance(cls, model.Class)
+        getDeprecated(cls, cls.raw_decorators)
+
+    def visit_FunctionDef(self, node:ast.FunctionDef) -> None:
+        """
+        Called when a function definition is visited.
+        """
+        super().visit_FunctionDef(node)
+        try:
+            func = self.builder.current.contents[node.name]
+        except KeyError:
+            # Inner functions are ignored.
+            return
+        assert isinstance(func, (model.Function, model.Attribute))
+        if func.decorators:
+            getDeprecated(func, func.decorators)
+
+
+def versionToUsefulObject(version:ast.Call) -> 'incremental.Version':
+    """
+    Change an AST C{Version()} to a real one.
+
+    @raises ValueError: If the incremental.Version call is invalid.
+    """
+
+    package = astutils.get_str_value(version.args[0])
+    major: Union[Number, str, None] = astutils.get_num_value(version.args[1]) or astutils.get_str_value(version.args[1])
+    if isinstance(major, str) and major != "NEXT": 
+        raise ValueError("Invalid call to incremental.Version(), first argument should be an int or 'NEXT'.")
+    return Version(package, major, *(astutils.get_num_value(x) for x in version.args[2:] if x))
+
+_deprecated_signature = inspect.signature(deprecated)
+def deprecatedToUsefulText(ctx:model.Documentable, name:str, deprecated:ast.Call) -> str:
+    """
+    Change a C{@deprecated} to a display string.
+
+    @param ctx: The context in which the deprecation is evaluated.
+    @param name: The name of the thing we're deprecating.
+    @param deprecated: AST call to L{twisted.python.deprecate.deprecated} or L{twisted.python.deprecate.deprecatedProperty}.
+    @returns: The text tu use in the deprecation warning.
+    @raises ValueError or TypeError: If something is wrong.
+    """
+
+    bound_args = astutils.bind_args(_deprecated_signature, deprecated)
+    _version_call = bound_args.arguments.get('version')
+    if not isinstance(_version_call, ast.Call) or \
+       astbuilder.node2fullname(_version_call.func, ctx) != "incremental.Version":
+        raise ValueError("Invalid call to twisted.python.deprecate.deprecated(), first argument should be a call to incremental.Version()")
+    
+    version = versionToUsefulObject(_version_call)
+    replacement: Optional[str] = None
+
+    replvalue = bound_args.arguments.get('replacement')
+    if replvalue is not None:
+        if astutils.node2dottedname(replvalue) is not None:
+            replacement = astbuilder.node2fullname(replvalue, ctx)
+        else:
+            replacement = astutils.get_str_value(replvalue)
+
+    return cast(str, _getDeprecationWarningString(name, version, replacement=replacement)) + "."
+
+
+class ASTBuilder(zopeinterface.ZopeInterfaceASTBuilder):
+    # Vistor is not a typo...
+    ModuleVistor = ModuleVisitor
+
+
+class System(zopeinterface.ZopeInterfaceSystem):
+    """
+    A system aware of {twisted.python.deprecate.deprecated} and cie.
+    """
+
+    defaultBuilder = ASTBuilder

--- a/pydoctor/deprecate.py
+++ b/pydoctor/deprecate.py
@@ -127,17 +127,30 @@ def deprecatedToUsefulText(ctx:model.Documentable, name:str, deprecated:ast.Call
         else:
             replacement = astutils.get_str_value(replvalue)
     _version = version.public()
+    _package = version.package
+
+    # Avoids html injections
+    def validate_identifier(_text:str) -> bool:
+        if not all(p.isidentifier() for p in _text.split('.')):
+            return False
+        return True
+
+    if not validate_identifier(_package):
+        raise ValueError(f"Invalid package name: {_package!r}")
+    if replacement is not None and not validate_identifier(replacement):
+        raise ValueError(f"Invalid replacement name: {replacement!r}")
+    
     if replacement is not None:
         text = _deprecation_text_with_replacement_template.format(
             name=name, 
-            package=version.package,
+            package=_package,
             version=_version,
             replacement=replacement
         )
     else:
         text = _deprecation_text_without_replacement_template.format(
             name=name, 
-            package=version.package,
+            package=_package,
             version=_version,
         )
     return _version, text

--- a/pydoctor/deprecate.py
+++ b/pydoctor/deprecate.py
@@ -9,7 +9,7 @@ Support for L{twisted.python.deprecate}.
 import ast
 import inspect
 from numbers import Number
-from typing import Optional, Sequence, Union, TYPE_CHECKING, cast
+from typing import Optional, Sequence, Union, TYPE_CHECKING
 
 from pydoctor import astbuilder, model, zopeinterface, epydoc2stan, astutils
 

--- a/pydoctor/deprecate.py
+++ b/pydoctor/deprecate.py
@@ -41,10 +41,12 @@ def getDeprecated(self:model.Documentable, decorators:Sequence[ast.expr]) -> Non
                     self.report(str(e), section='deprecation text')
                 else:
                     # Add a deprecation info with reStructuredText .. deprecated:: directive.
-                    parsed_info = epydoc2stan.parse_docstring(self,
-                        f".. deprecated:: {version}\n   {text}", self, 
+                    parsed_info = epydoc2stan.parse_docstring(
+                        obj=self,
+                        doc=f".. deprecated:: {version}\n   {text}", 
+                        source=self, 
                         markup='restructuredtext', 
-                        section='deprecation text')
+                        section='deprecation text',)
                     self.extra_info.append(parsed_info)
 
 
@@ -89,7 +91,7 @@ def versionToUsefulObject(version:ast.Call) -> 'incremental.Version':
     major: Union[Number, str, None] = astutils.get_num_value(bound_args.arguments['major']) or \
         astutils.get_str_value(bound_args.arguments['major'])
     if isinstance(major, str) and major != "NEXT": 
-        raise ValueError("Invalid call to incremental.Version(), first argument should be an int or 'NEXT'.")
+        raise ValueError("Invalid call to incremental.Version(), 'major' should be an int or 'NEXT'.")
     return Version(package, major, 
         minor=astutils.get_num_value(bound_args.arguments['minor']),
         micro=astutils.get_num_value(bound_args.arguments['micro']),)

--- a/pydoctor/driver.py
+++ b/pydoctor/driver.py
@@ -1,4 +1,4 @@
-"""The command-line parsing and entry point."""
+"""The entry point."""
 
 from typing import  Sequence
 import datetime

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -200,9 +200,9 @@ class ParsedDocstring(abc.ABC):
             visitor = SummaryExtractor(_document)
             _document.walk(visitor)
         except Exception: 
-            self._summary = epydoc2stan._ParsedStanOnly(tags.span(class_='undocumented')("Broken summary"))
+            self._summary = epydoc2stan.ParsedStanOnly(tags.span(class_='undocumented')("Broken summary"))
         else:
-            self._summary = visitor.summary or epydoc2stan._ParsedStanOnly(tags.span(class_='undocumented')("No summary"))
+            self._summary = visitor.summary or epydoc2stan.ParsedStanOnly(tags.span(class_='undocumented')("No summary"))
         return self._summary
 
       

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -372,7 +372,7 @@ class Documentable:
 
         linenumber: object
         if section in ('docstring', 'resolve_identifier_xref'):
-            linenumber = self.docstring_lineno
+            linenumber = self.docstring_lineno or self.linenumber
         else:
             linenumber = self.linenumber
         if linenumber:

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -30,7 +30,6 @@ from pydoctor.sphinx import CacheT, SphinxInventory
 
 if TYPE_CHECKING:
     from typing_extensions import Literal
-    from twisted.web.template import Flattenable
     from pydoctor.astbuilder import ASTBuilder, DocumentableT
 else:
     Literal = {True: bool, False: bool}
@@ -140,7 +139,10 @@ class Documentable:
         self.parent = parent
         self.parentMod: Optional[Module] = None
         self.source_path: Optional[Path] = source_path
-        self._deprecated_info: Optional["Flattenable"] = None
+        self.extra_info: List[ParsedDocstring] = []
+        """
+        A list to store extra informations about this documentable, as L{ParsedDocstring}.
+        """
         self.setup()
 
     @property

--- a/pydoctor/options.py
+++ b/pydoctor/options.py
@@ -1,5 +1,5 @@
 """
-Provides L{Options} container with high level factory methods.
+The command-line parsing.
 """
 
 import re
@@ -28,6 +28,8 @@ BUILDTIME_FORMAT_HELP = 'YYYY-mm-dd HH:MM:SS'
 
 DEFAULT_CONFIG_FILES = ['./pyproject.toml', './setup.cfg', './pydoctor.ini']
 CONFIG_SECTIONS = ['tool.pydoctor', 'tool:pydoctor', 'pydoctor']
+
+DEFAULT_SYSTEM = 'pydoctor.deprecate.System'
 
 __all__ = ("Options", )
 
@@ -230,7 +232,7 @@ def get_parser() -> ArgumentParser:
         help=("Do not generate the sidebar at all."))
     
     parser.add_argument(
-        '--system-class', dest='systemclass', default='pydoctor.deprecate.System',
+        '--system-class', dest='systemclass', default=DEFAULT_SYSTEM,
         help=("A dotted name of the class to use to make a system."))
     
     parser.add_argument('-V', '--version', action='version', version=f'%(prog)s {__version__}')

--- a/pydoctor/options.py
+++ b/pydoctor/options.py
@@ -230,7 +230,7 @@ def get_parser() -> ArgumentParser:
         help=("Do not generate the sidebar at all."))
     
     parser.add_argument(
-        '--system-class', dest='systemclass', default='pydoctor.zopeinterface.ZopeInterfaceSystem',
+        '--system-class', dest='systemclass', default='pydoctor.deprecate.System',
         help=("A dotted name of the class to use to make a system."))
     
     parser.add_argument('-V', '--version', action='version', version=f'%(prog)s {__version__}')

--- a/pydoctor/stanutils.py
+++ b/pydoctor/stanutils.py
@@ -27,9 +27,14 @@ def html2stan(html: Union[bytes, str]) -> Tag:
         html = html.encode('utf8')
 
     html = _RE_CONTROL.sub(lambda m:b'\\x%02x' % ord(m.group()), html)
-    stan = XMLString(b'<div>%s</div>' % html).load()[0]
-    assert isinstance(stan, Tag)
-    assert stan.tagName == 'div'
+    if not html.startswith(b'<?xml'):
+        stan = XMLString(b'<div>%s</div>' % html).load()[0]
+        assert isinstance(stan, Tag)
+        assert stan.tagName == 'div'
+    else:
+        stan = XMLString(b'%s' % html).load()[0]
+        assert isinstance(stan, Tag)
+        assert stan.tagName == 'html'
     stan.tagName = ''
     return stan
 

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -197,14 +197,6 @@ class CommonPage(Page):
         return parts
 
     @renderer
-    def deprecated(self, request: object, tag: Tag) -> "Flattenable":
-        msg = self.ob._deprecated_info
-        if msg is None:
-            return ()
-        else:
-            return tags.div(msg, role="alert", class_="deprecationNotice alert alert-warning")
-
-    @renderer
     def source(self, request: object, tag: Tag) -> "Flattenable":
         sourceHref = util.srclink(self.ob)
         if not sourceHref:
@@ -215,8 +207,8 @@ class CommonPage(Page):
     def inhierarchy(self, request: object, tag: Tag) -> "Flattenable":
         return ()
 
-    def extras(self) -> List["Flattenable"]:
-        return []
+    def extras(self) -> List[Tag]:
+        return self.objectExtras(self.ob)
 
     def docstring(self) -> "Flattenable":
         return self.docgetter.get(self.ob)
@@ -257,15 +249,22 @@ class CommonPage(Page):
 
         for c in self.methods():
             if isinstance(c, model.Function):
-                r.append(FunctionChild(self.docgetter, c, self.functionExtras(c), func_loader))
+                r.append(FunctionChild(self.docgetter, c, self.objectExtras(c), func_loader))
             elif isinstance(c, model.Attribute):
-                r.append(AttributeChild(self.docgetter, c, self.functionExtras(c), attr_loader))
+                r.append(AttributeChild(self.docgetter, c, self.objectExtras(c), attr_loader))
             else:
                 assert False, type(c)
         return r
 
-    def functionExtras(self, ob: model.Documentable) -> List["Flattenable"]:
-        return []
+    def objectExtras(self, ob: model.Documentable) -> List[Tag]:
+        """
+        Flatten each L{model.Documentable.extra_info} list item.
+        """
+        r: List[Tag] = []
+        for extra in ob.extra_info:
+            r.append(extra.to_stan(ob.docstring_linker, compact=False))
+        return r
+
 
     def functionBody(self, ob: model.Documentable) -> "Flattenable":
         return self.docgetter.get(ob)
@@ -299,13 +298,14 @@ class CommonPage(Page):
 class ModulePage(CommonPage):
     ob: model.Module
 
-    def extras(self) -> List["Flattenable"]:
-        r = super().extras()
+    def extras(self) -> List[Tag]:
+        r: List[Tag] = []
 
         sourceHref = util.srclink(self.ob)
         if sourceHref:
             r.append(tags.a("(source)", href=sourceHref, class_="sourceLink"))
 
+        r.extend(super().extras())
         return r
 
 
@@ -384,8 +384,8 @@ class ClassPage(CommonPage):
                 self.baselists.append((baselist, attrs))
         self.overridenInCount = 0
 
-    def extras(self) -> List["Flattenable"]:
-        r = super().extras()
+    def extras(self) -> List[Tag]:
+        r: List[Tag] = []
 
         sourceHref = util.srclink(self.ob)
         source: "Flattenable"
@@ -399,13 +399,14 @@ class ClassPage(CommonPage):
             self.classSignature(), ":", source
             )))
 
-        scs = sorted(self.ob.subclasses, key=util.objects_order)
-        if not scs:
-            return r
-        p = assembleList(self.ob.system, "Known subclasses: ",
-                         [o.fullName() for o in scs], "moreSubclasses", self.page_url)
-        if p is not None:
-            r.append(tags.p(p))
+        subclasses = sorted(self.ob.subclasses, key=util.objects_order)
+        if subclasses:
+            p = assembleList(self.ob.system, "Known subclasses: ",
+                            [o.fullName() for o in subclasses], "moreSubclasses", self.page_url)
+            if p is not None:
+                r.append(tags.p(p))
+
+        r.extend(super().extras())
         return r
 
     def classSignature(self) -> "Flattenable":
@@ -459,10 +460,10 @@ class ClassPage(CommonPage):
             r.extend([' (via ', tail, ')'])
         return r
 
-    def functionExtras(self, ob: model.Documentable) -> List["Flattenable"]:
+    def objectExtras(self, ob: model.Documentable) -> List[Tag]:
         page_url = self.page_url
         name = ob.name
-        r: List["Flattenable"] = []
+        r: List[Tag] = []
         for b in self.ob.allbases(include_self=False):
             if name not in b.contents:
                 continue
@@ -478,13 +479,14 @@ class ClassPage(CommonPage):
                              [o.fullName() for o in ocs], idbase, self.page_url)
             if l is not None:
                 r.append(tags.div(class_="interfaceinfo")(l))
+        r.extend(super().objectExtras(ob))
         return r
 
 
 class ZopeInterfaceClassPage(ClassPage):
     ob: zopeinterface.ZopeInterfaceClass
 
-    def extras(self) -> List["Flattenable"]:
+    def extras(self) -> List[Tag]:
         r = super().extras()
         if self.ob.isinterface:
             namelist = [o.fullName() for o in 
@@ -512,16 +514,16 @@ class ZopeInterfaceClassPage(ClassPage):
                         return method
         return None
 
-    def functionExtras(self, ob: model.Documentable) -> List["Flattenable"]:
+    def objectExtras(self, ob: model.Documentable) -> List[Tag]:
         imeth = self.interfaceMeth(ob.name)
-        r: List["Flattenable"] = []
+        r: List[Tag] = []
         if imeth:
             iface = imeth.parent
             assert iface is not None
             r.append(tags.div(class_="interfaceinfo")('from ', tags.code(
                 epydoc2stan.taglink(imeth, self.page_url, iface.fullName())
                 )))
-        r.extend(super().functionExtras(ob))
+        r.extend(super().objectExtras(ob))
         return r
 
 commonpages: 'Final[Mapping[str, Type[CommonPage]]]' = {

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -199,6 +199,7 @@ class CommonPage(Page):
     def deprecated(self, request: object, tag: Tag) -> "Flattenable":
         import warnings
         warnings.warn("Renderer 'CommonPage.deprecated' is deprecated, the twisted's deprecation system is now supported by default.")
+        return ''
     @renderer
     def source(self, request: object, tag: Tag) -> "Flattenable":
         sourceHref = util.srclink(self.ob)

--- a/pydoctor/templatewriter/pages/__init__.py
+++ b/pydoctor/templatewriter/pages/__init__.py
@@ -195,7 +195,10 @@ class CommonPage(Page):
             ob = ob.parent
         parts.reverse()
         return parts
-
+    @renderer
+    def deprecated(self, request: object, tag: Tag) -> "Flattenable":
+        import warnings
+        warnings.warn("Renderer 'CommonPage.deprecated' is deprecated, the twisted's deprecation system is now supported by default.")
     @renderer
     def source(self, request: object, tag: Tag) -> "Flattenable":
         sourceHref = util.srclink(self.ob)

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -19,7 +19,7 @@ class AttributeChild(TemplateElement):
     def __init__(self,
             docgetter: util.DocGetter,
             ob: Attribute,
-            extras: "Flattenable",
+            extras: List[Tag],
             loader: ITemplateLoader
             ):
         super().__init__(loader)
@@ -62,20 +62,12 @@ class AttributeChild(TemplateElement):
             return ()
 
     @renderer
-    def functionExtras(self, request: object, tag: Tag) -> "Flattenable":
+    def objectExtras(self, request: object, tag: Tag) -> List[Tag]:
         return self._functionExtras
 
     @renderer
     def functionBody(self, request: object, tag: Tag) -> "Flattenable":
         return self.docgetter.get(self.ob)
-
-    @renderer
-    def functionDeprecated(self, request: object, tag: Tag) -> "Flattenable":
-        msg = self.ob._deprecated_info
-        if msg is None:
-            return ()
-        else:
-            return tags.div(msg, role="alert", class_="deprecationNotice alert alert-warning")
 
     @renderer
     def constantValue(self, request: object, tag: Tag) -> "Flattenable":

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from twisted.web.iweb import ITemplateLoader
 from twisted.web.template import Tag, renderer, tags
@@ -18,7 +18,7 @@ class FunctionChild(TemplateElement):
     def __init__(self,
             docgetter: util.DocGetter,
             ob: Function,
-            extras: "Flattenable",
+            extras: List[Tag],
             loader: ITemplateLoader
             ):
         super().__init__(loader)
@@ -65,17 +65,10 @@ class FunctionChild(TemplateElement):
             return ()
 
     @renderer
-    def functionExtras(self, request: object, tag: Tag) -> "Flattenable":
+    def objectExtras(self, request: object, tag: Tag) -> List[Tag]:
         return self._functionExtras
 
     @renderer
     def functionBody(self, request: object, tag: Tag) -> "Flattenable":
         return self.docgetter.get(self.ob)
 
-    @renderer
-    def functionDeprecated(self, request: object, tag: Tag) -> "Flattenable":
-        msg = self.ob._deprecated_info
-        if msg is None:
-            return ()
-        else:
-            return tags.div(msg, role="alert", class_="deprecationNotice alert alert-warning")

--- a/pydoctor/test/test_twisted_python_deprecate.py
+++ b/pydoctor/test/test_twisted_python_deprecate.py
@@ -1,0 +1,63 @@
+
+import re
+from pydoctor import deprecate
+from pydoctor.stanutils import flatten_text, html2stan
+from pydoctor.test import CapSys, test_templatewriter
+from pydoctor.test.test_astbuilder import fromText
+
+
+def test_twisted_python_deprecate(capsys: CapSys) -> None:
+    """
+    It recognizes Twisted deprecation decorators and add the
+    deprecation info as part of the documentation.
+    """
+
+    # Adjusted from Twisted's tests at
+    # https://github.com/twisted/twisted/blob/3bbe558df65181ed455b0c5cc609c0131d68d265/src/twisted/python/test/test_release.py#L516
+
+    mod = fromText(
+        """
+        from twisted.python.deprecate import deprecated
+        from incremental import Version
+        @deprecated(Version('Twisted', 15, 0, 0), 'Baz')
+        def foo():
+            'docstring'
+        from twisted.python import deprecate
+        import incremental
+        @deprecate.deprecated(incremental.Version('Twisted', 16, 0, 0))
+        def _bar():
+            'should appear'
+        @deprecated(Version('Twisted', 14, 2, 3), replacement='stuff')
+        class Baz:
+            pass
+        class stuff: ...
+        """, systemcls=deprecate.System, modname='mod')
+
+    mod_html_text = flatten_text(html2stan(test_templatewriter.getHTMLOf(mod)))
+    class_html_text = flatten_text(html2stan(test_templatewriter.getHTMLOf(mod.contents['Baz'])))
+
+    # assert not capsys.readouterr().out
+    assert not capsys.readouterr().err
+
+    _html_template_with_replacement = r'(.*){name} was deprecated in {package} {version}; please use {replacement} instead\.(.*)'
+    _html_template_without_replacement = r'(.*){name} was deprecated in {package} {version}\.(.*)'
+    
+    assert 'docstring' in mod_html_text
+    assert 'should appear' in mod_html_text
+
+    assert re.match(_html_template_with_replacement.format(
+        name='foo', package='Twisted', version=r'15\.0\.0', replacement='Baz'
+    ), mod_html_text, re.DOTALL), mod_html_text
+    assert re.match(_html_template_without_replacement.format(
+        name='_bar', package='Twisted', version=r'16\.0\.0'
+    ), mod_html_text, re.DOTALL), mod_html_text
+
+    _class = mod.contents['Baz']
+    assert len(_class.extra_info)==1
+    assert re.match(_html_template_with_replacement.format(
+        name='Baz', package='Twisted', version=r'14\.2\.3', replacement='stuff'
+    ), flatten_text(_class.extra_info[0].to_stan(mod.docstring_linker, False)).strip(), re.DOTALL)
+
+    assert re.match(_html_template_with_replacement.format(
+        name='Baz', package='Twisted', version=r'14\.2\.3', replacement='stuff'
+    ), class_html_text, re.DOTALL), class_html_text

--- a/pydoctor/test/test_twisted_python_deprecate.py
+++ b/pydoctor/test/test_twisted_python_deprecate.py
@@ -5,6 +5,8 @@ from pydoctor.stanutils import flatten_text, html2stan
 from pydoctor.test import CapSys, test_templatewriter
 from pydoctor.test.test_astbuilder import fromText
 
+_html_template_with_replacement = r'(.*){name} was deprecated in {package} {version}; please use {replacement} instead\.(.*)'
+_html_template_without_replacement = r'(.*){name} was deprecated in {package} {version}\.(.*)'
 
 def test_twisted_python_deprecate(capsys: CapSys) -> None:
     """
@@ -45,10 +47,8 @@ def test_twisted_python_deprecate(capsys: CapSys) -> None:
     class_html_text = flatten_text(html2stan(test_templatewriter.getHTMLOf(mod.contents['Baz'])))
 
     assert not capsys.readouterr().out
-    assert not capsys.readouterr().err
 
-    _html_template_with_replacement = r'(.*){name} was deprecated in {package} {version}; please use {replacement} instead\.(.*)'
-    _html_template_without_replacement = r'(.*){name} was deprecated in {package} {version}\.(.*)'
+    
     
     assert 'docstring' in mod_html_text
     assert 'should appear' in mod_html_text
@@ -72,4 +72,63 @@ def test_twisted_python_deprecate(capsys: CapSys) -> None:
 
     assert re.match(_html_template_with_replacement.format(
         name='foom', package='Twisted', version=r'NEXT', replacement='faam'
+    ), class_html_text, re.DOTALL), class_html_text
+
+def test_twisted_python_deprecate_corner_cases(capsys: CapSys) -> None:
+    """
+    It does not crash and report appropriate warnings while handling Twisted deprecation decorators.
+    """
+    system = deprecate.System()
+    system.options.verbosity = -1
+    
+    mod = fromText(
+        """
+        from twisted.python.deprecate import deprecated, deprecatedProperty
+        from incremental import Version
+        # wrong incremental.Version() call (missing micro)
+        @deprecated(Version('Twisted', 15, 0), 'Baz')
+        def foo():
+            'docstring'
+
+        # wrong incremental.Version() call (argument should be 'NEXT')
+        @deprecated(Version('Twisted', 'latest', 0, 0))
+        def _bar():
+            'should appear'
+        
+        # wrong deprecated() call (argument should be incremental.Version() call)
+        @deprecated('14.2.3', replacement='stuff')
+        class Baz:
+            
+            # bad deprecation text: replacement not found
+            @deprecatedProperty(Version('Twisted', 'NEXT', 0, 0), replacement='notfound')
+            @property
+            def foom(self):
+                ...
+            
+            # replacement as callable works
+            @deprecatedProperty(Version('Twisted', 'NEXT', 0, 0), replacement=Baz.faam)
+            @property
+            def foum(self):
+                ...
+            @property
+            def faam(self):
+                ...
+        class stuff: ...
+        """, system=system, modname='mod')
+
+    test_templatewriter.getHTMLOf(mod)
+    class_html_text = flatten_text(html2stan(test_templatewriter.getHTMLOf(mod.contents['Baz'])))
+
+    assert capsys.readouterr().out=="""mod:5: missing a required argument: 'micro'
+mod:10: Invalid call to incremental.Version(), 'major' should be an int or 'NEXT'.
+mod:15: Invalid call to twisted.python.deprecate.deprecated(), first argument should be a call to incremental.Version()
+mod:19: Cannot find link target for "notfound"
+""", capsys.readouterr().out
+
+    assert re.match(_html_template_with_replacement.format(
+        name='foom', package='Twisted', version='NEXT', replacement='notfound'
+    ), class_html_text, re.DOTALL), class_html_text
+
+    assert re.match(_html_template_with_replacement.format(
+        name='foum', package='Twisted', version='NEXT', replacement='mod.Baz.faam'
     ), class_html_text, re.DOTALL), class_html_text

--- a/pydoctor/themes/base/apidocs.css
+++ b/pydoctor/themes/base/apidocs.css
@@ -1119,3 +1119,8 @@ pre.constant-value              { padding: .5em; }
 #childList a:target ~ .functionBody{
     box-shadow: -2px -8px 0px 13px rgb(253 255 223);
 }
+
+/* deprecations uses a orange text */
+.rst-deprecated > .rst-versionmodified{
+    color:#aa6708;
+}

--- a/pydoctor/themes/base/attribute-child.html
+++ b/pydoctor/themes/base/attribute-child.html
@@ -1,5 +1,5 @@
 <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" class="function">
-  <meta name="pydoctor-template-version" content="2" />
+  <meta name="pydoctor-template-version" content="3" />
   <t:attr name="class" t:render="class_" />
   <a>
     <t:attr name="name" t:render="functionAnchor" />

--- a/pydoctor/themes/base/attribute-child.html
+++ b/pydoctor/themes/base/attribute-child.html
@@ -16,8 +16,7 @@
     </a>
   </div>
   <div class="functionBody">
-    <t:transparent t:render="functionExtras" />
-    <t:transparent t:render="functionDeprecated" />
+    <t:transparent t:render="objectExtras" />
     <t:transparent t:render="functionBody">
       Docstring.
     </t:transparent>

--- a/pydoctor/themes/base/function-child.html
+++ b/pydoctor/themes/base/function-child.html
@@ -1,5 +1,5 @@
 <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
-  <meta name="pydoctor-template-version" content="1" />
+  <meta name="pydoctor-template-version" content="2" />
   <t:attr name="class" t:render="class_" />
   <a>
     <t:attr name="name" t:render="functionAnchor" />

--- a/pydoctor/themes/base/function-child.html
+++ b/pydoctor/themes/base/function-child.html
@@ -18,8 +18,7 @@
     </a>
   </div>
   <div class="docstring functionBody">
-    <t:transparent t:render="functionExtras" />
-    <t:transparent t:render="functionDeprecated" />
+    <t:transparent t:render="objectExtras" />
     <t:transparent t:render="functionBody">
       Docstring.
     </t:transparent>


### PR DESCRIPTION
Almost fixes issue #315 

It also includes a bit of refactor. 

<img width="1235" alt="by default 2022-05-01 at 11 10 00 AM" src="https://user-images.githubusercontent.com/19967168/166152135-c17c63c8-b0ab-4124-ae4a-cfaa2c8e0cef.png">

