### PR TITLE
Use pypy for the system tests: improve speed by about 30%

### DIFF
--- a/.github/workflows/system.yaml
+++ b/.github/workflows/system.yaml
@@ -18,13 +18,13 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up CPython
-      if: ${{ matrix.tox_target }} == 'python-igraph-apidocs'
+      if: ${{ matrix.tox_target == 'python-igraph-apidocs' }}
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
     
     - name: Set up PyPy
-      if: ${{ matrix.tox_target }} != 'python-igraph-apidocs'
+      if: ${{ matrix.tox_target != 'python-igraph-apidocs' }}
       uses: actions/setup-python@v2
       with:
         python-version: 'pypy-3.6'


### PR DESCRIPTION
<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->

Hopefully this will improve pydoctor's speed at generating the standard library's API docs...
