### PR TITLE
Fix docutils deprecation warning

### DIFF
--- a/pydoctor/epydoc/markup/_pyval_repr.py
+++ b/pydoctor/epydoc/markup/_pyval_repr.py
@@ -288,7 +288,7 @@ class PyvalColorizer:
     LINEWRAP = nodes.inline('', chr(8629), classes=[LINEWRAP_TAG])
     UNKNOWN_REPR = nodes.inline('??', '??', classes=[UNKNOWN_TAG])
     WORD_BREAK_OPPORTUNITY = wbr()
-    NEWLINE = nodes.Text('\n', '\n')
+    NEWLINE = nodes.Text('\n')
 
     GENERIC_OBJECT_RE = re.compile(r'^<(?P<descr>.*) at (?P<addr>0x[0-9a-f]+)>$', re.IGNORECASE)
 


### PR DESCRIPTION
Text() should be instantiates with one argument only.

<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
