### PR TITLE
Use pytest-xdist to speed-up tests locally

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,6 @@
 <!-- 
 Thanks for your contribution!
 
-Make sure the tests passes with the following command: 
-   tox -p all
-
-Don't forget to include a summary of your changes in the changelog located in the README file.
-
 Read more about contributing to pydoctor here:
    https://pydoctor.readthedocs.io/en/latest/contrib.html
 -->

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -42,9 +42,9 @@ jobs:
         python -c "print('\nENVIRONMENT VARIABLES\n=====================\n')"
         python -c "import os; [print(f'{k}={v}') for k, v in os.environ.items()]"
 
-    - name: Run unit tests
+    - name: Run unit tests and coverage reports
       run: |
-        tox -e test
+        tox -e test-cov
 
     - name: Run unit tests with latest Twisted version
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ test =
     docutils>=0.18.1
     coverage
     pytest
+    pytest-xdist
     hypothesis
     cython-test-exception-raiser
     bs4

--- a/tox.ini
+++ b/tox.ini
@@ -19,11 +19,19 @@ allowlist_externals =
 passenv = *
 
 [testenv:test]
+description = Run tests with multiprocessing without coverage report, made for local development.
+extras =
+    test
+commands =
+    pytest -vv -n auto {posargs: pydoctor}
+
+[testenv:test-cov]
 description = Run tests and coverage report
 extras =
     test
 commands =
     coverage erase
+    # The multiprocessing doesn't play well with the coverage :/
     coverage run -m pytest -vv {posargs: pydoctor}
     coverage report -m
     # The XML version is generatred to be uploaded to Codecov.


### PR DESCRIPTION
Since the multiprocessing doesn't play well with code coverage, use another specific environment for that.

<!-- 
Thanks for your contribution!

Make sure the tests passes with the following command: 
   tox -p all

Don't forget to include a summary of your changes in the changelog located in the README file.

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
