### PR TITLE
Disable Python3.14 on Windows for now

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -22,6 +22,11 @@ jobs:
         python-version: ['pypy-3.9', 'pypy-3.10', 
                          '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - python-version: "3.14-dev"
+            os: "ubuntu-latest"
+          - python-version: "3.14-dev"
+            os: "macos-latest"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Seems like a change in the C API of Python makes cython sad on Windows, thus we're not able to build the dependencies of our test suite.

<!-- 
Thanks for your contribution!

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
