### PR TITLE
Revert "Add anchors aside attributes and functions"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,8 +75,6 @@ What's New?
 
 in development
 ^^^^^^^^^^^^^^
-* Add anchors aside attributes and functions to ease 
-  the process of sharing links to these API docs.
 * Fix a bug in the return clause of google-style docstrings 
   where the return type would be treated as the description 
   when there is no explicit description.

--- a/pydoctor/templatewriter/pages/attributechild.py
+++ b/pydoctor/templatewriter/pages/attributechild.py
@@ -39,14 +39,9 @@ class AttributeChild(TemplateElement):
         return self.ob.fullName()
 
     @renderer
-    def shortFunctionAnchor(self, request: object, tag: Tag) -> str:
+    def shortFunctionAnchor(self, request: object, tag: Tag) -> "Flattenable":
         return self.ob.name
-    
-    @renderer
-    def anchorHref(self, request: object, tag: Tag) -> str:
-        name = self.shortFunctionAnchor(request, tag)
-        return f'#{name}'
-    
+
     @renderer
     def decorator(self, request: object, tag: Tag) -> "Flattenable":
         return list(format_decorators(self.ob))

--- a/pydoctor/templatewriter/pages/functionchild.py
+++ b/pydoctor/templatewriter/pages/functionchild.py
@@ -38,13 +38,8 @@ class FunctionChild(TemplateElement):
         return self.ob.fullName()
 
     @renderer
-    def shortFunctionAnchor(self, request: object, tag: Tag) -> str:
+    def shortFunctionAnchor(self, request: object, tag: Tag) -> "Flattenable":
         return self.ob.name
-    
-    @renderer
-    def anchorHref(self, request: object, tag: Tag) -> str:
-        name = self.shortFunctionAnchor(request, tag)
-        return f'#{name}'
 
     @renderer
     def decorator(self, request: object, tag: Tag) -> "Flattenable":

--- a/pydoctor/themes/base/apidocs.css
+++ b/pydoctor/themes/base/apidocs.css
@@ -1123,23 +1123,3 @@ pre.constant-value              { padding: .5em; }
 .rst-deprecated > .rst-versionmodified{
     color:#aa6708;
 }
-
-/* CSS for anchor links */
-.headerLink{
-    display:none;
-    color:black;
-    float:right;
-    margin-left:5px;
-    padding-left:5px;
-    padding-right:5px;
-}
-.headerLink:hover{
-    text-decoration:none;
-    background-color: #ccc;
-}
-#childList > div:hover .headerLink{
-    display:inline-block;
-}
-#childList a:target ~ .functionHeader .headerLink{
-    display: inline-block
-}

--- a/pydoctor/themes/base/attribute-child.html
+++ b/pydoctor/themes/base/attribute-child.html
@@ -1,5 +1,5 @@
 <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" class="function">
-  <meta name="pydoctor-template-version" content="4" />
+  <meta name="pydoctor-template-version" content="3" />
   <t:attr name="class" t:render="class_" />
   <a>
     <t:attr name="name" t:render="functionAnchor" />
@@ -13,11 +13,6 @@
     <a class="sourceLink" t:render="sourceLink">
       <t:attr name="href"><t:slot name="sourceHref" /></t:attr>
       (source)
-    </a>
-    <a class="headerLink">
-      <t:attr name="href" t:render="anchorHref" />
-      <t:attr name="title" t:render="functionAnchor" />
-      ¶
     </a>
   </div>
   <div class="functionBody">

--- a/pydoctor/themes/base/function-child.html
+++ b/pydoctor/themes/base/function-child.html
@@ -1,5 +1,5 @@
 <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
-  <meta name="pydoctor-template-version" content="3" />
+  <meta name="pydoctor-template-version" content="2" />
   <t:attr name="class" t:render="class_" />
   <a>
     <t:attr name="name" t:render="functionAnchor" />
@@ -15,11 +15,6 @@
     <a class="sourceLink" t:render="sourceLink">
       <t:attr name="href"><t:slot name="sourceHref" /></t:attr>
       (source)
-    </a>
-    <a class="headerLink">
-      <t:attr name="href" t:render="anchorHref" />
-      <t:attr name="title" t:render="functionAnchor" />
-      ¶
     </a>
   </div>
   <div class="docstring functionBody">


### PR DESCRIPTION
Reverts twisted/pydoctor#636

I’m reverting this PR because, from a touch screen, it takes two clicks to click on any link in a attribute or function child. So that’s not possible, maybe something can be done in JS to avoid that.