### PR TITLE
Refactor the ASTBuilder to get rid of the currentAttr attribute.

### DIFF
--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -15,7 +15,10 @@ from typing import (
 import astor
 from pydoctor import epydoc2stan, model, node2stan
 from pydoctor.epydoc.markup._pyval_repr import colorize_inline_pyval
-from pydoctor.astutils import bind_args, node2dottedname, node2fullname, is__name__equals__main__, NodeVisitor
+from pydoctor.astutils import (bind_args, node2dottedname, node2fullname, is__name__equals__main__, 
+    get_assign_docstring_node, parentage_ast_tree, NodeVisitor)
+
+
 
 def parseFile(path: Path) -> ast.Module:
     """Parse the contents of a Python source file."""
@@ -24,9 +27,13 @@ def parseFile(path: Path) -> ast.Module:
     return _parse(src, filename=str(path))
 
 if sys.version_info >= (3,8):
-    _parse = partial(ast.parse, type_comments=True)
+    _ast_parse = partial(ast.parse, type_comments=True)
 else:
-    _parse = ast.parse
+    _ast_parse = ast.parse
+
+def _parse(source: Union[str, bytes], **kwargs:Any) -> ast.Module:
+    mod = _ast_parse(source, **kwargs)
+    return parentage_ast_tree(mod)
 
 
 def _maybeAttribute(cls: model.Class, name: str) -> bool:
@@ -40,6 +47,8 @@ def _maybeAttribute(cls: model.Class, name: str) -> bool:
     obj = cls.find(name)
     return obj is None or isinstance(obj, model.Attribute)
 
+class SkipInlineDocstring(Exception):
+    ...
 
 def _handleAliasing(
         ctx: model.CanContainImportsDocumentable,
@@ -539,7 +548,7 @@ class ModuleVistor(NodeVisitor):
         obj = parent.contents.get(target)
         
         if obj is None:
-            obj = self.builder.addAttribute(name=target, kind=None, parent=parent)
+            obj = self.builder.addAttribute(name=target, kind=None, parent=parent, lineno=lineno)
         
         # If it's not an attribute it means that the name is already denifed as function/class 
         # probably meaning that this attribute is a bound callable. 
@@ -551,15 +560,16 @@ class ModuleVistor(NodeVisitor):
         # We don't know how to handle this,
         # so we ignore it to document the original object. This means that we might document arguments 
         # that are in reality not existing because they have values in a partial() call for instance.
+        # TODO: Should we report a warning?
 
         if not isinstance(obj, model.Attribute):
-            return
+            # Skips inline docsrings assigments
+            raise SkipInlineDocstring()
             
         if annotation is None and expr is not None:
             annotation = _infer_type(expr)
         
         obj.annotation = annotation
-        obj.setLineNumber(lineno)
         
         if is_constant(obj):
             self._handleConstant(obj=obj, value=expr, lineno=lineno)
@@ -568,8 +578,6 @@ class ModuleVistor(NodeVisitor):
             # We store the expr value for all Attribute in order to be able to 
             # check if they have been initialized or not.
             obj.value = expr
-
-        self.builder.currentAttr = obj
 
     def _handleAssignmentInModule(self,
             target: str,
@@ -591,13 +599,13 @@ class ModuleVistor(NodeVisitor):
         cls = self.builder.current
         assert isinstance(cls, model.Class)
         if not _maybeAttribute(cls, name):
-            return
+            raise SkipInlineDocstring()
 
         # Class variables can only be Attribute, so it's OK to cast
         obj = cast(Optional[model.Attribute], cls.contents.get(name))
 
         if obj is None:
-            obj = self.builder.addAttribute(name=name, kind=None, parent=cls)
+            obj = self.builder.addAttribute(name=name, kind=None, parent=cls, lineno=lineno)
 
         if obj.kind is None:
             instance = is_attrib(expr, cls) or (
@@ -615,41 +623,43 @@ class ModuleVistor(NodeVisitor):
                 annotation = _infer_type(expr)
         
         obj.annotation = annotation
-        obj.setLineNumber(lineno)
 
         if is_constant(obj):
             self._handleConstant(obj=obj, value=expr, lineno=lineno)
         else:
             obj.value = expr
-
-        self.builder.currentAttr = obj
-
+    
+    def _getClassFromMethodContext(self) -> Optional[model.Class]:
+        func = self.builder.current
+        if not isinstance(func, model.Function):
+            return None
+        cls = func.parent
+        if not isinstance(cls, model.Class):
+            return None
+        return cls
+    
     def _handleInstanceVar(self,
             name: str,
             annotation: Optional[ast.expr],
             expr: Optional[ast.expr],
             lineno: int
             ) -> None:
-        func = self.builder.current
-        if not isinstance(func, model.Function):
-            return
-        cls = func.parent
-        if not isinstance(cls, model.Class):
+        cls = self._getClassFromMethodContext()
+        if not cls:
             return
         if not _maybeAttribute(cls, name):
-            return
+            raise SkipInlineDocstring()
 
         # Class variables can only be Attribute, so it's OK to cast because we used _maybeAttribute() above.
         obj = cast(Optional[model.Attribute], cls.contents.get(name))
         if obj is None:
 
-            obj = self.builder.addAttribute(name=name, kind=None, parent=cls)
+            obj = self.builder.addAttribute(name=name, kind=None, parent=cls, lineno=lineno)
 
         if annotation is None and expr is not None:
             annotation = _infer_type(expr)
         
         obj.annotation = annotation
-        obj.setLineNumber(lineno)
 
         # Maybe an instance variable overrides a constant, 
         # so we check before setting the kind to INSTANCE_VARIABLE.
@@ -659,7 +669,6 @@ class ModuleVistor(NodeVisitor):
             obj.kind = model.DocumentableKind.INSTANCE_VARIABLE
             obj.value = expr
         
-        self.builder.currentAttr = obj
 
     def _handleAssignmentInClass(self,
             target: str,
@@ -752,25 +761,54 @@ class ModuleVistor(NodeVisitor):
             annotation = self._unstring_annotation(ast.Str(type_comment, lineno=lineno))
 
         for target in node.targets:
-            if isinstance(target, ast.Tuple):
-                for elem in target.elts:
-                    # Note: We skip type and aliasing analysis for this case,
-                    #       but we do record line numbers.
-                    self._handleAssignment(elem, None, None, lineno)
+            try:
+                if isinstance(target, ast.Tuple):
+                    for elem in target.elts:
+                        # Note: We skip type and aliasing analysis for this case,
+                        #       but we do record line numbers.
+                        self._handleAssignment(elem, None, None, lineno)
+                else:
+                    self._handleAssignment(target, annotation, expr, lineno)
+            except SkipInlineDocstring:
+                continue
             else:
-                self._handleAssignment(target, annotation, expr, lineno)
+                self._handleInlineDocstrings(node, target)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         annotation = self._unstring_annotation(node.annotation)
-        self._handleAssignment(node.target, annotation, node.value, node.lineno)
+        try:
+            self._handleAssignment(node.target, annotation, node.value, node.lineno)
+        except SkipInlineDocstring:
+            return
+        else:
+            self._handleInlineDocstrings(node, node.target)
+
+    def _handleInlineDocstrings(self, assign:Union[ast.Assign, ast.AnnAssign], target:ast.expr) -> None:
+        # Process the inline docstrings
+        dottedname = node2dottedname(target)
+        if not dottedname:
+            return
+
+        parent = self.builder.current
+        if dottedname[0] == 'self':
+            dottedname = dottedname[1:]
+            parent = self._getClassFromMethodContext()
+            if not parent:
+                return
+        
+        if len(dottedname) != 1:
+            return 
+
+        docstring_node = get_assign_docstring_node(assign)
+        if docstring_node:
+   
+            # fetch the target of the inline docstring
+            attr = parent.contents.get(dottedname[0])
+            if attr:
+                attr.setDocstring(docstring_node)
 
     def visit_Expr(self, node: ast.Expr) -> None:
-        value = node.value
-        if isinstance(value, ast.Str):
-            attr = self.builder.currentAttr
-            if attr is not None:
-                attr.setDocstring(value)
-                self.builder.currentAttr = None
+        # Visit's ast.Expr.value with the visitor, used by extensions to visit top-level calls.
         self.generic_visit(node)
 
 
@@ -903,8 +941,10 @@ class ModuleVistor(NodeVisitor):
             lineno: int
             ) -> model.Attribute:
 
-        attr = self.builder.addAttribute(name=node.name, kind=model.DocumentableKind.PROPERTY, parent=self.builder.current)
-        attr.setLineNumber(lineno)
+        attr = self.builder.addAttribute(name=node.name, 
+                                         kind=model.DocumentableKind.PROPERTY, 
+                                         parent=self.builder.current, 
+                                         lineno=lineno)
 
         if docstring is not None:
             attr.setDocstring(docstring)
@@ -1044,7 +1084,7 @@ class _AnnotationStringParser(ast.NodeTransformer):
     """
 
     def _parse_string(self, value: str) -> ast.expr:
-        statements = ast.parse(value).body
+        statements = _parse(value).body
         if len(statements) != 1:
             raise SyntaxError("expected expression, found multiple statements")
         stmt, = statements
@@ -1148,28 +1188,31 @@ class ASTBuilder:
     def __init__(self, system: model.System):
         self.system = system
         
-        self.current = cast(model.Documentable, None) # current visited object
-        self.currentMod: Optional[model.Module] = None # module, set when visiting ast.Module
-        self.currentAttr: Optional[model.Documentable] = None # recently visited attribute object
+        self.current = cast(model.Documentable, None) # current visited object.
+        self.currentMod: Optional[model.Module] = None # current module, set when visiting ast.Module.
         
         self._stack: List[model.Documentable] = []
         self.ast_cache: Dict[Path, Optional[ast.Module]] = {}
 
-
-    def _push(self, cls: Type[DocumentableT], name: str, lineno: int) -> DocumentableT:
+    def _push(self, 
+              cls: Type[DocumentableT], 
+              name: str, 
+              lineno: int, 
+              parent:Optional[model.Documentable]=None) -> DocumentableT:
         """
         Create and enter a new object of the given type and add it to the system.
+
+        @param parent: Parent of the new documentable instance, it will use self.current if unspecified.
+            Used for attributes declared in methods, typically ``__init__``.
         """
-        obj = cls(self.system, name, self.current)
+        obj = cls(self.system, name, parent or self.current)
         self.system.addObject(obj)
         self.push(obj, lineno)
-        self.currentAttr = None
         return obj
 
     def _pop(self, cls: Type[model.Documentable]) -> None:
         assert isinstance(self.current, cls)
         self.pop(self.current)
-        self.currentAttr = None
 
     def push(self, obj: model.Documentable, lineno: int) -> None:
         """
@@ -1224,18 +1267,17 @@ class ASTBuilder:
         self._pop(self.system.Function)
 
     def addAttribute(self,
-            name: str, kind: Optional[model.DocumentableKind], parent: model.Documentable
+            name: str, 
+            kind: Optional[model.DocumentableKind], 
+            parent: model.Documentable, 
+            lineno: int
             ) -> model.Attribute:
         """
-        Add a new attribute to the system, attributes cannot be "entered".
+        Add a new attribute to the system.
         """
-        system = self.system
-        parentMod = self.currentMod
-        attr = system.Attribute(system, name, parent)
+        attr = self._push(self.system.Attribute, name, lineno, parent=parent)
+        self._pop(self.system.Attribute)
         attr.kind = kind
-        attr.parentMod = parentMod
-        system.addObject(attr)
-        self.currentAttr = attr
         return attr
 
     def warning(self, message: str, detail: str) -> None:

--- a/pydoctor/extensions/zopeinterface.py
+++ b/pydoctor/extensions/zopeinterface.py
@@ -183,16 +183,26 @@ class ZopeInterfaceModuleVisitor(extensions.ModuleVisitorExt):
         ob = self.visitor.system.objForFullName(funcName)
         if isinstance(ob, ZopeInterfaceClass) and ob.isinterfaceclass:
             # TODO: Process 'bases' and '__doc__' arguments.
-            # TODO: Currently, this implementation will create a duplicate class 
-            # with the same name as the attribute, overriding it.
+
+            # Fetch older attr documentable
+            old_attr = self.visitor.builder.current.contents.get(target)
+            if old_attr:
+                self.visitor.builder.system._remove(old_attr) # avoid duplicate warning by simply removing the old item
+
             interface = self.visitor.builder.pushClass(target, lineno)
             assert isinstance(interface, ZopeInterfaceClass)
+            
+            # the docstring node has already been attached to the documentable 
+            # by the time the zopeinterface extension is run, so we fetch the right docstring info from old documentable.
+            if old_attr:
+                interface.docstring = old_attr.docstring
+                interface.docstring_lineno = old_attr.docstring_lineno
+
             interface.isinterface = True
             interface.implementedby_directly = []
             interface.bases = []
             interface.baseobjects = []
             self.visitor.builder.popClass()
-            self.visitor.builder.currentAttr = interface
 
     def _handleZopeInterfaceAssignmentInClass(self,
             target: str,

--- a/pydoctor/test/test_astutils.py
+++ b/pydoctor/test/test_astutils.py
@@ -1,0 +1,15 @@
+
+from pydoctor import astutils, astbuilder
+
+def test_parentage() -> None:
+    tree = astbuilder._parse('class f(b):...')
+    assert tree.body[0].parent == tree
+    assert tree.body[0].body[0].parent == tree.body[0]
+    assert tree.body[0].bases[0].parent == tree.body[0]
+
+def test_get_assign_docstring_node() -> None:
+    tree = astbuilder._parse('var = 1\n\n\n"inline docs"')
+    assert astutils.get_str_value(astutils.get_assign_docstring_node(tree.body[0])) == "inline docs"
+
+    tree = astbuilder._parse('var:int = 1\n\n\n"inline docs"')
+    assert astutils.get_str_value(astutils.get_assign_docstring_node(tree.body[0])) == "inline docs"

--- a/pydoctor/test/test_zopeinterface.py
+++ b/pydoctor/test/test_zopeinterface.py
@@ -158,7 +158,7 @@ def test_attribute(capsys: CapSys, systemcls: Type[model.System]) -> None:
     assert captured == 'mod:5: definition of attribute "bad_attr" should have docstring as its sole argument\n'
 
 @zope_interface_systemcls_param
-def test_interfaceclass(systemcls: Type[model.System]) -> None:
+def test_interfaceclass(systemcls: Type[model.System], capsys: CapSys) -> None:
     system = processPackage('interfaceclass', systemcls=systemcls)
     mod = system.allobjects['interfaceclass.mod']
     I = mod.contents['MyInterface']
@@ -169,6 +169,8 @@ def test_interfaceclass(systemcls: Type[model.System]) -> None:
     J = mod.contents['AnInterface']
     assert isinstance(J, ZopeInterfaceClass)
     assert J.isinterface
+
+    assert 'interfaceclass.mod duplicate' not in capsys.readouterr().out
 
 @zope_interface_systemcls_param
 def test_warnerproofing(systemcls: Type[model.System]) -> None:


### PR DESCRIPTION
Refactor the ASTBuilder to get rid of the currentAttr attribute.

This attribute was used to attach the right docstring node to the right Attribute object. Now it uses AST node navigation (with the .parent attribute) instead for fetching the docstring node for an ast.Assign.

This change might not be worth it, on the one hand it removes a attribute being mutated at different places in the code, but replaces this kind of "unsafe" state tracking (meaning not with pop() and push()) by some more verbose solution that involves adding the .parent attribute on all nodes.

The zopeinferface extension needed to be adjusted as well because it relied on the docstring assignment feature in an implicit way, now it's explicit what we're doing.

<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
