### PR TITLE
tests: make use of incorporated Pytest subtests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,13 +62,14 @@ rst =
 test = 
     docutils>=0.18.1
     coverage
-    pytest
+    pytest >= 9; python_version >= '3.10'
+    pytest; python_version < '3.10'
+    pytest-subtests; python_version < '3.10'
     pytest-xdist
     hypothesis
     cython-test-exception-raiser
     bs4
     Sphinx
-    pytest-subtests
     setuptools
 
 mypy =


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-subtests?tab=readme-ov-file#important

> This plugin has been integrated directly into pytest 9.0, so the
  plugin itself will no longer be maintained and the repository will be
  archived.

Fixes: https://github.com/twisted/pydoctor/issues/948

<!-- 
Thanks for your contribution!

Read more about contributing to pydoctor here:
   https://pydoctor.readthedocs.io/en/latest/contrib.html
-->
