### PR TITLE
Add missing config value in twisted-apidoc environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ commands =
     - pydoctor --config {toxworkdir}/twisted-trunk/setup.cfg \
         --html-output {toxworkdir}/twisted-apidocs-build \
         --project-base-dir {toxworkdir}/twisted-trunk/ \
+        --template-dir {toxworkdir}/twisted-trunk/src/twisted/python/_pydoctortemplates/ \
         {toxworkdir}/twisted-trunk/src/twisted/ --theme=classic
 
     pytest -vv docs/tests/test_twisted_docs.py


### PR DESCRIPTION
<!-- 
Thanks for your contribution!

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->

Fix #856