### PR TITLE
Docs: minor improvements of the github action

### DIFF
--- a/docs/source/publish-github-action.rst
+++ b/docs/source/publish-github-action.rst
@@ -16,10 +16,15 @@ with the appropriate information.
     on:
       push:
         branches: [main]
+      pull_request:
+        branches: [main]
 
     jobs:
       deploy:
         runs-on: ubuntu-latest
+
+        permissions:
+              contents: write
 
         steps:
         - uses: actions/checkout@master
@@ -47,8 +52,9 @@ with the appropriate information.
                 --intersphinx=https://docs.python.org/3/objects.inv \
                 ./(packagedirectory)
 
-        - name: Push API documentation to Github Pages
-          uses: peaceiris/actions-gh-pages@v3
+        - name: Push API documentation to Github Pages (if on main branch)
+          if: github.ref == 'refs/heads/main'
+          uses: peaceiris/actions-gh-pages@v4
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
             publish_dir: ./apidocs


### PR DESCRIPTION
<!-- 
Thanks for your contribution!

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->

- The template github action will now make pydoctor run on PRs as well. 
   But still only push documentation when comitting to the main branch.
- Added the required permission to the action because github changed the default permission a while ago now.
- Bump version of `actions-gh-pages` from v3 to v4/