### PR TITLE
prefer newer "tomli" over "toml"

### DIFF
--- a/pydoctor/_configparser.py
+++ b/pydoctor/_configparser.py
@@ -37,14 +37,16 @@ from configargparse import ConfigFileParserException, ConfigFileParser, Argument
 
 if sys.version_info >= (3, 11):
     from tomllib import load as _toml_load
-    import io
-    # The tomllib module from the standard library 
-    # expect a binary IO and will fail if receives otherwise. 
-    # So we hack a compat function that will work with TextIO and assume the utf-8 encoding.
-    def toml_load(stream: TextIO) -> Any:
-        return _toml_load(io.BytesIO(stream.read().encode()))
 else:
-    from toml import load as toml_load
+    from tomli import load as _toml_load
+
+import io
+# The tomllib module from the standard library
+# expect a binary IO and will fail if receives otherwise.
+# So we hack a compat function that will work with TextIO and assume the utf-8 encoding.
+def toml_load(stream: TextIO) -> Any:
+    return _toml_load(io.BytesIO(stream.read().encode()))
+
 
 # I did not invented these regex, just put together some stuff from:
 # - https://stackoverflow.com/questions/11859442/how-to-match-string-in-quotes-using-regex

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     lunr>=0.6.2,<0.9.0
     configargparse
 
-    toml; python_version < "3.11"
+    tomli; python_version < "3.11"
 
 [options.extras_require]
 docs =
@@ -82,7 +82,6 @@ mypy =
     twisted
     types-requests
     types-docutils
-    types-toml
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
`tomli` is newer and better maintained than `toml`

in fact the whole story is pytoml -> toml -> tomli -> tomllib

https://wiki.debian.org/Python/Backports

Greetings
