### PR TITLE
Add support for re-exporting names imported from a wildcard import

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -8,7 +8,7 @@ from inspect import BoundArguments, Parameter, Signature, signature
 from itertools import chain
 from pathlib import Path
 from typing import (
-    Any, Callable, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple,
+    Any, Callable, Collection, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple,
     Type, TypeVar, Union, cast
 )
 
@@ -372,12 +372,7 @@ class ModuleVistor(ast.NodeVisitor):
         for name in names:
             _localNameToFullName[name] = expandName(name)
 
-    def _importNames(self, modname: str, names: Iterable[ast.alias]) -> None:
-        """Handle a C{from <modname> import <names>} statement."""
-
-        # Process the module we're importing from.
-        mod = self.system.getProcessedModule(modname)
-
+    def _getCurrentModuleExports(self) -> Collection[str]:
         # Fetch names to export.
         current = self.builder.current
         if isinstance(current, model.Module):
@@ -385,34 +380,59 @@ class ModuleVistor(ast.NodeVisitor):
             if exports is None:
                 exports = []
         else:
-            assert isinstance(current, model.CanContainImportsDocumentable)
             # Don't export names imported inside classes or functions.
             exports = []
+        return exports
 
+    def _handleReExport(self, curr_mod_exports:Collection[str], 
+                        origin_name:str, as_name:str,
+                        origin_module:model.Module) -> bool:
+        """
+        Move re-exported objects into current module.
+
+        @returns: True if the imported name has been sucessfully re-exported.
+        """
+        # Move re-exported objects into current module.
+        current = self.builder.current
+        modname = origin_module.fullName()
+        if as_name in curr_mod_exports:
+            # In case of duplicates names, we can't rely on resolveName,
+            # So we use content.get first to resolve non-alias names. 
+            ob = origin_module.contents.get(origin_name) or origin_module.resolveName(origin_name)
+            if ob is None:
+                self.builder.warning("cannot resolve re-exported name",
+                                        f'{modname}.{origin_name}')
+            else:
+                if origin_module.all is None or origin_name not in origin_module.all:
+                    self.system.msg(
+                        "astbuilder",
+                        "moving %r into %r" % (ob.fullName(), current.fullName())
+                        )
+                    # Must be a Module since the exports is set to an empty list if it's not.
+                    assert isinstance(current, model.Module)
+                    ob.reparent(current, as_name)
+                    return True
+        return False
+
+    def _importNames(self, modname: str, names: Iterable[ast.alias]) -> None:
+        """Handle a C{from <modname> import <names>} statement."""
+
+        # Process the module we're importing from.
+        mod = self.system.getProcessedModule(modname)
+
+        # Fetch names to export.
+        exports = self._getCurrentModuleExports()
+
+        current = self.builder.current
+        assert isinstance(current, model.CanContainImportsDocumentable)
         _localNameToFullName = current._localNameToFullName_map
         for al in names:
             orgname, asname = al.name, al.asname
             if asname is None:
                 asname = orgname
 
-            # Move re-exported objects into current module.
-            if asname in exports and mod is not None:
-                # In case of duplicates names, we can't rely on resolveName,
-                # So we use content.get first to resolve non-alias names. 
-                ob = mod.contents.get(orgname) or mod.resolveName(orgname)
-                if ob is None:
-                    self.builder.warning("cannot resolve re-exported name",
-                                         f'{modname}.{orgname}')
-                else:
-                    if mod.all is None or orgname not in mod.all:
-                        self.system.msg(
-                            "astbuilder",
-                            "moving %r into %r" % (ob.fullName(), current.fullName())
-                            )
-                        # Must be a Module since the exports is set to an empty list if it's not.
-                        assert isinstance(current, model.Module)
-                        ob.reparent(current, asname)
-                        continue
+            if mod is not None and self._handleReExport(exports, orgname, asname, mod) is True:
+                continue
 
             # If we're importing from a package, make sure imported modules
             # are processed (getProcessedModule() ignores non-modules).

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -365,11 +365,18 @@ class ModuleVistor(ast.NodeVisitor):
                 if not name.startswith('_')
                 ]
 
+        # Fetch names to export.
+        exports = self._getCurrentModuleExports()
+
         # Add imported names to our module namespace.
         assert isinstance(self.builder.current, model.CanContainImportsDocumentable)
         _localNameToFullName = self.builder.current._localNameToFullName_map
         expandName = mod.expandName
         for name in names:
+
+            if self._handleReExport(exports, name, name, mod) is True:
+                continue
+
             _localNameToFullName[name] = expandName(name)
 
     def _getCurrentModuleExports(self) -> Collection[str]:

--- a/pydoctor/test/test_astbuilder.py
+++ b/pydoctor/test/test_astbuilder.py
@@ -2015,3 +2015,35 @@ def test_package_name_clash(systemcls: Type[model.System]) -> None:
     builder.addModuleString('', 'sub2', parent_name='mod', is_package=True)
 
     assert isinstance(system.allobjects['mod.sub2'], model.Module)
+
+@systemcls_param
+def test_reexport_wildcard(systemcls: Type[model.System]) -> None:
+    """
+    """
+    system = systemcls()
+    builder = system.systemBuilder(system)
+    builder.addModuleString('''
+    from ._impl import *
+    from _impl2 import *
+    __all__ = ['f', 'g', 'h', 'i', 'j']
+    ''', modname='top', is_package=True)
+
+    builder.addModuleString('''
+    def f(): 
+        pass
+    def g():
+        pass
+    def h():
+        pass
+    ''', modname='_impl', parent_name='top')
+    
+    builder.addModuleString('''
+    class i: pass
+    class j: pass
+    ''', modname='_impl2')
+
+    builder.buildModules()
+
+    assert system.allobjects['top._impl'].resolveName('f') == system.allobjects['top'].contents['f']
+    assert system.allobjects['_impl2'].resolveName('i') == system.allobjects['top'].contents['i']
+    assert all(n in system.allobjects['top'].contents for n in  ['f', 'g', 'h', 'i', 'j'])


### PR DESCRIPTION
Fixes #565. I did not changed the implementation, only made some basic refactor and apply the same process for imported names from wildcard imports.

It does the job, but we still have no code to handle cases where some names are re-exported more than once.

<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
