### PR TITLE
Hard coded name of the package for Github's dependency graph

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import setuptools
 
 
 setuptools.setup(
+    name="pydoctor", # for GitHub's dependency graph
     long_description=re.sub(
         pattern="(?ms)^.. description-end.*",
         repl="",


### PR DESCRIPTION
<!-- 
Thanks for your contribution!

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->

If I understand correctly, support for setup.cfg is not in the Github's plans. So this is workaround for the short therm.

https://github.com/orgs/community/discussions/6456
