### PR TITLE
Sphinx may not generate an api folder

### DIFF
--- a/pydoctor/sphinx_ext/build_apidocs.py
+++ b/pydoctor/sphinx_ext/build_apidocs.py
@@ -67,7 +67,8 @@ def on_build_finished(app: Sphinx, exception: Exception) -> None:
 
         temp_path = output_path.with_suffix('.pydoctor_temp')
         shutil.rmtree(sphinx_files, ignore_errors=True)
-        output_path.rename(sphinx_files)
+        if output_path.exists():
+          output_path.rename(sphinx_files)
         temp_path.rename(output_path)
 
 


### PR DESCRIPTION
Trivial fix for a bug with simple projects where sphinx does not generate a docs/build/html/api/ folder.  Without this fix the rename fails because the output_path does not exist.