### PR TITLE
Enable the security advisories process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+twisted/pydoctor project uses the same security policy as [twisted/twisted](https://github.com/twisted/twisted).
+
+For more details please check the [Twisted security process](https://github.com/twisted/twisted?tab=security-ov-file#readme)
+
+You can send a security report via [GitHub Security Advisories](https://github.com/twisted/pydoctor/security/advisories/new)


### PR DESCRIPTION
This is mostly paperwork to get the standard GitHub security process up and running.