### PR TITLE
Make the tests pass with Docutils 0.22

### DIFF
--- a/pydoctor/test/epydoc/test_epytext2node.py
+++ b/pydoctor/test/epydoc/test_epytext2node.py
@@ -1,3 +1,5 @@
+import docutils
+
 from pydoctor.test.epydoc.test_epytext2html import epytext2node
 
 def test_nested_markup() -> None:
@@ -22,10 +24,11 @@ def test_nested_markup() -> None:
     doc = '''
         It becomes a little bit complicated with U{B{custom} links <https://google.ca>}
         '''
-    expected = '''<document source="docstring">
+    docutils_0_22 = docutils.__version_info__ >= (0, 22)
+    expected = f'''<document source="docstring">
     <paragraph>
         It becomes a little bit complicated with 
-        <reference internal="False" refuri="https://google.ca">
+        <reference internal="{0 if docutils_0_22 else False}" refuri="https://google.ca">
             <strong>
                 custom
              links

--- a/pydoctor/test/epydoc/test_pyval_repr.py
+++ b/pydoctor/test/epydoc/test_pyval_repr.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 from typing import Any, Union
 import xml.sax
 
+import docutils
 import pytest
 
 from pydoctor.epydoc.markup._pyval_repr import PyvalColorizer, colorize_inline_pyval
@@ -1572,16 +1573,17 @@ def test_expressions_parens(subtests:Any) -> None:
 
 def test_is_annotation_flag() -> None:
     # the is_annotation attribute is added to all links when is_annotation=True is passed.
-    assert color(extract_expr(ast.parse('list[dict] + set()')), is_annotation=True) == '''<document source="code">
-    <obj_reference is_annotation="True" refuri="list">
+    docutils_0_22 = docutils.__version_info__ >= (0, 22)
+    assert color(extract_expr(ast.parse('list[dict] + set()')), is_annotation=True) == f'''<document source="code">
+    <obj_reference is_annotation="{1 if docutils_0_22 else True}" refuri="list">
         list
     [
     <wbr>
-    <obj_reference is_annotation="True" refuri="dict">
+    <obj_reference is_annotation="{1 if docutils_0_22 else True}" refuri="dict">
         dict
     ]
      + 
-    <obj_reference is_annotation="True" refuri="set">
+    <obj_reference is_annotation="{1 if docutils_0_22 else True}" refuri="set">
         set
     (
     )


### PR DESCRIPTION
Docutils now normalizes boolean values using `str(int(value))`: <https://sourceforge.net/p/docutils/code/9691/>.

This fixes test failures seen in Debian: <https://ci.debian.net/packages/p/pydoctor/unstable/amd64/64724144/>.