### PR TITLE
Intersphinx features

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install tox
       run: |

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,14 @@ This is the last major release to support Python 3.7.
 * `ExtRegistrar.register_post_processor()` now supports a `priority` argument that is an int.
   Highest priority callables will be called first during post-processing.
 * Fix too noisy ``--verbose`` mode (suppres some ambiguous annotations warnings).
+* Major improvements of the intersphinx integration:
+  -  The ``--intersphinx`` option now supports the following format: ``[INVENTORY_NAME:]URL_OR_PATH[:BASE_URL]``.
+     Where ``INVENTORY_NAME`` is a an arbitrary name used to filter ``:external:`` references, 
+     ``URL_OR_PATH`` is an URL pointing to a ``objects.inv`` file OR a file path pointing to a local ``.inv`` file,
+     ``BASE_URL`` is the base for the generated links, it is mandatory if loading the inventory from a file.
+  - Pydoctor now supports linking to arbitrary intersphinx references with Sphinx role ``:external:``. 
+  - Other common Sphinx reference roles like ``:ref:``, ``:any:``, ``:class:``, ``py:*``, etc are now 
+    properly interpreted (instead of stripping the with a regex).
 
 pydoctor 23.9.1
 ^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ This is the last major release to support Python 3.7.
      ``BASE_URL`` is the base for the generated links, it is mandatory if loading the inventory from a file.
   - Pydoctor now supports linking to arbitrary intersphinx references with Sphinx role ``:external:``. 
   - Other common Sphinx reference roles like ``:ref:``, ``:any:``, ``:class:``, ``py:*``, etc are now 
-    properly interpreted (instead of stripping the with a regex).
+    properly interpreted (instead of being simply stripping from the docstring).
 
 pydoctor 23.9.1
 ^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -84,13 +84,16 @@ This is the last major release to support Python 3.7.
   Highest priority callables will be called first during post-processing.
 * Fix too noisy ``--verbose`` mode (suppres some ambiguous annotations warnings).
 * Major improvements of the intersphinx integration:
-  -  The ``--intersphinx`` option now supports the following format: ``[INVENTORY_NAME:]URL_OR_PATH[:BASE_URL]``.
-     Where ``INVENTORY_NAME`` is a an arbitrary name used to filter ``:external:`` references, 
-     ``URL_OR_PATH`` is an URL pointing to a ``objects.inv`` file OR a file path pointing to a local ``.inv`` file,
-     ``BASE_URL`` is the base for the generated links, it is mandatory if loading the inventory from a file.
   - Pydoctor now supports linking to arbitrary intersphinx references with Sphinx role ``:external:``. 
   - Other common Sphinx reference roles like ``:ref:``, ``:any:``, ``:class:``, ``py:*``, etc are now 
     properly interpreted (instead of being simply stripping from the docstring).
+  - The ``--intersphinx`` option now supports the following format: ``[INVENTORY_NAME:]URL[:BASE_URL]``.
+    Where ``INVENTORY_NAME`` is a an arbitrary name used to filter ``:external:`` references, 
+    ``URL`` is an URL pointing to a ``objects.inv`` file (it can also be the base URL, ``/objects.inv`` will be added to the URL in this case).
+    It is recommended to always include the HTTP scheme in the intersphinx URLs. 
+  - The ``--intersphinx-file`` option has been added in order to load a local inventory file, this option
+    support the following format: ``[INVENTORY_NAME:]PATH:BASE_URL``. 
+    ``BASE_URL`` is the base for the generated links, it is mandatory if loading the inventory from a file.
 
 pydoctor 23.9.1
 ^^^^^^^^^^^^^^^

--- a/pydoctor/astbuilder.py
+++ b/pydoctor/astbuilder.py
@@ -439,17 +439,10 @@ class ModuleVistor(NodeVisitor):
             _localNameToFullName[asname] = f'{modname}.{orgname}'
 
     def visit_Import(self, node: ast.Import) -> None:
-        """Process an import statement.
+        """
+        Process an import statement.
 
-        The grammar for the statement is roughly:
-
-        mod_as := DOTTEDNAME ['as' NAME]
-        import_stmt := 'import' mod_as (',' mod_as)*
-
-        and this is translated into a node which is an instance of Import wih
-        an attribute 'names', which is in turn a list of 2-tuples
-        (dotted_name, as_name) where as_name is None if there was no 'as foo'
-        part of the statement.
+        See L{import}. 
         """
         if not isinstance(self.builder.current, model.CanContainImportsDocumentable):
             # processing import statement in odd context

--- a/pydoctor/epydoc/markup/__init__.py
+++ b/pydoctor/epydoc/markup/__init__.py
@@ -297,7 +297,11 @@ class DocstringLinker(Protocol):
         @return: The link, or just the label if the target was not found.
         """
 
