### PR TITLE
Fix class hierarchy elements taking too much vertical space

### DIFF
--- a/pydoctor/themes/base/apidocs.css
+++ b/pydoctor/themes/base/apidocs.css
@@ -1133,7 +1133,7 @@ pre.constant-value              { padding: .5em; }
     box-shadow: 0px 0px 0px 7px rgb(253, 255, 223);
 }
 #summaryTree div {
-    display: inline-block;
+    display: inline-table;
 }
 
 /* deprecations uses a orange text */


### PR DESCRIPTION
<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->

Just a small css change.