### PR TITLE
Visit try orelse finalbody and if orelse

### DIFF
--- a/pydoctor/extensions/deprecate.py
+++ b/pydoctor/extensions/deprecate.py
@@ -60,7 +60,8 @@ class ModuleVisitor(extensions.ModuleVisitorExt):
         except KeyError:
             # Classes inside functions are ignored.
             return
-        assert isinstance(cls, model.Class)
+        if not isinstance(cls, model.Class):
+            return
         getDeprecated(cls, node.decorator_list)
 
     def depart_FunctionDef(self, node:ast.FunctionDef) -> None:
@@ -73,7 +74,8 @@ class ModuleVisitor(extensions.ModuleVisitorExt):
         except KeyError:
             # Inner functions are ignored.
             return
-        assert isinstance(func, (model.Function, model.Attribute))
+        if not isinstance(func, (model.Function, model.Attribute)):
+            return
         getDeprecated(func, node.decorator_list)
 
 _incremental_Version_signature = inspect.signature(Version)


### PR DESCRIPTION
<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->

Since the new NodeVisitor class, all the node are not visited as before. The older visitor relied on generic_visit() to be recursive. Where the provided generic_visit() is not recursive anymore, and moreover not called automatically when visiting unknown nodes! So what I'm saying here is that since https://github.com/twisted/pydoctor/pull/576 have been merged, we're not visiting the statements inside the 'orelse' field of Try and If nodes, same goes for 'finalbody' and 'handlers'.

This commit fixes that issue. The rationale is now the following: All statements in the 'orelse' block of IF nodes and statements in the except handlers of TRY nodes that would override a name already defined in the main 'body' (or TRY 'orelse' or 'finalbody') are ignored.

Meaning that in the context of the code below, 'ssl' would resolve to 'twisted.internet.ssl':

```python
try:
    from twisted.internet import ssl as _ssl
except ImportError:
    ssl = None
else:
    ssl = _ssl
```