-    def link_xref(self, target: str, label: "Flattenable", lineno: int) -> Tag:
+    def link_xref(self, target: str, label: "Flattenable", lineno: int, *, 
+                  invname: Optional[str] = None,
+                  domain: Optional[str] = None,
+                  reftype: Optional[str] = None,
+                  external: bool = False) -> Tag:
         """
         Format a cross-reference link to a Python identifier.
         This will resolve the identifier to any reasonable target,
@@ -308,6 +312,14 @@ class DocstringLinker(Protocol):
         @param label: The label to show for the link.
         @param lineno: The line number within the docstring at which the
             crossreference is located.
+        @param invname: In the case of an intersphinx resolution, filters by
+            inventory name. 
+        @param domain: In the case of an intersphinx resolution, filters by
+            domain. 
+        @param reftype: In the case of an intersphinx resolution, filters by
+            reference type.
+        @param external: If True, forces the lookup to use intersphinx and 
+            ingnore local names.  
         @return: The link, or just the label if the target was not found.
             In either case, the returned top-level tag will be C{<code>}.
         """

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -1194,7 +1194,8 @@ def _colorize_link(link: Element, token: Token, end: int, errors: List[ParseErro
         # Here we used to process the target in order to remove arg lists for functions
         # and validate it. But now this happens in node2stan.parse_reference().
         # The target is not validated anymore since the intersphinx taget names can contain any kind of text.
-        pass
+        # We simply normalize it.
+        target = re.sub(r'\s', ' ', target)
 
     # Construct the target element.
     target_elt = Element('target', target, lineno=str(token.startline))

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -1181,8 +1181,10 @@ def _colorize_link(link: Element, token: Token, end: int, errors: List[ParseErro
 
     # Clean up the target.  For URIs, assume http or mailto if they
     # don't specify (no relative urls)
-    target = re.sub(r'\s', '', target)
+    # we used to stip spaces from the target here but that's no good 
+    # since intersphinx targets can contain spaces.
     if link.tag=='uri':
+        target = re.sub(r'\s', '', target)
         if not re.match(r'\w+:', target):
             if re.match(r'\w+@(\w+)(\.\w+)*', target):
                 target = 'mailto:' + target
@@ -1191,10 +1193,8 @@ def _colorize_link(link: Element, token: Token, end: int, errors: List[ParseErro
     elif link.tag=='link':
         # Remove arg lists for functions (e.g., L{_colorize_link()})
         target = re.sub(r'\(.*\)$', '', target)
-        if not re.match(r'^[a-zA-Z_]\w*(\.[a-zA-Z_]\w*)*$', target):
-            estr = "Bad link target."
-            errors.append(ColorizingError(estr, token, end))
-            return
+        # We used to validate the link target against the following regex: r'^[a-zA-Z_]\w*(\.[a-zA-Z_]\w*)*$'
+        # but we don;t do that anymore since the intersphinx taget names can contain any kind of text.
 
     # Construct the target element.
     target_elt = Element('target', target, lineno=str(token.startline))

--- a/pydoctor/epydoc/markup/epytext.py
+++ b/pydoctor/epydoc/markup/epytext.py
@@ -1191,10 +1191,10 @@ def _colorize_link(link: Element, token: Token, end: int, errors: List[ParseErro
             else:
                 target = 'http://'+target
     elif link.tag=='link':
-        # Remove arg lists for functions (e.g., L{_colorize_link()})
-        target = re.sub(r'\(.*\)$', '', target)
-        # We used to validate the link target against the following regex: r'^[a-zA-Z_]\w*(\.[a-zA-Z_]\w*)*$'
-        # but we don;t do that anymore since the intersphinx taget names can contain any kind of text.
+        # Here we used to process the target in order to remove arg lists for functions
+        # and validate it. But now this happens in node2stan.parse_reference().
+        # The target is not validated anymore since the intersphinx taget names can contain any kind of text.
+        pass
 
     # Construct the target element.
     target_elt = Element('target', target, lineno=str(token.startline))

--- a/pydoctor/linker.py
+++ b/pydoctor/linker.py
@@ -147,7 +147,7 @@ class _EpydocLinker(DocstringLinker):
             link = self.obj.system.intersphinx.getLink(name, 
                         invname=invname, domain=domain, 
                         reftype=reftype)
-            if lineno is not None:
+            if self.reporting_obj is not None and lineno is not None:
                 self.reporting_obj.report(str(e), 'resolve_identifier_xref', lineno, thresh=1)
             return link
 

--- a/pydoctor/linker.py
+++ b/pydoctor/linker.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import contextlib
 from twisted.web.template import Tag, tags
 from typing import  (
-     TYPE_CHECKING, Iterable, Iterator, 
+     TYPE_CHECKING, Any, Iterable, Iterator, 
      Optional, Union
 )
 
@@ -123,13 +123,18 @@ class _EpydocLinker(DocstringLinker):
                 'resolve_identifier_xref', lineno)
         return None
 
-    def look_for_intersphinx(self, name: str) -> Optional[str]:
+    def look_for_intersphinx(self, name: str, *, 
+                             invname: Optional[str] = None,
+                             domain: Optional[str] = None,
+                             reftype: Optional[str] = None) -> Optional[str]:
         """
         Return link for `name` based on intersphinx inventory.
 
         Return None if link is not found.
         """
-        return self.obj.system.intersphinx.getLink(name)
+        return self.obj.system.intersphinx.getLink(name, 
+                    invname=invname, domain=domain, 
+                    reftype=reftype)
 
     def link_to(self, identifier: str, label: "Flattenable") -> Tag:
         fullID = self.obj.expandName(identifier)
@@ -145,10 +150,16 @@ class _EpydocLinker(DocstringLinker):
         link = tags.transparent(label)
         return link
 
-    def link_xref(self, target: str, label: "Flattenable", lineno: int) -> Tag:
+    def link_xref(self, target: str, label: "Flattenable", lineno: int, *, 
+                    invname: Optional[str] = None,
+                    domain: Optional[str] = None,
+                    reftype: Optional[str] = None,
+                    external: bool = False) -> Tag:
         xref: "Flattenable"
         try:
-            resolved = self._resolve_identifier_xref(target, lineno)
+            resolved = self._resolve_identifier_xref(target, lineno, 
+                        invname=invname, domain=domain, 
+                        reftype=reftype, external=external)
         except LookupError:
             xref = label
         else:
@@ -161,7 +172,12 @@ class _EpydocLinker(DocstringLinker):
 
     def _resolve_identifier_xref(self,
             identifier: str,
-            lineno: int
+            lineno: int, 
+            *,
+            invname: Optional[str] = None,
+            domain: Optional[str] = None,
+            reftype: Optional[str] = None,
+            external: bool = False
             ) -> Union[str, 'model.Documentable']:
         """
         Resolve a crossreference link to a Python identifier.
@@ -172,72 +188,95 @@ class _EpydocLinker(DocstringLinker):
             should be linked to.
         @param lineno: The line number within the docstring at which the
             crossreference is located.
+        @param invname: Filters by inventory name, implies external=True.
+        @param domain: Filters by domain.
+        @param reftype: Filters by reference type.
+        @param external: Forces the lookup to happen with interspinx.
         @return: The referenced object within our system, or the URL of
             an external target (found via Intersphinx).
         @raise LookupError: If C{identifier} could not be resolved.
         """
+        if invname: assert external
+        might_be_local_python_ref = not external and domain in ('py', None) and reftype not in ('doc', )
 
         # There is a lot of DWIM here. Look for a global match first,
         # to reduce the chance of a false positive.
 
         # Check if 'identifier' is the fullName of an object.
-        target = self.obj.system.objForFullName(identifier)
-        if target is not None:
-            return target
+        if might_be_local_python_ref:
+            target = self.obj.system.objForFullName(identifier)
+            if target is not None:
+                return target
 
         # Check if the fullID exists in an intersphinx inventory.
         fullID = self.obj.expandName(identifier)
-        target_url = self.look_for_intersphinx(fullID)
+        target_url = self.look_for_intersphinx(fullID, invname=invname, 
+                                               domain=domain, reftype=reftype)
+        intersphinx_target_url_unfiltered = self.look_for_intersphinx(fullID)
         if not target_url:
             # FIXME: https://github.com/twisted/pydoctor/issues/125
             # expandName is unreliable so in the case fullID fails, we
             # try our luck with 'identifier'.
-            target_url = self.look_for_intersphinx(identifier)
+            target_url = self.look_for_intersphinx(identifier, invname=invname, 
+                                               domain=domain, reftype=reftype)
+            if not intersphinx_target_url_unfiltered:
+                intersphinx_target_url_unfiltered = self.look_for_intersphinx(identifier)
         if target_url:
             return target_url
+        
+        if might_be_local_python_ref:
+            # Since there was no global match, go look for the name in the
+            # context where it was used.
 
-        # Since there was no global match, go look for the name in the
-        # context where it was used.
+            # Check if 'identifier' refers to an object by Python name resolution
+            # in our context. Walk up the object tree and see if 'identifier' refers
+            # to an object by Python name resolution in each context.
+            src: Optional['model.Documentable'] = self.obj
+            while src is not None:
+                target = src.resolveName(identifier)
+                if target is not None:
+                    return target
+                src = src.parent
 
-        # Check if 'identifier' refers to an object by Python name resolution
-        # in our context. Walk up the object tree and see if 'identifier' refers
-        # to an object by Python name resolution in each context.
-        src: Optional['model.Documentable'] = self.obj
-        while src is not None:
-            target = src.resolveName(identifier)
+            # Walk up the object tree again and see if 'identifier' refers to an
+            # object in an "uncle" object.  (So if p.m1 has a class C, the
+            # docstring for p.m2 can say L{C} to refer to the class in m1).
+            # If at any level 'identifier' refers to more than one object, complain.
+            src = self.obj
+            while src is not None:
+                target = self.look_for_name(identifier, src.contents.values(), lineno)
+                if target is not None:
+                    return target
+                src = src.parent
+
+            # Examine every module and package in the system and see if 'identifier'
+            # names an object in each one.  Again, if more than one object is
+            # found, complain.
+            target = self.look_for_name(
+                # System.objectsOfType now supports passing the type as string.
+                identifier, self.obj.system.objectsOfType('pydoctor.model.Module'), lineno)
             if target is not None:
                 return target
-            src = src.parent
 
-        # Walk up the object tree again and see if 'identifier' refers to an
-        # object in an "uncle" object.  (So if p.m1 has a class C, the
-        # docstring for p.m2 can say L{C} to refer to the class in m1).
-        # If at any level 'identifier' refers to more than one object, complain.
-        src = self.obj
-        while src is not None:
-            target = self.look_for_name(identifier, src.contents.values(), lineno)
-            if target is not None:
-                return target
-            src = src.parent
-
-        # Examine every module and package in the system and see if 'identifier'
-        # names an object in each one.  Again, if more than one object is
-        # found, complain.
-        target = self.look_for_name(
-            # System.objectsOfType now supports passing the type as string.
-            identifier, self.obj.system.objectsOfType('pydoctor.model.Module'), lineno)
-        if target is not None:
-            return target
-
-        message = f'Cannot find link target for "{fullID}"'
-        if identifier != fullID:
-            message = f'{message}, resolved from "{identifier}"'
-        root_idx = fullID.find('.')
-        if root_idx != -1 and fullID[:root_idx] not in self.obj.system.root_names:
-            message += ' (you can link to external docs with --intersphinx)'
+            message = f'Cannot find link target for "{fullID}"'
+            if identifier != fullID:
+                message = f'{message}, resolved from "{identifier}"'
+            if intersphinx_target_url_unfiltered:
+                message += f' (your link role filters {intersphinx_target_url_unfiltered!r}, is it by design?)'
+            else:
+                root_idx = fullID.find('.')
+                if root_idx != -1 and fullID[:root_idx] not in self.obj.system.root_names:
+                    message += ' (you can link to external docs with --intersphinx)'
+            
+        else:
+            message = f'Cannot find intersphinx link target for "{fullID}"'
+            if intersphinx_target_url_unfiltered:
+                message += f' (your link role filters {intersphinx_target_url_unfiltered!r}, is it by design?)'
+        
         if self.reporting_obj:
             self.reporting_obj.report(message, 'resolve_identifier_xref', lineno)
         raise LookupError(identifier)
+
 
 class _AnnotationLinker(DocstringLinker):
     """
@@ -278,9 +317,9 @@ class _AnnotationLinker(DocstringLinker):
             else:
                 return self._module_linker.link_to(target, label)
     
-    def link_xref(self, target: str, label: "Flattenable", lineno: int) -> Tag:
+    def link_xref(self, target: str, label: "Flattenable", lineno: int, **kw: Any) -> Tag:
         with self.switch_context(self._obj):
-            return self.obj.docstring_linker.link_xref(target, label, lineno)
+            return self.obj.docstring_linker.link_xref(target, label, lineno, **kw)
 
     @contextlib.contextmanager
     def switch_context(self, ob:Optional['model.Documentable']) -> Iterator[None]:

--- a/pydoctor/linker.py
+++ b/pydoctor/linker.py
@@ -192,7 +192,8 @@ class _EpydocLinker(DocstringLinker):
             invname: Optional[str] = None,
             domain: Optional[str] = None,
             reftype: Optional[str] = None,
-            external: bool = False
+            external: bool = False,
+            no_warnings: bool = False, 
             ) -> Union[str, 'model.Documentable']:
         """
         Resolve a crossreference link to a Python identifier.
@@ -307,12 +308,13 @@ class _EpydocLinker(DocstringLinker):
             try:
                 return self._resolve_identifier_xref(_SPACE_RE.sub('', identifier), 
                                                      lineno, invname=invname, domain=domain, 
-                                                     reftype=reftype, external=external)
+                                                     reftype=reftype, external=external, no_warnings=True)
             except LookupError:
                 pass
 
-        if self.reporting_obj:
+        if self.reporting_obj and no_warnings is False:
             self.reporting_obj.report(message, 'resolve_identifier_xref', lineno)
+        
         raise LookupError(identifier)
 
 

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -1447,6 +1447,8 @@ class System:
         """
         for i in self.options.intersphinx:
             self.intersphinx.update(cache, i)
+        for i in self.options.intersphinx_files:
+            self.intersphinx.update_from_file(i)
 
 def defaultPostProcess(system:'System') -> None:
     for cls in system.objectsOfType(Class):

--- a/pydoctor/model.py
+++ b/pydoctor/model.py
@@ -1445,8 +1445,8 @@ class System:
         """
         Download and parse intersphinx inventories based on configuration.
         """
-        for url in self.options.intersphinx:
-            self.intersphinx.update(cache, url)
+        for i in self.options.intersphinx:
+            self.intersphinx.update(cache, i)
 
 def defaultPostProcess(system:'System') -> None:
     for cls in system.objectsOfType(Class):

--- a/pydoctor/node2stan.py
+++ b/pydoctor/node2stan.py
@@ -80,11 +80,13 @@ def parse_reference(node:nodes.Node) -> Reference:
         label, target = node.children, node.attributes['refuri']
     else:
         # RST parsed.
-        m = _TARGET_RE.match(node.astext())
+        # Sanitize links spaning over multiple lines
+        node_text = re.sub(r'\s', ' ', node.astext())
+        m = _TARGET_RE.match(node_text)
         if m:
             label, target = m.groups()
         else:
-            label = target = node.astext()
+            label = target = node_text
     # Support linking to functions and methods with parameters
     try:
         begin_parameters = target.index('(')

--- a/pydoctor/options.py
+++ b/pydoctor/options.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import enum
 
 import re
-from typing import Sequence, List, Optional, Type, Tuple, TYPE_CHECKING, TypeAlias
+from typing import Sequence, List, Optional, Type, Tuple, TYPE_CHECKING
 import sys
 import functools
 from pathlib import Path
@@ -22,6 +22,7 @@ from pydoctor.utils import parse_path, findClassFromDottedName, parse_privacy_tu
 from pydoctor._configparser import CompositeConfigParser, IniConfigParser, TomlConfigParser, ValidatorParser
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
     from pydoctor import model
     from pydoctor.templatewriter import IWriter
 
@@ -369,7 +370,7 @@ def _split_intersphinx_parts(s:str, option:str='--intersphinx') -> List[str]:
         parts[part_nb] += c
     return parts
 
-IntersphinxOption: TypeAlias = Tuple[Optional[str], str, str]
+IntersphinxOption: 'TypeAlias' = Tuple[Optional[str], str, str]
 
 def _parse_intersphinx_file(s:str) -> IntersphinxOption:
     """

--- a/pydoctor/options.py
+++ b/pydoctor/options.py
@@ -317,7 +317,7 @@ def _object_inv_url_and_base_url(url:str) -> Tuple[str, str]:
 
 def _is_identifier_like(s:str) -> bool:
     """
-    Examples of identifier-like strings:
+    Examples of identifier-like strings::
 
         identifier
         identifier_thing

--- a/pydoctor/options.py
+++ b/pydoctor/options.py
@@ -17,7 +17,7 @@ import attr
 from pydoctor import __version__
 from pydoctor.themes import get_themes
 from pydoctor.epydoc.markup import get_supported_docformats
-from pydoctor.sphinx import MAX_AGE_HELP, USER_INTERSPHINX_CACHE, IntersphinxOption, IntersphinxSource
+from pydoctor.sphinx import MAX_AGE_HELP, USER_INTERSPHINX_CACHE, IntersphinxOption, URL, FILE
 from pydoctor.utils import parse_path, findClassFromDottedName, parse_privacy_tuple, error
 from pydoctor._configparser import CompositeConfigParser, IniConfigParser, TomlConfigParser, ValidatorParser
 
@@ -288,16 +288,16 @@ def _convert_htmlwriter(s: str) -> Type['IWriter']:
 def _convert_privacy(l: List[str]) -> List[Tuple['model.PrivacyClass', str]]:
     return list(map(functools.partial(parse_privacy_tuple, opt='--privacy'), l))
 
-def _intersphinx_source(url_or_path:str) -> IntersphinxSource:
-    """
-    Infer the kind source this string refers to. 
+# def _intersphinx_source(url_or_path:str) -> object:
+#     """
+#     Infer the kind source this string refers to. 
 
-    """
-    if url_or_path.startswith(HTTP_SCHEMES):
-        return IntersphinxSource.URL
-    if not url_or_path.endswith('.inv'):
-        return IntersphinxSource.URL
-    return IntersphinxSource.FILE
+#     """
+#     if url_or_path.startswith(HTTP_SCHEMES):
+#         return URL
+#     if not url_or_path.endswith('.inv'):
+#         return URL
+#     return FILE
 
 def _object_inv_url_and_base_url(url:str) -> Tuple[str, str]:
     """
@@ -368,6 +368,7 @@ def _split_intersphinx_parts(s:str) -> List[str]:
 
 _RE_DRIVE_LIKE = re.compile(r':[a-z]:(\\|\/)', re.IGNORECASE)
 HTTP_SCHEMES = ('http://', 'https://')
+
 def _parse_intersphinx(s:str) -> IntersphinxOption:
     """
     Given a string like::
@@ -388,7 +389,7 @@ def _parse_intersphinx(s:str) -> IntersphinxOption:
             objects_inv_url, base_url = _object_inv_url_and_base_url(*parts)
             return IntersphinxOption(
                 invname=None, 
-                source=IntersphinxSource.URL, 
+                source=URL, 
                 url_or_path=objects_inv_url,
                 base_url=base_url
             )
@@ -402,13 +403,13 @@ def _parse_intersphinx(s:str) -> IntersphinxOption:
                 invname, url_or_path, base_url = None, p1, p2
                 _, base_url = _object_inv_url_and_base_url(base_url)
                 source = _intersphinx_source(url_or_path)
-                if source is IntersphinxSource.URL:
+                if source is URL:
                     url_or_path, _ = _object_inv_url_and_base_url(url_or_path)
             else:
                 # At this point we have: INVENTORY_NAME:URL_TO_OBJECTS.INV
                 invname, url_or_path = p1, p2
                 url_or_path, base_url = _object_inv_url_and_base_url(url_or_path)
-                source = IntersphinxSource.URL
+                source = URL
             
             return IntersphinxOption(
                 invname=invname, 
@@ -421,7 +422,7 @@ def _parse_intersphinx(s:str) -> IntersphinxOption:
             # we have INVENTORY_NAME:URL_OR_FILEPATH_TO_OBJECTS.INV:BASE_URL
             invname, url_or_path, base_url = parts
             source = _intersphinx_source(url_or_path)
-            if source is IntersphinxSource.URL:
+            if source is URL:
                 url_or_path, _ = _object_inv_url_and_base_url(url_or_path)
                 _, base_url = _object_inv_url_and_base_url(base_url)
             return IntersphinxOption(

--- a/pydoctor/options.py
+++ b/pydoctor/options.py
@@ -331,18 +331,13 @@ def _is_identifier_like(s:str) -> bool:
 # --intersphinx=something.org
 # --intersphinx=http://something.org/objects.inv
 # --intersphinx=http://cnd.abc.something.org/objects.inv:http://something.org/
-# --intersphinx=inventories/pack.inv:http://something.org/
-
-# --intersphinx=file.inv:http://something.org/ 
-# ok so this one and the next one are hard to differenciate...
-# we have to require the file to have the extension '.inv' but what about a project 
-# called 'project.inv' ? So for these cases we should check if the file exists or not.
-
 # --intersphinx=pydoctor:http://something.org/
 # --intersphinx=pydoctor:http://something.org/objects.inv
 # --intersphinx=pydoctor:http://cnd.abc.something.org/objects.inv:http://something.org/
-# --intersphinx=pydoctor:inventories/pack.inv:http://something.org/
-# --intersphinx=pydoctor:c:/data/inventories/pack.inv:http://something.org/
+# --intersphinx-file=inventories/pack.inv:http://something.org/
+# --intersphinx-file=file.inv:http://something.org/ 
+# --intersphinx-file=pydoctor:inventories/pack.inv:http://something.org/
+# --intersphinx-file=pydoctor:c:/data/inventories/pack.inv:http://something.org/
 
 _RE_DRIVE_LIKE = re.compile(r':[a-z]:(\\|\/)', re.IGNORECASE)
 def _split_intersphinx_parts(s:str, option:str='--intersphinx') -> List[str]:

--- a/pydoctor/options.py
+++ b/pydoctor/options.py
@@ -305,8 +305,16 @@ def _convert_privacy(l: List[str]) -> List[Tuple['model.PrivacyClass', str]]:
 
 def _object_inv_url_and_base_url(url:str) -> Tuple[str, str]:
     """
-    Given a base url OR an url to objects.inv file.
+    Given a base url OR an url to .inv file.
     Returns a tuple: (URL_TO_OBJECTS.INV, BASE_URL)
+
+    >>> _object_inv_url_and_base_url('thing.inv') # error
+    >>> _object_inv_url_and_base_url('hello.com/thing.inv')
+    ('hello.com/thing.inv', 'hello.com')
+    >>> _object_inv_url_and_base_url('hello.com')
+    ('hello.com/objects.inv', 'hello.com')
+    >>> _object_inv_url_and_base_url('hello.com/')
+    ('hello.com/objects.inv', 'hello.com')
     """
     if url.endswith('.inv'):
         parts = url.rsplit('/', 1)
@@ -325,12 +333,12 @@ def _object_inv_url_and_base_url(url:str) -> Tuple[str, str]:
 
 def _is_identifier_like(s:str) -> bool:
     """
-    Examples of identifier-like strings::
+    True if C{s} is an identifier-like strings
 
-        identifier
-        identifier_thing
-        zope.interface
-        identifier-like
+    >>> assert _is_identifier_like('identifier')
+    >>> assert _is_identifier_like('identifier_thing')
+    >>> assert _is_identifier_like('zope.interface')
+    >>> assert _is_identifier_like('identifier-like')
     """
     return s.replace('-', '_').replace('.', '_').isidentifier()
 
@@ -350,8 +358,7 @@ def _is_identifier_like(s:str) -> bool:
 _RE_DRIVE_LIKE = re.compile(r':[a-z]:(\\|\/)', re.IGNORECASE)
 def _split_intersphinx_parts(s:str, option:str='--intersphinx') -> List[str]:
     """
-    This replies on the fact the filename does not contain a colon. 
-    # TODO: find a manner to lift this limitation.
+    Colons in filenames must be escaped with a backslash.
     """
     parts = ['']
     part_nb = 0
@@ -366,10 +373,14 @@ def _split_intersphinx_parts(s:str, option:str='--intersphinx') -> List[str]:
             elif _RE_DRIVE_LIKE.match(s[i-2:i+2]):
                 # Still not a separator, a windows drive :c:/
                 pass
+            elif s[i-1] == '\\':
+                # An escaped colon, remove the backslash and keep the colon
+                parts[part_nb] = parts[part_nb][:-1]
+                pass
             elif len(parts) == 3:
-                raise ValueError(f'Malformed {option} option {s!r}: too many parts, beware that colons in filenames are not supported')
+                raise ValueError(f'Malformed {option} option {s!r}: too many parts, beware that colons in filenames must be escaped with a backslash')
             elif not parts[part_nb]:
-                raise ValueError(f'Malformed {option} option {s!r}: two consecutive colons is not valid')
+                raise ValueError(f'Malformed {option} option {s!r}: two consecutive colons is not valid, beware that colons in filenames must be escaped with a backslash')
             else:
                 parts.append('')
                 part_nb += 1
@@ -377,7 +388,7 @@ def _split_intersphinx_parts(s:str, option:str='--intersphinx') -> List[str]:
         parts[part_nb] += c
     return parts
 
-IntersphinxOption: 'TypeAlias' = Tuple[Optional[str], str, str]
+IntersphinxOption: TypeAlias = Tuple[Optional[str], str, str]
 
 def _parse_intersphinx_file(s:str) -> IntersphinxOption:
     """
@@ -386,6 +397,14 @@ def _parse_intersphinx_file(s:str) -> IntersphinxOption:
         [INVENTORY_NAME:]PATH:BASE_URL
     
     Returns a L{IntersphinxOption} tuple.
+
+    >>> _parse_intersphinx_file('privpackage:./shinx inventories/privpackage.inv:https://myprivatehost/apidocs/privpackage/')
+    >>> _parse_intersphinx_file('./shinx inventories/privpackage.inv:https://myprivatehost/apidocs/privpackage/')
+    >>> _parse_intersphinx_file('privpackage:d:/shinx inventories/privpackage.inv:https://myprivatehost/apidocs/privpackage/')
+    >>> _parse_intersphinx_file('./shinx inventories/privpackage.inv') # error
+    >>> _parse_intersphinx_file('https://myprivatehost/apidocs/privpackage/') # error
+    >>> _parse_intersphinx_file(r'shinx inventories\\:aka intersphinx/privpackage.inv:https://myprivatehost/apidocs/privpackage/')
+
     """
     try:
         parts = _split_intersphinx_parts(s, '--intersphinx-file')
@@ -423,6 +442,9 @@ def _parse_intersphinx(s:str) -> IntersphinxOption:
         [INVENTORY_NAME:]URL[:BASE_URL]
 
     Returns a L{IntersphinxOption} tuple.
+
+    >>> _parse_intersphinx('docs.stuff.org')
+    >>> _parse_intersphinx('https://docs.stuff.org')
     """
     try:
 

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -285,7 +285,7 @@ class SphinxInventory:
                invname:Optional[str], 
                domain:Optional[str], 
                reftype:Optional[str],
-               options: Sequence[InventoryObject]):
+               options: Sequence[InventoryObject]) -> None:
 
         # Build the taget string
         target_str = target

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -258,12 +258,13 @@ class SphinxInventory:
             py_options = list(filter(_filter, options))
             if py_options:
                 # TODO: We might want to leave a message in the case where several objects
-                # are still in consideration. But for now, we just pick the last one.
+                # are still in consideration. But for now, we just pick the last one because our old version
+                # of the inventory (that only dealing with the 'py' domain) would override names as they were parsed.
                 return py_options[-1]
         
-        # Last, we fall back to the last matching object because our old version
-        # of the inventory would override names as they were parsed.
-        return options[-1]
+        # If it hasn't been found in the 'py' domain, then we use the first mathing object because it makes 
+        # more sens in the case of the `std` domain of the standard library.
+        return options[0]
 
     def getLink(self, target: str,
                 invname:Optional[str]=None, 

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -12,6 +12,7 @@ from typing import (
     TYPE_CHECKING, Callable, ContextManager, Dict, IO, Iterable, Mapping,
     Optional, Tuple
 )
+import enum
 
 import appdirs
 import attr
@@ -34,6 +35,40 @@ else:
 
 logger = logging.getLogger(__name__)
 
+class InvObjectType(enum.Enum):
+
+    FUNCTION = ('function', 'func')
+    METHOD = ('method', 'meth')
+    MODULE = ('module', 'mod', 'package', 'pack')
+    CLASS = ('class', 'cls')
+    ATTRIBUTE = ('attribute', 'attr', 'attrib', 'data')
+    OBJECT = ('obj', 'object')
+
+    def common_name(self) -> str:
+        v = self.value
+        assert isinstance(v, tuple)
+        return v[0] # type:ignore
+
+    @classmethod
+    def from_text(cls, txt:str) -> 'InvObjectType':
+        for e in InvObjectType._member_map_.values():
+            if txt in e.value:
+                assert isinstance(e, InvObjectType)
+                return e
+        return InvObjectType.OBJECT
+
+def _convert_typ(typ:str) -> 'InvObjectType':
+    if typ.startswith('py:'):
+        return InvObjectType.from_text(typ[3:].strip(':'))
+    else:
+        return InvObjectType.from_text(typ.strip(':'))
+
+@attr.s(auto_attribs=True)
+class InventoryObject:
+    name:str
+    base_url:str
+    location:str
+    typ:InvObjectType = attr.ib(converter=_convert_typ)
 
 class SphinxInventory:
     """
@@ -47,9 +82,11 @@ class SphinxInventory:
             ):
         """
         @param project_name: Dummy argument to stay compatible with
-                             L{twisted.python._pydoctor}.
+            L{twisted.python._pydoctor}. This will be used when we fix
+            U{#609 <https://github.com/twisted/pydoctor/issues/609>}.
+
         """
-        self._links: Dict[str, Tuple[str, str]] = {}
+        self._links: Dict[str, InventoryObject] = {}
         self._logger = logger
 
     def error(self, where: str, message: str) -> None:
@@ -110,7 +147,7 @@ class SphinxInventory:
             self,
             base_url: str,
             payload: str
-            ) -> Dict[str, Tuple[str, str]]:
+            ) -> Dict[str, InventoryObject]:
         """
         Parse clear text payload and return a dict with module to link mapping.
         """
@@ -129,16 +166,24 @@ class SphinxInventory:
                 # Non-Python references are ignored.
                 continue
 
-            result[name] = (base_url, location)
+            result[name] = InventoryObject(name=name, typ=typ,
+                base_url=base_url, location=location)
+        
         return result
+
+    def getInv(self, name) -> Optional[InventoryObject]:
+        return self._links.get(name)
 
     def getLink(self, name: str) -> Optional[str]:
         """
         Return link for `name` or None if no link is found.
         """
-        base_url, relative_link = self._links.get(name, (None, None))
-        if not relative_link:
+        invobj = self.getInv(name)
+        if not invobj:
             return None
+        
+        base_url = invobj.base_url
+        relative_link = invobj.location
 
         # For links ending with $, replace it with full name.
         if relative_link.endswith('$'):
@@ -253,23 +298,24 @@ class SphinxInventoryWriter:
         url = obj.url
 
         display = '-'
+        objtype: InvObjectType
         if isinstance(obj, model.Module):
-            domainname = 'module'
+            objtype = InvObjectType.MODULE
         elif isinstance(obj, model.Class):
-            domainname = 'class'
+            objtype = InvObjectType.CLASS
         elif isinstance(obj, model.Function):
             if obj.kind is model.DocumentableKind.FUNCTION:
-                domainname = 'function'
+                objtype = InvObjectType.FUNCTION
             else:
-                domainname = 'method'
+                objtype = InvObjectType.METHOD
         elif isinstance(obj, model.Attribute):
-            domainname = 'attribute'
+            objtype = InvObjectType.ATTRIBUTE
         else:
-            domainname = 'obj'
+            objtype = InvObjectType.OBJECT
             self.error(
                 'sphinx', "Unknown type %r for %s." % (type(obj), full_name,))
 
-        return f'{full_name} py:{domainname} -1 {url} {display}\n'
+        return f'{full_name} py:{objtype.common_name()} -1 {url} {display}\n'
 
 
 USER_INTERSPHINX_CACHE = appdirs.user_cache_dir("pydoctor")

--- a/pydoctor/sphinx.py
+++ b/pydoctor/sphinx.py
@@ -301,11 +301,13 @@ class SphinxInventory:
 
         if not missing_filters:
             # there is a problem with this inventory...
-            msg = f'complete intersphinx ref is still ambiguous {target_str}, could be {",".join(options_urls)}'
-            msg += ', this is likely an issue with the inventory'
+            # TODO: should we even report such an issue ?
+            # probably mnot since the dev cannot do anything about it
+            msg = (f'there is an issue with the inventory {invname}: '
+                    f' {target_str}, could be {",".join(options_urls)}')
         else:
             msg = f'ambiguous intersphinx ref to {target_str}, could be {",".join(options_urls)}'
-            msg += f', try adding one of {", ".join(missing_filters)} filter to your RST role'
+            msg += f', try adding one of {", ".join(missing_filters)} filter to your role'
         raise ValueError(msg)
 
     def getInv(self, target: str, 

--- a/pydoctor/test/__init__.py
+++ b/pydoctor/test/__init__.py
@@ -2,7 +2,7 @@
 
 import contextlib
 from logging import LogRecord
-from typing import Iterable, TYPE_CHECKING, Iterator, Optional, Sequence
+from typing import Any, Iterable, TYPE_CHECKING, Iterator, Optional, Sequence
 import sys
 import pytest
 from pathlib import Path
@@ -90,7 +90,7 @@ class NotFoundLinker(DocstringLinker):
     def link_to(self, target: str, label: "Flattenable") -> Tag:
         return tags.transparent(label)
 
-    def link_xref(self, target: str, label: "Flattenable", lineno: int) -> Tag:
+    def link_xref(self, target: str, label: "Flattenable", lineno: int, **kw:Any) -> Tag:
         return tags.code(label)
     
     @contextlib.contextmanager

--- a/pydoctor/test/epydoc/test_epytext.py
+++ b/pydoctor/test/epydoc/test_epytext.py
@@ -21,6 +21,20 @@ def parse(s: str) -> str:
         # this strips off the <epytext>...</epytext>
         return ''.join(str(n) for n in element.children)
 
+def test_links() -> None:
+    L1 = 'L{link}'
+    L2 = 'L{something.link}'
+    L3 = 'L{any kind of text since intersphinx name can contain spaces}'
+    L4 = 'L{looks-like-identifier}'
+    L5 = 'L{this stuff <any kind of text>}'
+    L6 = 'L{this stuff <looks-like-identifier>}'
+
+    assert parse(L1) == "<para><link><name>link</name><target lineno='0'>link</target></link></para>"
+    assert parse(L2) == "<para><link><name>something.link</name><target lineno='0'>something.link</target></link></para>"
+    assert parse(L3) == "<para><link><name>any kind of text since intersphinx name can contain spaces</name><target lineno='0'>any kind of text since intersphinx name can contain spaces</target></link></para>"
+    assert parse(L4) == "<para><link><name>looks-like-identifier</name><target lineno='0'>looks-like-identifier</target></link></para>"
+    assert parse(L5) == "<para><link><name>this stuff</name><target lineno='0'>any kind of text</target></link></para>"
+    assert parse(L6) == "<para><link><name>this stuff</name><target lineno='0'>looks-like-identifier</target></link></para>"
 
 def test_basic_list() -> None:
     P1 = "This is a paragraph."

--- a/pydoctor/test/epydoc/test_epytext2node.py
+++ b/pydoctor/test/epydoc/test_epytext2node.py
@@ -39,7 +39,7 @@ def test_nested_markup() -> None:
     expected = '''<document source="epytext">
     <paragraph>
         It becomes a little bit complicated with 
-        <title_reference refuri="twisted.web">
+        <title_reference refuri="twisted.web()">
             <strong>
                 custom
              links

--- a/pydoctor/test/test_commandline.py
+++ b/pydoctor/test/test_commandline.py
@@ -186,7 +186,7 @@ def test_main_return_zero_on_warnings() -> None:
 
     assert exit_code == 0
     assert "__init__.py:8: Unknown field 'bad_field'" in stream.getvalue()
-    assert 'report_module.py:9: Cannot find link target for "BadLink"' in stream.getvalue()
+    assert 'report_module.py:9: Cannot find link target for "Bad Link"' in stream.getvalue()
 
 
 def test_main_return_non_zero_on_warnings() -> None:
@@ -203,7 +203,7 @@ def test_main_return_non_zero_on_warnings() -> None:
 
     assert exit_code == 3
     assert "__init__.py:8: Unknown field 'bad_field'" in stream.getvalue()
-    assert 'report_module.py:9: Cannot find link target for "BadLink"' in stream.getvalue()
+    assert 'report_module.py:9: Cannot find link target for "Bad Link"' in stream.getvalue()
 
 
 def test_main_symlinked_paths(tmp_path: Path) -> None:

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Type, cast, TYPE_CHECKING
+from typing import Any, List, Optional, Type, cast, TYPE_CHECKING
 import re
 
 from pytest import mark, raises
@@ -168,7 +168,15 @@ def test_xref_link_intersphinx() -> None:
 
     system = mod.system
     inventory = SphinxInventory(system.msg)
-    inventory._links['external.func'] = InventoryObject(name='external.func', base_url='https://example.net', location='lib.html#func', typ='func')
+    inventory._links['external.func'] = [
+        InventoryObject(
+            invname='xxx',
+            name='external.func', 
+            base_url='https://example.net', 
+            location='lib.html#func', 
+            domain='py',
+            reftype='func',
+            display='-')]
     system.intersphinx = inventory
 
     html = docstring2html(mod.contents['func'])
@@ -1079,7 +1087,15 @@ def test_EpydocLinker_look_for_intersphinx_hit() -> None:
     """
     system = model.System()
     inventory = SphinxInventory(system.msg)
-    inventory._links['base.module.other'] = InventoryObject(name='base.module.other', base_url='http://tm.tld', location='some.html', typ='mod')
+    inventory._links['base.module.other'] = [
+        InventoryObject(
+            invname='xxx',
+            name='base.module.other', 
+            base_url='http://tm.tld', 
+            location='some.html', 
+            domain='py',
+            reftype='mod',
+            display='-')]
     system.intersphinx = inventory
     target = model.Module(system, 'ignore-name')
     sut = target.docstring_linker
@@ -1095,7 +1111,15 @@ def test_EpydocLinker_adds_intersphinx_link_css_class() -> None:
     """
     system = model.System()
     inventory = SphinxInventory(system.msg)
-    inventory._links['base.module.other'] = InventoryObject(name='base.module.other', base_url='http://tm.tld', location='some.html', typ='mod')
+    inventory._links['base.module.other'] = [
+        InventoryObject(
+            invname='xxx',
+            name='base.module.other', 
+            base_url='http://tm.tld', 
+            location='some.html', 
+            domain='py',
+            reftype='mod',
+            display='-')]
     system.intersphinx = inventory
     target = model.Module(system, 'ignore-name')
     sut = target.docstring_linker
@@ -1116,7 +1140,15 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_absolute_id() -> None:
     """
     system = model.System()
     inventory = SphinxInventory(system.msg)
-    inventory._links['base.module.other'] = InventoryObject(name='base.module.other', base_url='http://tm.tld', location='some.html', typ='mod')
+    inventory._links['base.module.other'] = [
+        InventoryObject(
+            invname='xxx',
+            name='base.module.other', 
+            base_url='http://tm.tld', 
+            location='some.html', 
+            domain='py',
+            reftype='mod',
+            display='-')]
     system.intersphinx = inventory
     target = model.Module(system, 'ignore-name')
     sut = target.docstring_linker
@@ -1136,7 +1168,16 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_relative_id() -> None:
     """
     system = model.System()
     inventory = SphinxInventory(system.msg)
-    inventory._links['ext_package.ext_module'] = InventoryObject(name='ext_package.ext_module', base_url='http://tm.tld', location='some.html', typ='mod')
+    inventory._links['ext_package.ext_module'] = [
+        InventoryObject(
+            invname='xxx',
+            name='ext_package.ext_module', 
+            base_url='http://tm.tld', 
+            location='some.html',
+            domain='py',
+            reftype='mod', 
+            display='-',
+            )]
     system.intersphinx = inventory
     target = model.Module(system, 'ignore-name')
     # Here we set up the target module as it would have this import.
@@ -1197,7 +1238,7 @@ class InMemoryInventory:
         'socket.socket': 'https://docs.python.org/3/library/socket.html#socket.socket',
         }
 
-    def getLink(self, name: str) -> Optional[str]:
+    def getLink(self, name: str, **kw:Any) -> Optional[str]:
         return self.INVENTORY.get(name)
 
 def test_EpydocLinker_resolve_identifier_xref_order(capsys: CapSys) -> None:
@@ -1418,7 +1459,7 @@ class RecordingAnnotationLinker(NotFoundLinker):
         self.requests.append(target)
         return tags.transparent(label)
 
-    def link_xref(self, target: str, label: "Flattenable", lineno: int) -> Tag:
+    def link_xref(self, target: str, label: "Flattenable", lineno: int, **kw:Any) -> Tag:
         assert False
 
 @mark.parametrize('annotation', (

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -1100,9 +1100,10 @@ def test_EpydocLinker_look_for_intersphinx_with_spaces() -> None:
     sut = target.docstring_linker
     assert isinstance(sut, linker._EpydocLinker)
 
-    result = sut.look_for_intersphinx('base .module .other')
+    result = sut.link_xref('base .module .other', 'thing', 0)
+    assert 'http://tm.tld/some.html' in flatten(result)
 
-    assert 'http://tm.tld/some.html' == result
+# TODO: Test filtering look_for_intersphinx(name, invname, domain, reftype)
 
 def test_EpydocLinker_look_for_intersphinx_hit() -> None:
     """

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -1080,6 +1080,29 @@ def test_EpydocLinker_look_for_intersphinx_no_link() -> None:
 
     assert None is result
 
+def test_EpydocLinker_look_for_intersphinx_with_spaces() -> None:
+    """
+    Return the link from inventory based on first package name.
+    """
+    system = model.System()
+    inventory = SphinxInventory(system.msg)
+    inventory._links['base.module.other'] = [
+        InventoryObject(
+            invname='xxx',
+            name='base.module.other', 
+            base_url='http://tm.tld', 
+            location='some.html', 
+            domain='py',
+            reftype='mod',
+            display='-')]
+    system.intersphinx = inventory
+    target = model.Module(system, 'ignore-name')
+    sut = target.docstring_linker
+    assert isinstance(sut, linker._EpydocLinker)
+
+    result = sut.look_for_intersphinx('base .module .other')
+
+    assert 'http://tm.tld/some.html' == result
 
 def test_EpydocLinker_look_for_intersphinx_hit() -> None:
     """

--- a/pydoctor/test/test_epydoc2stan.py
+++ b/pydoctor/test/test_epydoc2stan.py
@@ -9,7 +9,7 @@ from pydoctor import epydoc2stan, model, linker
 from pydoctor.epydoc.markup import get_supported_docformats
 from pydoctor.stanutils import flatten, flatten_text
 from pydoctor.epydoc.markup.epytext import ParsedEpytextDocstring
-from pydoctor.sphinx import SphinxInventory
+from pydoctor.sphinx import SphinxInventory, InventoryObject
 from pydoctor.test.test_astbuilder import fromText, unwrap
 from pydoctor.test import CapSys, NotFoundLinker
 from pydoctor.templatewriter.search import stem_identifier
@@ -168,7 +168,7 @@ def test_xref_link_intersphinx() -> None:
 
     system = mod.system
     inventory = SphinxInventory(system.msg)
-    inventory._links['external.func'] = ('https://example.net', 'lib.html#func')
+    inventory._links['external.func'] = InventoryObject(name='external.func', base_url='https://example.net', location='lib.html#func', typ='func')
     system.intersphinx = inventory
 
     html = docstring2html(mod.contents['func'])
@@ -1079,7 +1079,7 @@ def test_EpydocLinker_look_for_intersphinx_hit() -> None:
     """
     system = model.System()
     inventory = SphinxInventory(system.msg)
-    inventory._links['base.module.other'] = ('http://tm.tld', 'some.html')
+    inventory._links['base.module.other'] = InventoryObject(name='base.module.other', base_url='http://tm.tld', location='some.html', typ='mod')
     system.intersphinx = inventory
     target = model.Module(system, 'ignore-name')
     sut = target.docstring_linker
@@ -1095,7 +1095,7 @@ def test_EpydocLinker_adds_intersphinx_link_css_class() -> None:
     """
     system = model.System()
     inventory = SphinxInventory(system.msg)
-    inventory._links['base.module.other'] = ('http://tm.tld', 'some.html')
+    inventory._links['base.module.other'] = InventoryObject(name='base.module.other', base_url='http://tm.tld', location='some.html', typ='mod')
     system.intersphinx = inventory
     target = model.Module(system, 'ignore-name')
     sut = target.docstring_linker
@@ -1116,7 +1116,7 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_absolute_id() -> None:
     """
     system = model.System()
     inventory = SphinxInventory(system.msg)
-    inventory._links['base.module.other'] = ('http://tm.tld', 'some.html')
+    inventory._links['base.module.other'] = InventoryObject(name='base.module.other', base_url='http://tm.tld', location='some.html', typ='mod')
     system.intersphinx = inventory
     target = model.Module(system, 'ignore-name')
     sut = target.docstring_linker
@@ -1136,7 +1136,7 @@ def test_EpydocLinker_resolve_identifier_xref_intersphinx_relative_id() -> None:
     """
     system = model.System()
     inventory = SphinxInventory(system.msg)
-    inventory._links['ext_package.ext_module'] = ('http://tm.tld', 'some.html')
+    inventory._links['ext_package.ext_module'] = InventoryObject(name='ext_package.ext_module', base_url='http://tm.tld', location='some.html', typ='mod')
     system.intersphinx = inventory
     target = model.Module(system, 'ignore-name')
     # Here we set up the target module as it would have this import.

--- a/pydoctor/test/test_model.py
+++ b/pydoctor/test/test_model.py
@@ -147,11 +147,9 @@ def test_fetchIntersphinxInventories_content() -> None:
     Download and parse intersphinx inventories for each configured
     intersphix.
     """
-    options = Options.defaults()
-    options.intersphinx = [
-        'http://sphinx/objects.inv',
-        'file:///twisted/index.inv',
-        ]
+    options = Options.from_args(['--intersphinx=http://sphinx/objects.inv', 
+                                 '--intersphinx=file:///twisted/index.inv'])
+    
     url_content = {
         'http://sphinx/objects.inv': zlib.compress(
             b'sphinx.module py:module -1 sp.html -'),

--- a/pydoctor/test/test_options.py
+++ b/pydoctor/test/test_options.py
@@ -6,7 +6,7 @@ from io import StringIO
 
 from pydoctor import model
 from pydoctor.options import (PydoctorConfigParser, Options, _split_intersphinx_parts, 
-                              _object_inv_url_and_base_url, IntersphinxOption, FILE, URL)
+                              _object_inv_url_and_base_url )
 
 from pydoctor.test import FixtureRequest, TempPathFactory
 
@@ -170,15 +170,13 @@ def test_config_parsers(project_conf:str, pydoctor_conf:str, tempDir:Path) -> No
     assert options.warnings_as_errors == True
     assert options.privacy == [(model.PrivacyClass.HIDDEN, 'pydoctor.test')]
     
-    assert options.intersphinx[0] == IntersphinxOption(
-        invname=None, source=URL, 
-        url_or_path='https://docs.python.org/3/objects.inv', 
-        base_url='https://docs.python.org/3')
+    assert options.intersphinx[0] == (None,
+        'https://docs.python.org/3/objects.inv', 
+        'https://docs.python.org/3')
     
-    assert options.intersphinx[-1] == IntersphinxOption(
-        invname=None, source=URL, 
-        url_or_path='https://tristanlatr.github.io/apidocs/docutils/objects.inv', 
-        base_url='https://tristanlatr.github.io/apidocs/docutils')
+    assert options.intersphinx[-1] == (None,
+        'https://tristanlatr.github.io/apidocs/docutils/objects.inv', 
+        'https://tristanlatr.github.io/apidocs/docutils')
 
 def test_repeatable_options_multiple_configs_and_args(tempDir:Path) -> None:
     config1 = """
@@ -213,22 +211,18 @@ project-name = "Hello World!"
         options = Options.defaults()
 
         assert options.verbosity == 1
-        assert options.intersphinx == [IntersphinxOption(
-                                        invname=None, 
-                                        source=URL, 
-                                        url_or_path='https://docs.python.org/3/objects.inv', 
-                                        base_url='https://docs.python.org/3'),]
+        assert options.intersphinx == [(None, 
+                                        'https://docs.python.org/3/objects.inv', 
+                                        'https://docs.python.org/3'),]
         assert options.projectname == "Hello World!"
         assert options.projectversion == "2050.4C"
 
         options = Options.from_args(['-vv'])
 
         assert options.verbosity == 3 
-        assert options.intersphinx == [IntersphinxOption(
-                                        invname=None, 
-                                        source=URL, 
-                                        url_or_path='https://docs.python.org/3/objects.inv', 
-                                        base_url='https://docs.python.org/3'),]
+        assert options.intersphinx == [(None, 
+                                        'https://docs.python.org/3/objects.inv', 
+                                        'https://docs.python.org/3'),]
         assert options.projectname == "Hello World!"
         assert options.projectversion == "2050.4C"
 
@@ -237,17 +231,13 @@ project-name = "Hello World!"
 
         assert options.verbosity == 3
         assert options.intersphinx == [
-                                       IntersphinxOption(
-                                        invname=None, 
-                                        source=URL, 
-                                        url_or_path='https://twistedmatrix.com/documents/current/api/objects.inv', 
-                                        base_url='https://twistedmatrix.com/documents/current/api'),
+                                       (None, 
+                                        'https://twistedmatrix.com/documents/current/api/objects.inv', 
+                                        'https://twistedmatrix.com/documents/current/api'),
 
-                                       IntersphinxOption(
-                                        invname=None, 
-                                        source=URL, 
-                                        url_or_path='https://urllib3.readthedocs.io/en/latest/objects.inv', 
-                                        base_url='https://urllib3.readthedocs.io/en/latest'),
+                                       (None, 
+                                        'https://urllib3.readthedocs.io/en/latest/objects.inv', 
+                                        'https://urllib3.readthedocs.io/en/latest'),
                                         ]
         assert options.projectname == "Hello World!"
         assert options.projectversion == "2050.4C"
@@ -290,7 +280,7 @@ not-found = 423
     assert options.warnings_as_errors == False
     assert options.htmloutput == '1'
 
-def test_intersphinx_split_on_colon():
+def test_intersphinx_split_on_colon() -> None:
     
     assert _split_intersphinx_parts('http://something.org/')==['http://something.org/']
     assert _split_intersphinx_parts('something.org')==['something.org']
@@ -309,7 +299,7 @@ def test_intersphinx_split_on_colon():
     with pytest.raises(ValueError, match='Malformed --intersphinx option, too many parts'):
         _split_intersphinx_parts('pydoctor:a:b:c:d')
 
-def test_intersphinx_base_url_deductions():
+def test_intersphinx_base_url_deductions() -> None:
     assert _object_inv_url_and_base_url('http://some.url/api/objects.inv')==('http://some.url/api/objects.inv', 'http://some.url/api')
     assert _object_inv_url_and_base_url('http://some.url/api')==('http://some.url/api/objects.inv', 'http://some.url/api')
     assert _object_inv_url_and_base_url('http://some.url/api/')==('http://some.url/api/objects.inv', 'http://some.url/api')

--- a/pydoctor/test/test_options.py
+++ b/pydoctor/test/test_options.py
@@ -6,7 +6,7 @@ from io import StringIO
 
 from pydoctor import model
 from pydoctor.options import (PydoctorConfigParser, Options, _split_intersphinx_parts, 
-                              _object_inv_url_and_base_url, IntersphinxOption, IntersphinxSource)
+                              _object_inv_url_and_base_url, IntersphinxOption, FILE, URL)
 
 from pydoctor.test import FixtureRequest, TempPathFactory
 
@@ -171,12 +171,12 @@ def test_config_parsers(project_conf:str, pydoctor_conf:str, tempDir:Path) -> No
     assert options.privacy == [(model.PrivacyClass.HIDDEN, 'pydoctor.test')]
     
     assert options.intersphinx[0] == IntersphinxOption(
-        invname=None, source=IntersphinxSource.URL, 
+        invname=None, source=URL, 
         url_or_path='https://docs.python.org/3/objects.inv', 
         base_url='https://docs.python.org/3')
     
     assert options.intersphinx[-1] == IntersphinxOption(
-        invname=None, source=IntersphinxSource.URL, 
+        invname=None, source=URL, 
         url_or_path='https://tristanlatr.github.io/apidocs/docutils/objects.inv', 
         base_url='https://tristanlatr.github.io/apidocs/docutils')
 
@@ -215,7 +215,7 @@ project-name = "Hello World!"
         assert options.verbosity == 1
         assert options.intersphinx == [IntersphinxOption(
                                         invname=None, 
-                                        source=IntersphinxSource.URL, 
+                                        source=URL, 
                                         url_or_path='https://docs.python.org/3/objects.inv', 
                                         base_url='https://docs.python.org/3'),]
         assert options.projectname == "Hello World!"
@@ -226,7 +226,7 @@ project-name = "Hello World!"
         assert options.verbosity == 3 
         assert options.intersphinx == [IntersphinxOption(
                                         invname=None, 
-                                        source=IntersphinxSource.URL, 
+                                        source=URL, 
                                         url_or_path='https://docs.python.org/3/objects.inv', 
                                         base_url='https://docs.python.org/3'),]
         assert options.projectname == "Hello World!"
@@ -239,13 +239,13 @@ project-name = "Hello World!"
         assert options.intersphinx == [
                                        IntersphinxOption(
                                         invname=None, 
-                                        source=IntersphinxSource.URL, 
+                                        source=URL, 
                                         url_or_path='https://twistedmatrix.com/documents/current/api/objects.inv', 
                                         base_url='https://twistedmatrix.com/documents/current/api'),
 
                                        IntersphinxOption(
                                         invname=None, 
-                                        source=IntersphinxSource.URL, 
+                                        source=URL, 
                                         url_or_path='https://urllib3.readthedocs.io/en/latest/objects.inv', 
                                         base_url='https://urllib3.readthedocs.io/en/latest'),
                                         ]

--- a/pydoctor/test/test_options.py
+++ b/pydoctor/test/test_options.py
@@ -294,9 +294,9 @@ def test_intersphinx_split_on_colon() -> None:
     assert _split_intersphinx_parts('pydoctor:inventories/pack.inv:http://something.org/')==['pydoctor', 'inventories/pack.inv', 'http://something.org/']
     assert _split_intersphinx_parts('pydoctor:c:/data/inventories/pack.inv:http://something.org/')==['pydoctor', 'c:/data/inventories/pack.inv', 'http://something.org/']
     
-    with pytest.raises(ValueError, match='Malformed --intersphinx option, two consecutive colons is not valid'):
+    with pytest.raises(ValueError, match='Malformed --intersphinx option \'pydoctor::\': two consecutive colons is not valid'):
         _split_intersphinx_parts('pydoctor::')
-    with pytest.raises(ValueError, match='Malformed --intersphinx option, too many parts'):
+    with pytest.raises(ValueError, match='Malformed --intersphinx option \'pydoctor:a:b:c:d\': too many parts'):
         _split_intersphinx_parts('pydoctor:a:b:c:d')
 
 def test_intersphinx_base_url_deductions() -> None:

--- a/pydoctor/test/test_options.py
+++ b/pydoctor/test/test_options.py
@@ -294,6 +294,8 @@ def test_intersphinx_split_on_colon() -> None:
     assert _split_intersphinx_parts('pydoctor:inventories/pack.inv:http://something.org/')==['pydoctor', 'inventories/pack.inv', 'http://something.org/']
     assert _split_intersphinx_parts('pydoctor:c:/data/inventories/pack.inv:http://something.org/')==['pydoctor', 'c:/data/inventories/pack.inv', 'http://something.org/']
     
+    assert _split_intersphinx_parts('file with a colon\\: in the name.inv:http://something.org/')==['file with a colon: in the name.inv', 'http://something.org/']
+
     with pytest.raises(ValueError, match='Malformed --intersphinx option \'pydoctor::\': two consecutive colons is not valid'):
         _split_intersphinx_parts('pydoctor::')
     with pytest.raises(ValueError, match='Malformed --intersphinx option \'pydoctor:a:b:c:d\': too many parts'):

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -403,8 +403,7 @@ def test_update_bad_url(inv_reader: InvReader) -> None:
 
     assert inv_reader._links == {}
     expected_log = [(
-        'sphinx', ('Failed to get object inventory from url really.bad.url/objects.inv. '
-                   'To load inventory from a file, the BASE_URL part of the intersphinx option is required.'), -1
+        'sphinx', ('Failed to get object inventory from url really.bad.url/objects.inv'), -1
         )]
     assert expected_log == inv_reader._logger.messages
 
@@ -417,10 +416,7 @@ def test_update_fail(inv_reader: InvReader) -> None:
     url = 'http://some.tld/o.inv'
 
     inv_reader.update(cast('sphinx.CacheT', {}), 
-                      options.IntersphinxOption(
-                                None, options.URL,
-                                url, 'http://some.tld/', 
-                            ))
+                      (None, url, 'http://some.tld/', ))
 
     assert inv_reader._links == {}
     expected_log = [(

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -418,7 +418,7 @@ def test_update_fail(inv_reader: InvReader) -> None:
 
     inv_reader.update(cast('sphinx.CacheT', {}), 
                       options.IntersphinxOption(
-                                None, options.IntersphinxSource.URL,
+                                None, options.URL,
                                 url, 'http://some.tld/', 
                             ))
 

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -19,7 +19,7 @@ from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 from . import CapLog, FixtureRequest, MonkeyPatch, TempPathFactory
-from pydoctor import model, sphinx
+from pydoctor import model, sphinx, options
 
 
 
@@ -334,7 +334,14 @@ def test_getLink_found(inv_reader_nolog: sphinx.SphinxInventory) -> None:
     Return the link from internal state.
     """
 
-    inv_reader_nolog._links['some.name'] = sphinx.InventoryObject(name='some.name', base_url='http://base.tld', location='some/url.php', typ='mod')
+    inv_reader_nolog._links['some.name'] = [sphinx.InventoryObject(
+        invname='xxx',
+        name='some.name', 
+        base_url='http://base.tld', 
+        location='some/url.php', 
+        domain='py',
+        reftype='mod',
+        display='-')]
 
     assert 'http://base.tld/some/url.php' == inv_reader_nolog.getLink('some.name')
 
@@ -344,7 +351,14 @@ def test_getLink_self_anchor(inv_reader_nolog: sphinx.SphinxInventory) -> None:
     Return the link with anchor as target name when link end with $.
     """
 
-    inv_reader_nolog._links['some.name'] = sphinx.InventoryObject(name='some.name', base_url='http://base.tld', location='some/url.php#$', typ='mod')
+    inv_reader_nolog._links['some.name'] = [sphinx.InventoryObject(
+            invname='xxx',
+            name='some.name', 
+            base_url='http://base.tld', 
+            location='some/url.php#$', 
+            reftype='mod', 
+            domain='py', 
+            display='-')]
 
     assert 'http://base.tld/some/url.php#some.name' == inv_reader_nolog.getLink('some.name')
 
@@ -365,9 +379,12 @@ def test_update_functional(inv_reader_nolog: sphinx.SphinxInventory) -> None:
 # The rest of this file is compressed with zlib.
 """ + zlib.compress(payload)
 
+
     url = 'http://some.url/api/objects.inv'
 
-    inv_reader_nolog.update(cast('sphinx.CacheT', {url: content}), url)
+    opt = options.Options.from_args([f'--intersphinx={url}'])
+
+    inv_reader_nolog.update(cast('sphinx.CacheT', {url: content}), *opt.intersphinx)
 
     assert 'http://some.url/api/module1.html' == inv_reader_nolog.getLink('some.module1')
     assert 'http://some.url/api/module2.html' == inv_reader_nolog.getLink('other.module2')
@@ -375,14 +392,19 @@ def test_update_functional(inv_reader_nolog: sphinx.SphinxInventory) -> None:
 
 def test_update_bad_url(inv_reader: InvReader) -> None:
     """
-    Log an error when failing to get base url from url.
+    Log an error when failing to get objects.inv.
     """
 
-    inv_reader.update(cast('sphinx.CacheT', {}), 'really.bad.url')
+    url = 'really.bad.url'
+
+    opt = options.Options.from_args([f'--intersphinx={url}'])
+
+    inv_reader.update(cast('sphinx.CacheT', {}), *opt.intersphinx)
 
     assert inv_reader._links == {}
     expected_log = [(
-        'sphinx', 'Failed to get remote base url for really.bad.url', -1
+        'sphinx', ('Failed to get object inventory from url really.bad.url/objects.inv. '
+                   'To load inventory from a file, the BASE_URL part of the intersphinx option is required.'), -1
         )]
     assert expected_log == inv_reader._logger.messages
 
@@ -392,12 +414,18 @@ def test_update_fail(inv_reader: InvReader) -> None:
     Log an error when failing to get content from url.
     """
 
-    inv_reader.update(cast('sphinx.CacheT', {}), 'http://some.tld/o.inv')
+    url = 'http://some.tld/o.inv'
+
+    inv_reader.update(cast('sphinx.CacheT', {}), 
+                      options.IntersphinxOption(
+                                None, options.IntersphinxSource.URL,
+                                url, 'http://some.tld/', 
+                            ))
 
     assert inv_reader._links == {}
     expected_log = [(
         'sphinx',
-        'Failed to get object inventory from http://some.tld/o.inv',
+        'Failed to get object inventory from url http://some.tld/o.inv',
         -1,
         )]
     assert expected_log == inv_reader._logger.messages
@@ -408,7 +436,7 @@ def test_parseInventory_empty(inv_reader_nolog: sphinx.SphinxInventory) -> None:
     Return empty dict for empty input.
     """
 
-    result = inv_reader_nolog._parseInventory('http://base.tld', '')
+    result = inv_reader_nolog._parseInventory('http://base.tld', '', 'xxx')
 
     assert {} == result
 
@@ -419,9 +447,16 @@ def test_parseInventory_single_line(inv_reader_nolog: sphinx.SphinxInventory) ->
     """
 
     result = inv_reader_nolog._parseInventory(
-        'http://base.tld', 'some.attr py:attr -1 some.html De scription')
+        'http://base.tld', 'some.attr py:attr -1 some.html De scription', 'xxx')
 
-    assert {'some.attr': sphinx.InventoryObject(name='some.attr', base_url='http://base.tld', location='some.html', typ='py:attr')} == result
+    assert {'some.attr': [sphinx.InventoryObject(
+        invname='xxx',
+        name='some.attr', 
+        base_url='http://base.tld', 
+        location='some.html', 
+        reftype='attr', 
+        domain='py', 
+        display='De scription')]} == result
 
 
 def test_parseInventory_spaces() -> None:
@@ -468,31 +503,46 @@ def test_parseInventory_invalid_lines(inv_reader: InvReader) -> None:
         'good.again py:module 0 again.html -\n'
         )
 
-    result = inv_reader._parseInventory(base_url, content)
+    result = inv_reader._parseInventory(base_url, content, 'xxx')
 
     assert {
-        'good.attr': sphinx.InventoryObject(name='good.attr', base_url='http://tm.tld', location='some.html', typ='py:attribute'),
-        'good.again': sphinx.InventoryObject(name='good.again', base_url='http://tm.tld', location='again.html', typ='py:module'),
+        'good.attr': [sphinx.InventoryObject(
+            invname='xxx',
+            name='good.attr', 
+            base_url='http://tm.tld', 
+            location='some.html', 
+            reftype='attr', # reftypes are normalized
+            domain='py',
+            display='-')],
+        'good.again': [sphinx.InventoryObject(
+            invname='xxx',
+            name='good.again', 
+            base_url='http://tm.tld', 
+            location='again.html', 
+            reftype='mod', # reftypes are normalized
+            domain='py',
+            display='-')],
         } == result
+    
     assert [
         (
             'sphinx',
-            'Failed to parse line "missing.display.name py:attribute 1 some.html" for http://tm.tld',
+            'Failed to parse line \'missing.display.name py:attribute 1 some.html\' for http://tm.tld: Display name column cannot be empty',
             -1,
             ),
         (
             'sphinx',
-            'Failed to parse line "bad.attr bad format" for http://tm.tld',
+            'Failed to parse line \'bad.attr bad format\' for http://tm.tld: Could not find priority column',
             -1,
             ),
-        ('sphinx', 'Failed to parse line "very.bad" for http://tm.tld', -1),
-        ('sphinx', 'Failed to parse line "" for http://tm.tld', -1),
+        ('sphinx', 'Failed to parse line \'very.bad\' for http://tm.tld: Could not find priority column', -1),
+        ('sphinx', 'Failed to parse line \'\' for http://tm.tld: Could not find priority column', -1),
         ] == inv_reader._logger.messages
 
 
-def test_parseInventory_type_filter(inv_reader: InvReader) -> None:
+def test_parseInventory_all_kinds(inv_reader: InvReader) -> None:
     """
-    Ignore entries that don't have a 'py:' type field.
+    All inventory entries are parsed, the one in the 'py' domain as well as others.
     """
 
     base_url = 'https://docs.python.org/3'
@@ -500,13 +550,50 @@ def test_parseInventory_type_filter(inv_reader: InvReader) -> None:
         'dict std:label -1 reference/expressions.html#$ Dictionary displays\n'
         'dict py:class 1 library/stdtypes.html#$ -\n'
         'dict std:2to3fixer 1 library/2to3.html#2to3fixer-$ -\n'
+        'py:attribute:value rst:directive:option 1 usage/domains/python.html#directive-option-py-attribute-value -\n'
         )
 
-    result = inv_reader._parseInventory(base_url, content)
+    result = inv_reader._parseInventory(base_url, content, 'python')
 
     assert {
-        'dict': sphinx.InventoryObject(name='dict', base_url='https://docs.python.org/3', location='library/stdtypes.html#$', typ='py:class'),
+        'dict': [
+        sphinx.InventoryObject(
+            invname='python',
+            name='dict', 
+            base_url='https://docs.python.org/3', 
+            location='reference/expressions.html#$', 
+            reftype='label',
+            domain='std', 
+            display='Dictionary displays'),
+        sphinx.InventoryObject(
+            invname='python',
+            name='dict', 
+            base_url='https://docs.python.org/3', 
+            location='library/stdtypes.html#$', 
+            reftype='class',
+            domain='py', 
+            display='-'),
+        sphinx.InventoryObject(
+            invname='python',
+            name='dict', 
+            base_url='https://docs.python.org/3', 
+            location='library/2to3.html#2to3fixer-$', 
+            reftype='2to3fixer',
+            domain='std', 
+            display='-'),],
+
+        'py:attribute:value':[
+        sphinx.InventoryObject(
+            invname='python',
+            name='py:attribute:value', 
+            base_url='https://docs.python.org/3', 
+            location='usage/domains/python.html#directive-option-py-attribute-value', 
+            reftype='directive:option',
+            domain='rst', 
+            display='-'),
+            ],
         } == result
+    
     assert [] == inv_reader._logger.messages
 
 
@@ -758,12 +845,11 @@ def test_prepareCache(
     if clearCache:
         assert not cacheDirectory.exists()
 
-def test_inv_object_typ() -> None:
-    obj = sphinx.InventoryObject(name='dict', base_url='https://docs.python.org/3', location='library/stdtypes.html#$', typ='py:class')
-    assert obj.typ is sphinx.InvObjectType.CLASS
-    obj = sphinx.InventoryObject(name='dict', base_url='https://docs.python.org/3', location='library/stdtypes.html#$', typ='py:class:')
-    assert obj.typ is sphinx.InvObjectType.CLASS
-    obj = sphinx.InventoryObject(name='dict', base_url='https://docs.python.org/3', location='library/stdtypes.html#$', typ='cls')
-    assert obj.typ is sphinx.InvObjectType.CLASS
-    obj = sphinx.InventoryObject(name='dict', base_url='https://docs.python.org/3', location='library/stdtypes.html#$', typ='class')
-    assert obj.typ is sphinx.InvObjectType.CLASS
+def test_inv_object_reftyp() -> None:
+    obj = sphinx.InventoryObject(invname='abc',
+                                 name='dict', 
+                                 base_url='https://docs.python.org/3', 
+                                 location='library/stdtypes.html#$', 
+                                 domain='py', 
+                                 reftype='class', 
+                                 display='-')

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -334,7 +334,7 @@ def test_getLink_found(inv_reader_nolog: sphinx.SphinxInventory) -> None:
     Return the link from internal state.
     """
 
-    inv_reader_nolog._links['some.name'] = ('http://base.tld', 'some/url.php')
+    inv_reader_nolog._links['some.name'] = sphinx.InventoryObject(name='some.name', base_url='http://base.tld', location='some/url.php', typ='mod')
 
     assert 'http://base.tld/some/url.php' == inv_reader_nolog.getLink('some.name')
 
@@ -344,7 +344,7 @@ def test_getLink_self_anchor(inv_reader_nolog: sphinx.SphinxInventory) -> None:
     Return the link with anchor as target name when link end with $.
     """
 
-    inv_reader_nolog._links['some.name'] = ('http://base.tld', 'some/url.php#$')
+    inv_reader_nolog._links['some.name'] = sphinx.InventoryObject(name='some.name', base_url='http://base.tld', location='some/url.php#$', typ='mod')
 
     assert 'http://base.tld/some/url.php#some.name' == inv_reader_nolog.getLink('some.name')
 
@@ -421,7 +421,7 @@ def test_parseInventory_single_line(inv_reader_nolog: sphinx.SphinxInventory) ->
     result = inv_reader_nolog._parseInventory(
         'http://base.tld', 'some.attr py:attr -1 some.html De scription')
 
-    assert {'some.attr': ('http://base.tld', 'some.html')} == result
+    assert {'some.attr': sphinx.InventoryObject(name='some.attr', base_url='http://base.tld', location='some.html', typ='py:attr')} == result
 
 
 def test_parseInventory_spaces() -> None:
@@ -471,8 +471,8 @@ def test_parseInventory_invalid_lines(inv_reader: InvReader) -> None:
     result = inv_reader._parseInventory(base_url, content)
 
     assert {
-        'good.attr': (base_url, 'some.html'),
-        'good.again': (base_url, 'again.html'),
+        'good.attr': sphinx.InventoryObject(name='good.attr', base_url='http://tm.tld', location='some.html', typ='py:attribute'),
+        'good.again': sphinx.InventoryObject(name='good.again', base_url='http://tm.tld', location='again.html', typ='py:module'),
         } == result
     assert [
         (
@@ -505,7 +505,7 @@ def test_parseInventory_type_filter(inv_reader: InvReader) -> None:
     result = inv_reader._parseInventory(base_url, content)
 
     assert {
-        'dict': (base_url, 'library/stdtypes.html#$'),
+        'dict': sphinx.InventoryObject(name='dict', base_url='https://docs.python.org/3', location='library/stdtypes.html#$', typ='py:class'),
         } == result
     assert [] == inv_reader._logger.messages
 
@@ -757,3 +757,13 @@ def test_prepareCache(
 
     if clearCache:
         assert not cacheDirectory.exists()
+
+def test_inv_object_typ() -> None:
+    obj = sphinx.InventoryObject(name='dict', base_url='https://docs.python.org/3', location='library/stdtypes.html#$', typ='py:class')
+    assert obj.typ is sphinx.InvObjectType.CLASS
+    obj = sphinx.InventoryObject(name='dict', base_url='https://docs.python.org/3', location='library/stdtypes.html#$', typ='py:class:')
+    assert obj.typ is sphinx.InvObjectType.CLASS
+    obj = sphinx.InventoryObject(name='dict', base_url='https://docs.python.org/3', location='library/stdtypes.html#$', typ='cls')
+    assert obj.typ is sphinx.InvObjectType.CLASS
+    obj = sphinx.InventoryObject(name='dict', base_url='https://docs.python.org/3', location='library/stdtypes.html#$', typ='class')
+    assert obj.typ is sphinx.InvObjectType.CLASS

--- a/pydoctor/test/test_sphinx.py
+++ b/pydoctor/test/test_sphinx.py
@@ -849,3 +849,46 @@ def test_inv_object_reftyp() -> None:
                                  domain='py', 
                                  reftype='class', 
                                  display='-')
+
+def test_get_inventory_filtered_by_invname() -> None:
+    ...
+
+def test_get_inventory_filtered_by_domain() -> None:
+    ...
+
+def test_get_inventory_filtered_by_reftype() -> None:
+    ...
+
+def test_get_inventory_filtered_by_both_domain_and_reftype() -> None:
+    ...
+
+def test_get_inventory_filtered_by_invname_and_domain() -> None:
+    ...
+
+def test_get_inventory_py_domain_has_precedence() -> None:
+    ...
+
+def test_get_inventory_ambigous_ref_in_std_domain() -> None:
+    ...
+
+def test_duplicate_inventory_from_url() -> None:
+    ...
+
+def test_duplicate_inventory_from_file() -> None:
+    ...
+
+def test_inventory_from_file_with_colon_in_the_filename() -> None:
+    ...
+
+def test_duplicate_inventory_from_both_file_and_url() -> None:
+    ...
+
+def test_inventory_from_file_fails_because_of_io_error() -> None:
+    ...
+
+def test_get_inventory_object_ambiguous_missing_some_filters() -> None:
+    ...
+
+def test_get_inventory_object_truly_ambiguous() -> None:
+    ...
+


### PR DESCRIPTION
<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->

Fixes #609
Fixes #741

Missing a lot tests..

TODO:
- the exception reftype and the class reftype should be compatible since a exception is a class. 
- lift the limitation regarding colon in filenames, change the --intersphinx options parser in order to seek both from right and from left for the colon, excluding '://'. This might require the users to always specify the http scheme if they use the new feature. 