### PR TITLE
Do not fail the tests when the warning NotOpenSSLWarning is triggered

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -110,6 +110,7 @@ doctest_optionflags = ELLIPSIS IGNORE_EXCEPTION_DETAIL
 xfail_strict = true
 filterwarnings =
     error
+    default::urllib3.exceptions.NotOpenSSLWarning
     
 [tool:pydoctor]
 intersphinx = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,8 +109,8 @@ addopts = --doctest-glob='*.doctest' --doctest-modules --ignore-glob='*/testpack
 doctest_optionflags = ELLIPSIS IGNORE_EXCEPTION_DETAIL
 xfail_strict = true
 filterwarnings =
-    error
     default::urllib3.exceptions.NotOpenSSLWarning
+    error
     
 [tool:pydoctor]
 intersphinx = 


### PR DESCRIPTION
Do not consider urllib3.exceptions.NotOpenSSLWarning as an error in the testing. 
This simplifies local development on latest macos environments.

<!-- 
Thanks for your contribution!

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
