### PR TITLE
Add test-parallel environment for tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ test =
     docutils>=0.18.1
     coverage
     pytest
+    pytest-xdist
     hypothesis
     cython-test-exception-raiser
     bs4

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,12 @@ commands =
     pytest -vv {posargs: pydoctor}
 
 
+[testenv:test-parallel]
+description = Run tests with multiprocessing without report
+extras =
+    test
+commands =
+    pytest -vv -n auto {posargs: pydoctor}
 
 [testenv:twisted-apidoc]
 deps =


### PR DESCRIPTION
<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->

Tests are now ran in 10s instead of 37s, with 16 cores. 