### PR TITLE
Small docs update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ pydoctor
 .. image:: https://img.shields.io/badge/-documentation-blue
   :target: https://pydoctor.readthedocs.io/
 
-This is *pydoctor*, an API documentation generator that works by
+This is *pydoctor*, a standalone API documentation generator that works by
 static analysis.
 
 It was written primarily to replace ``epydoc`` for the purposes of the
@@ -27,15 +27,12 @@ Twisted, knows about ``zope.interface``'s declaration API and can present
 information about which classes implement which interface, and vice
 versa.
 
-.. contents:: Contents:
-
-
 Simple Usage
 ~~~~~~~~~~~~
 
 You can run pydoctor on your project like this::
 
-    $ pydoctor --make-html --html-output=docs/api src/mylib
+    $ pydoctor --html-output=docs/api src/mylib
 
 For more info, `Read The Docs <https://pydoctor.readthedocs.io/>`_.
 

--- a/docs/source/publish-github-action.rst
+++ b/docs/source/publish-github-action.rst
@@ -40,9 +40,7 @@ with the appropriate information.
                 --project-name=(projectname) \
                 --project-url=https://github.com/$GITHUB_REPOSITORY \
                 --html-viewsource-base=https://github.com/$GITHUB_REPOSITORY/tree/$GITHUB_SHA \
-                --make-html \
                 --html-output=./apidocs \
-                --project-base-dir="$(pwd)" \
                 --docformat=restructuredtext \
                 --intersphinx=https://docs.python.org/3/objects.inv \
                 ./(packagedirectory)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -29,9 +29,7 @@ The result looks like `this <api/index.html>`_.
         --project-version=1.2.0 \
         --project-url=https://github.com/twisted/pydoctor/ \
         --html-viewsource-base=https://github.com/twisted/pydoctor/tree/20.7.2 \
-        --make-html \
         --html-output=docs/api \
-        --project-base-dir="." \
         --docformat=epytext \
         --intersphinx=https://docs.python.org/3/objects.inv \
         ./pydoctor


### PR DESCRIPTION
Simplify documentation examples and emphasis that pydoctor is a standalone api docs generator.

Option --make-html is not necessary since it's enabled by default.

Option --project-base-dir has automatically the default value of the current working directory, so it's useless to specify it explicitely.

<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
