### PR TITLE
Outline diff to sphinx in context of automation level

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -36,6 +36,7 @@ It also has support for `zope.interface <https://zopeinterface.readthedocs.io/en
 
 How is it different from ``sphinx-autodoc``
 -------------------------------------------
+``sphinx-autodoc`` operates semi-automatic rather than fully automatically. It can not generate documentation solely from Python source files; it always requires a reStructuredText file as well.
 
 ``sphinx-autodoc`` can be complex and the output is sometimes overwhelming, ``pydoctor`` will generate
 one page per class, module and package, it tries to keeps it simple and present information in a efficient way with tables.


### PR DESCRIPTION
Accidentally discovered this FAQ section.

Correct me if I am wrong but I often tried Sphinx* in the past and was not able to auto-generated documentation based on source files. You always need a rst file.